### PR TITLE
add rubocop styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
 testruns
+

--- a/styles/rubocop-rails.yml
+++ b/styles/rubocop-rails.yml
@@ -1,0 +1,10 @@
+Rails:
+  Enabled: true
+
+# Mongoid doesn't like find_each.
+Rails/FindEach:
+  Enabled: false
+
+# Ignore timezone issues
+Rails/TimeZone:
+  Enabled: false

--- a/styles/rubocop.yml
+++ b/styles/rubocop.yml
@@ -1,0 +1,134 @@
+# ==================== Linters ====================
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/BlockAlignment:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Description: 'Checks for unused block arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Description: 'Checks for unused method arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: false
+
+# ==================== Metrics ====================
+Metrics/BlockNesting:
+  Max: 4
+
+Metrics/BlockLength:
+  Max: 50
+
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 500
+
+Metrics/CyclomaticComplexity:
+  Max: 48
+
+Metrics/LineLength:
+  Max: 1200
+
+# Configuration parameters: CountComments.
+Metrics/MethodLength:
+  Max: 350
+
+# Configuration parameters: CountKeywordArgs.
+Metrics/ParameterLists:
+  Max: 8
+
+# ==================== Styles, Layouts, and Naming ====================
+# Configuration parameters: EnforcedStyle, SupportedStyles.
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassVars:
+  Enabled: false
+
+# Allow this syntax -- do not autocorrect.
+#   a = if true
+#         1
+#       else
+#         2
+#       end
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+# Configuration parameters: AllowedVariables.
+Style/GlobalVars:
+  Enabled: false
+
+# Configuration parameters: MinBodyLength.
+Style/GuardClause:
+  Enabled: true
+
+# Configuration parameters: MaxLineLength.
+Style/IfUnlessModifier:
+  Enabled: false
+
+# Do NOT enable.  For some reason this is catching any next which I feel are okay.
+# Configuration parameters: EnforcedStyle, SupportedStyles.
+Style/Next:
+  Enabled: false
+
+# Do not convert 10000 to 10_000
+Style/NumericLiterals:
+  Description: 'Add underscores to large numeric literals to improve readability.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: false
+
+# Change per DLM -- pulled from https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
+Style/RedundantReturn:
+  Description: 'Do not use return where it is not required.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-return'
+  Enabled: false
+
+# Do NOT enable this because it appears $? is different than $CHILD_STATUS.
+Style/SpecialGlobalVars:
+  Enabled: false
+
+# Do not use %w, %W, %i, etc
+# Prefer [:a, :b, :c] over %i[a b c]
+Style/SymbolArray:
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-i'
+  EnforcedStyle: brackets
+
+# Do not use %w, %W, %i, etc
+# Prefer ['a', 'b', 'c'] over %w[a b c]
+Style/WordArray:
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
+  EnforcedStyle: brackets
+
+# Need to allow indented case statements
+# Configuration parameters: IndentWhenRelativeTo, SupportedStyles, IndentOneStep.
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  Enabled: true
+
+Naming/AccessorMethodName:
+  Enabled: true
+


### PR DESCRIPTION
Hoping to put our ruby style guide in this repo so that we can pull from it in our other OpenStudio repos. Rubocop supports pulling the configs from urls, e.g.

```
inherit_from:
  - https://raw.githubusercontent.com/NREL/OpenStudio-resources/develop/styles/rubocop.yml
  - https://raw.githubusercontent.com/NREL/OpenStudio-resources/develop/styles/rubocop-rails.yml
```

