### PR TITLE
Zone load distribution scheme

### DIFF
--- a/model/simulationtests/airloop_and_zonehvac.osm
+++ b/model/simulationtests/airloop_and_zonehvac.osm
@@ -1,10 +1,10 @@
 
 OS:Version,
-  {172549e0-d900-4c8f-b284-523256dcf11d}, !- Handle
-  2.4.0;                                  !- Version Identifier
+  {49131b1f-1ffe-4ba2-90a0-3e9bdee90e2e}, !- Handle
+  2.6.2;                                  !- Version Identifier
 
 OS:BuildingStory,
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Handle
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Handle
   Story 1,                                !- Name
   0,                                      !- Nominal Z Coordinate {m}
   4,                                      !- Nominal Floor to Floor Height {m}
@@ -13,7 +13,7 @@ OS:BuildingStory,
   ;                                       !- Group Rendering Name
 
 OS:Space,
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Handle
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Handle
   Story 1 West Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -22,15 +22,15 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Building Story Name
-  {44537ee3-44f1-46da-bd10-0463bec291d1}; !- Thermal Zone Name
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Building Story Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}; !- Thermal Zone Name
 
 OS:Surface,
-  {63f9ec41-3b22-48fc-9dbe-f407bc9979fa}, !- Handle
+  {bb212b93-b8b4-41f5-8230-ed4fb0bad9b8}, !- Handle
   Surface 1,                              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -43,11 +43,11 @@ OS:Surface,
   3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {88d10f29-0ae8-495d-acdc-30ab70274148}, !- Handle
+  {8ac96433-7af0-4522-a165-51ffbab5705f}, !- Handle
   Surface 2,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -60,13 +60,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {57a628ae-d048-4433-80cb-02e1c8137986}, !- Handle
+  {288f326e-a176-4bf7-a77b-00036407e0a8}, !- Handle
   Surface 3,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {41207460-e604-4927-86aa-1241e75dea31}, !- Outside Boundary Condition Object
+  {888662cf-d551-4a41-aea3-56cc0c298324}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -77,13 +77,13 @@ OS:Surface,
   0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {ddf6f149-ad86-4772-b185-4c322d216b8a}, !- Handle
+  {9655cfd8-a9f0-4085-aca5-880b483a595e}, !- Handle
   Surface 4,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {bce24b22-ac25-4215-9cda-fb569e0cc84a}, !- Outside Boundary Condition Object
+  {780fd17b-9161-4353-bc2d-6e1533140549}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -94,13 +94,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {ae11c035-ffbf-4603-9032-a3dd9f7518af}, !- Handle
+  {7effc036-fab3-4fa3-8993-e45986c364e7}, !- Handle
   Surface 5,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {8a93009a-d4e2-418c-92e2-0c88d6259207}, !- Outside Boundary Condition Object
+  {4db01e5e-ef86-4e08-95d4-26259753f453}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -111,15 +111,15 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {80b4790a-547a-4fb4-9906-04808f9e4609}, !- Handle
+  {46aa6bce-b61a-470f-8c85-26e48066f99b}, !- Handle
   Surface 6,                              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {9cc70fda-a576-440f-b81f-465c533dc07b}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {5262dd77-9b59-4cea-b1dd-33ece3461229}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  {b1722243-7f7b-4e84-b3ac-1ed016071d0f}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
@@ -128,7 +128,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Handle
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Handle
   Story 1 North Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -137,15 +137,15 @@ OS:Space,
   3,                                      !- X Origin {m}
   47,                                     !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Building Story Name
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}; !- Thermal Zone Name
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Building Story Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}; !- Thermal Zone Name
 
 OS:Surface,
-  {e0c04a78-0456-481b-8017-a47b734c73d2}, !- Handle
+  {7b2b3f51-a716-4821-87e3-0385b7e40d5e}, !- Handle
   Surface 7,                              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -158,11 +158,11 @@ OS:Surface,
   0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {dfa64537-6ad2-4fb3-aaad-16d0cc939763}, !- Handle
+  {c9349cf4-ca4c-4462-87fb-6806b7ecb7aa}, !- Handle
   Surface 8,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -175,13 +175,13 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {c48da955-05e9-418d-ae8b-c4e432de7591}, !- Handle
+  {a66b5e20-501d-464c-b0d7-5d97f438635f}, !- Handle
   Surface 9,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {697fb912-39ab-47d0-a085-573a05f0f89a}, !- Outside Boundary Condition Object
+  {855b229d-f6ab-4b7a-8d86-b49499f2ce32}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -192,13 +192,13 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {eebf08f2-e5b7-41b5-bc79-3382156594ae}, !- Handle
+  {81a385e0-c881-4483-b74a-594f9e7af96c}, !- Handle
   Surface 10,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {4b62ddae-77ad-4789-b4cd-b071d13d0f76}, !- Outside Boundary Condition Object
+  {4f9b7e5f-d7c6-4c30-a1bd-cdc0a22e563c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -209,13 +209,13 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {41207460-e604-4927-86aa-1241e75dea31}, !- Handle
+  {888662cf-d551-4a41-aea3-56cc0c298324}, !- Handle
   Surface 11,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {57a628ae-d048-4433-80cb-02e1c8137986}, !- Outside Boundary Condition Object
+  {288f326e-a176-4bf7-a77b-00036407e0a8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -226,15 +226,15 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {c6bc978d-ffb2-4a64-95c6-40ad3e06c3ca}, !- Handle
+  {1f3347b5-7d02-4f1f-8a4b-66d15ae39b5b}, !- Handle
   Surface 12,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {45d204ec-d3b0-44d3-b1be-94053f503d64}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {e12243d2-42af-445d-8747-939f6ef6cc35}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  {adaf156c-5fa2-45da-81bd-29a1467c192a}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
@@ -243,7 +243,7 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Handle
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Handle
   Story 1 East Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -252,15 +252,15 @@ OS:Space,
   97,                                     !- X Origin {m}
   3,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Building Story Name
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}; !- Thermal Zone Name
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Building Story Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}; !- Thermal Zone Name
 
 OS:Surface,
-  {62e41c89-63f8-460a-be95-78b20b88028a}, !- Handle
+  {7043f796-e3ec-4932-b70d-94e8bd391971}, !- Handle
   Surface 13,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -273,11 +273,11 @@ OS:Surface,
   0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {e0bc5538-f918-4ec0-8d48-5ba586601d6e}, !- Handle
+  {88923dce-7eda-44b6-95bf-339d963d97cb}, !- Handle
   Surface 14,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -290,13 +290,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {bab5e478-fa4d-44fa-a982-c8c4bbc6edba}, !- Handle
+  {dee4c623-fbf5-4a12-bb39-4db3e1522f3e}, !- Handle
   Surface 15,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {ad9dcd55-1e4b-4bb6-b202-5f8f010e2f6b}, !- Outside Boundary Condition Object
+  {ce73ad62-d905-4efa-b5bb-6d784ae33a16}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -307,13 +307,13 @@ OS:Surface,
   3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {a853ad33-a5fe-42f8-8a70-e0d36b36a7a3}, !- Handle
+  {4a2d8e93-901d-4351-9887-90d9b527a5a0}, !- Handle
   Surface 16,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {6901ddb7-f578-4283-8c83-5e9082b0d0dc}, !- Outside Boundary Condition Object
+  {ad1454c2-2010-4ebf-afcb-af09a7203c6b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -324,13 +324,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {697fb912-39ab-47d0-a085-573a05f0f89a}, !- Handle
+  {855b229d-f6ab-4b7a-8d86-b49499f2ce32}, !- Handle
   Surface 17,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {c48da955-05e9-418d-ae8b-c4e432de7591}, !- Outside Boundary Condition Object
+  {a66b5e20-501d-464c-b0d7-5d97f438635f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -341,15 +341,15 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {d761d080-2407-431e-82a3-36b72b367856}, !- Handle
+  {27ab3607-9e66-4953-ad4e-070044542c55}, !- Handle
   Surface 18,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {c7f4a7b2-4b9d-4dc4-9aec-26449a143077}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {328d6499-6e0b-4de1-b6ab-ef82fe5569f4}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  {2be25e0c-4fff-4bbb-a58d-c34b47ffc1fe}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
@@ -358,7 +358,7 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Handle
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Handle
   Story 1 South Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -367,15 +367,15 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Building Story Name
-  {32b80fbc-8c27-4843-8888-50924df2dba5}; !- Thermal Zone Name
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Building Story Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}; !- Thermal Zone Name
 
 OS:Surface,
-  {7296760d-b07a-4a1e-ac3b-3d79aba3de3f}, !- Handle
+  {df4c4c8f-c65b-45c4-80ff-4dbede540a69}, !- Handle
   Surface 19,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -388,11 +388,11 @@ OS:Surface,
   97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {ae816bb7-3e55-4ff2-8930-1d054678d525}, !- Handle
+  {39d430eb-3fcd-4268-96c7-54e3b49b048c}, !- Handle
   Surface 20,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -405,13 +405,13 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {8a93009a-d4e2-418c-92e2-0c88d6259207}, !- Handle
+  {4db01e5e-ef86-4e08-95d4-26259753f453}, !- Handle
   Surface 21,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {ae11c035-ffbf-4603-9032-a3dd9f7518af}, !- Outside Boundary Condition Object
+  {7effc036-fab3-4fa3-8993-e45986c364e7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -422,13 +422,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {308c62b8-8847-40ce-bbab-1927acc69d3f}, !- Handle
+  {c79ef30d-fcd8-429e-bb9a-0ca51ab4cf71}, !- Handle
   Surface 22,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {83c99d12-9710-46fd-8010-5acb42d3b8ca}, !- Outside Boundary Condition Object
+  {f3a3e631-e473-4e3a-b159-036471c88e6b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -439,13 +439,13 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {ad9dcd55-1e4b-4bb6-b202-5f8f010e2f6b}, !- Handle
+  {ce73ad62-d905-4efa-b5bb-6d784ae33a16}, !- Handle
   Surface 23,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {bab5e478-fa4d-44fa-a982-c8c4bbc6edba}, !- Outside Boundary Condition Object
+  {dee4c623-fbf5-4a12-bb39-4db3e1522f3e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -456,15 +456,15 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {90802aa7-9fec-4cd1-947b-38f112754e0e}, !- Handle
+  {d869d5ec-0245-4a8b-ab0e-5e9f0b54a7ec}, !- Handle
   Surface 24,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {51668e31-658c-421f-b368-31382cc7b458}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {3eec83b1-695f-4d6b-bbf7-cbe8f70b7f02}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  {f65a63d6-351f-49ca-b201-d3f96e58a3e3}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
@@ -473,7 +473,7 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Handle
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Handle
   Story 1 Core Space,                     !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -482,15 +482,15 @@ OS:Space,
   3,                                      !- X Origin {m}
   3,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {2e99ac02-1687-4fcd-a207-742b0bdd0a86}, !- Building Story Name
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}; !- Thermal Zone Name
+  {df8b7b10-bb72-4a67-af16-1568b13348a6}, !- Building Story Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}; !- Thermal Zone Name
 
 OS:Surface,
-  {b9519da7-a599-4b8e-ae82-2999819b9a92}, !- Handle
+  {9f5f57c5-27aa-4ce1-999b-9ca8c55a12b9}, !- Handle
   Surface 25,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -503,13 +503,13 @@ OS:Surface,
   94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {bce24b22-ac25-4215-9cda-fb569e0cc84a}, !- Handle
+  {780fd17b-9161-4353-bc2d-6e1533140549}, !- Handle
   Surface 26,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {ddf6f149-ad86-4772-b185-4c322d216b8a}, !- Outside Boundary Condition Object
+  {9655cfd8-a9f0-4085-aca5-880b483a595e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -520,13 +520,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {4b62ddae-77ad-4789-b4cd-b071d13d0f76}, !- Handle
+  {4f9b7e5f-d7c6-4c30-a1bd-cdc0a22e563c}, !- Handle
   Surface 27,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {eebf08f2-e5b7-41b5-bc79-3382156594ae}, !- Outside Boundary Condition Object
+  {81a385e0-c881-4483-b74a-594f9e7af96c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -537,13 +537,13 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {6901ddb7-f578-4283-8c83-5e9082b0d0dc}, !- Handle
+  {ad1454c2-2010-4ebf-afcb-af09a7203c6b}, !- Handle
   Surface 28,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {a853ad33-a5fe-42f8-8a70-e0d36b36a7a3}, !- Outside Boundary Condition Object
+  {4a2d8e93-901d-4351-9887-90d9b527a5a0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -554,13 +554,13 @@ OS:Surface,
   94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {83c99d12-9710-46fd-8010-5acb42d3b8ca}, !- Handle
+  {f3a3e631-e473-4e3a-b159-036471c88e6b}, !- Handle
   Surface 29,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {308c62b8-8847-40ce-bbab-1927acc69d3f}, !- Outside Boundary Condition Object
+  {c79ef30d-fcd8-429e-bb9a-0ca51ab4cf71}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -571,595 +571,11 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {2d385b62-5763-4b4c-bdc2-f5e20276ba7d}, !- Handle
+  {08b3908b-7650-4162-84f4-98f50eb3224d}, !- Handle
   Surface 30,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {a2c2dae5-13a5-4ac0-a7f1-d201f40815ad}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {8e7a7a65-49c1-4d6b-9090-d21a1350c00d}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
-  94, 44, 4,                              !- X,Y,Z Vertex 2 {m}
-  0, 44, 4,                               !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:BuildingStory,
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Handle
-  Story 2,                                !- Name
-  4,                                      !- Nominal Z Coordinate {m}
-  4,                                      !- Nominal Floor to Floor Height {m}
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  ;                                       !- Group Rendering Name
-
-OS:Space,
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Handle
-  Story 2 West Perimeter Space,           !- Name
-  ,                                       !- Space Type Name
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  -0,                                     !- Direction of Relative North {deg}
-  0,                                      !- X Origin {m}
-  0,                                      !- Y Origin {m}
-  4,                                      !- Z Origin {m}
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Building Story Name
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}; !- Thermal Zone Name
-
-OS:Surface,
-  {5262dd77-9b59-4cea-b1dd-33ece3461229}, !- Handle
-  Surface 31,                             !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {80b4790a-547a-4fb4-9906-04808f9e4609}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
-  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
-  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
-  3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {66f2e8a5-ee6b-411f-8f22-939283ea85a8}, !- Handle
-  Surface 32,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 50, 4,                               !- X,Y,Z Vertex 1 {m}
-  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {d14c00c9-fb5a-4e71-9cbb-e4fed31c3fe4}, !- Handle
-  Surface 33,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {b9e779ec-b157-4bd8-8d16-6d68a82c4458}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
-  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 50, 0,                               !- X,Y,Z Vertex 3 {m}
-  0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {3ce305c4-cdb6-4bfc-ad10-a0bd42b4950f}, !- Handle
-  Surface 34,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {1b091bf8-ec53-46a8-a2b2-215b7077decb}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
-  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
-  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
-  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {2ba9588c-226b-47a9-8805-628a1ac8c2ea}, !- Handle
-  Surface 35,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {51ee4620-dc2f-4460-b09e-974106c4f94c}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
-  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {175e68bc-2305-4357-8fe0-c62b115e7c37}, !- Handle
-  Surface 36,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {504a8ef3-9da0-47b6-9da5-de5eb8947f42}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
-  3, 47, 4,                               !- X,Y,Z Vertex 2 {m}
-  0, 50, 4,                               !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Space,
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Handle
-  Story 2 North Perimeter Space,          !- Name
-  ,                                       !- Space Type Name
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  -0,                                     !- Direction of Relative North {deg}
-  3,                                      !- X Origin {m}
-  47,                                     !- Y Origin {m}
-  4,                                      !- Z Origin {m}
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Building Story Name
-  {5e119a23-a619-43bd-90fc-7ca644e00207}; !- Thermal Zone Name
-
-OS:Surface,
-  {e12243d2-42af-445d-8747-939f6ef6cc35}, !- Handle
-  Surface 37,                             !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {c6bc978d-ffb2-4a64-95c6-40ad3e06c3ca}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  -3, 3, 0,                               !- X,Y,Z Vertex 1 {m}
-  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
-  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
-  0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {32a0c5c9-a553-4a3a-9ca7-060efe37816e}, !- Handle
-  Surface 38,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
-  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
-  -3, 3, 0,                               !- X,Y,Z Vertex 3 {m}
-  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {ae34ca4d-647d-4ee1-8308-1884da30445d}, !- Handle
-  Surface 39,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {40307294-3995-4b0d-8ebd-9d7b98a16de4}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
-  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
-  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
-  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {501a20f4-241b-4fc1-81da-6345e8cf4de1}, !- Handle
-  Surface 40,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {203c1532-6f1a-4bd6-81de-b4e1ef2dbcab}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
-  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {b9e779ec-b157-4bd8-8d16-6d68a82c4458}, !- Handle
-  Surface 41,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {d14c00c9-fb5a-4e71-9cbb-e4fed31c3fe4}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  -3, 3, 4,                               !- X,Y,Z Vertex 1 {m}
-  -3, 3, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {c0997130-75d1-4a8e-b8d0-84c8371c7597}, !- Handle
-  Surface 42,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {1bdf2d7e-0e41-4ec3-8960-906a33b92254}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  94, 0, 4,                               !- X,Y,Z Vertex 2 {m}
-  97, 3, 4,                               !- X,Y,Z Vertex 3 {m}
-  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Space,
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Handle
-  Story 2 East Perimeter Space,           !- Name
-  ,                                       !- Space Type Name
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  -0,                                     !- Direction of Relative North {deg}
-  97,                                     !- X Origin {m}
-  3,                                      !- Y Origin {m}
-  4,                                      !- Z Origin {m}
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Building Story Name
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}; !- Thermal Zone Name
-
-OS:Surface,
-  {328d6499-6e0b-4de1-b6ab-ef82fe5569f4}, !- Handle
-  Surface 43,                             !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {d761d080-2407-431e-82a3-36b72b367856}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 47, 0,                               !- X,Y,Z Vertex 1 {m}
-  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {41b476ed-50ae-42d3-92bf-1ee1d68d2921}, !- Handle
-  Surface 44,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, -3, 4,                               !- X,Y,Z Vertex 1 {m}
-  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
-  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
-  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {b0b5a188-5eea-4a0e-b8ae-bc2cb57d2e82}, !- Handle
-  Surface 45,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {67f1159d-0679-4efc-addc-01087713f4df}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  3, -3, 0,                               !- X,Y,Z Vertex 3 {m}
-  3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {da4a9cb0-02eb-47d5-822f-7eccb4e24172}, !- Handle
-  Surface 46,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {61b59c39-3962-4bcf-a4c6-85ce87e8b7f9}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
-  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {40307294-3995-4b0d-8ebd-9d7b98a16de4}, !- Handle
-  Surface 47,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {ae34ca4d-647d-4ee1-8308-1884da30445d}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
-  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
-  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {48d0a3cf-e28e-40e5-8f44-a652cd4b4e2d}, !- Handle
-  Surface 48,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {b9298af2-ee57-4e0c-9538-31b08a08a2a8}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
-  0, 0, 4,                                !- X,Y,Z Vertex 2 {m}
-  3, -3, 4,                               !- X,Y,Z Vertex 3 {m}
-  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Space,
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Handle
-  Story 2 South Perimeter Space,          !- Name
-  ,                                       !- Space Type Name
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  -0,                                     !- Direction of Relative North {deg}
-  0,                                      !- X Origin {m}
-  0,                                      !- Y Origin {m}
-  4,                                      !- Z Origin {m}
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Building Story Name
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}; !- Thermal Zone Name
-
-OS:Surface,
-  {3eec83b1-695f-4d6b-bbf7-cbe8f70b7f02}, !- Handle
-  Surface 49,                             !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {90802aa7-9fec-4cd1-947b-38f112754e0e}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  100, 0, 0,                              !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
-  97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {cd6d4ff8-914d-443c-abc9-1fd054e82872}, !- Handle
-  Surface 50,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  100, 0, 0,                              !- X,Y,Z Vertex 3 {m}
-  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {51ee4620-dc2f-4460-b09e-974106c4f94c}, !- Handle
-  Surface 51,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {2ba9588c-226b-47a9-8805-628a1ac8c2ea}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
-  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {078b3c2e-8590-4ff1-a5e1-54f8737144ec}, !- Handle
-  Surface 52,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {67c8cfa9-12de-4776-889b-9a021c4bfe16}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
-  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
-  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
-  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {67f1159d-0679-4efc-addc-01087713f4df}, !- Handle
-  Surface 53,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {b0b5a188-5eea-4a0e-b8ae-bc2cb57d2e82}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  100, 0, 4,                              !- X,Y,Z Vertex 1 {m}
-  100, 0, 0,                              !- X,Y,Z Vertex 2 {m}
-  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
-  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {8f21500f-6fdd-40d2-a7c6-5df805457839}, !- Handle
-  Surface 54,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {4b01776e-4b33-46a8-99b7-3c3bde3cbf86}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
-  3, 3, 4,                                !- X,Y,Z Vertex 2 {m}
-  0, 0, 4,                                !- X,Y,Z Vertex 3 {m}
-  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
-
-OS:Space,
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Handle
-  Story 2 Core Space,                     !- Name
-  ,                                       !- Space Type Name
-  ,                                       !- Default Construction Set Name
-  ,                                       !- Default Schedule Set Name
-  -0,                                     !- Direction of Relative North {deg}
-  3,                                      !- X Origin {m}
-  3,                                      !- Y Origin {m}
-  4,                                      !- Z Origin {m}
-  {8d2cc2da-42d2-4959-92f4-b70a08d5d51e}, !- Building Story Name
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}; !- Thermal Zone Name
-
-OS:Surface,
-  {8e7a7a65-49c1-4d6b-9090-d21a1350c00d}, !- Handle
-  Surface 55,                             !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {2d385b62-5763-4b4c-bdc2-f5e20276ba7d}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
-  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
-  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
-  94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {1b091bf8-ec53-46a8-a2b2-215b7077decb}, !- Handle
-  Surface 56,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {3ce305c4-cdb6-4bfc-ad10-a0bd42b4950f}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
-  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {203c1532-6f1a-4bd6-81de-b4e1ef2dbcab}, !- Handle
-  Surface 57,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {501a20f4-241b-4fc1-81da-6345e8cf4de1}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  94, 44, 4,                              !- X,Y,Z Vertex 1 {m}
-  94, 44, 0,                              !- X,Y,Z Vertex 2 {m}
-  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
-  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {61b59c39-3962-4bcf-a4c6-85ce87e8b7f9}, !- Handle
-  Surface 58,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {da4a9cb0-02eb-47d5-822f-7eccb4e24172}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
-  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
-  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
-  94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {67c8cfa9-12de-4776-889b-9a021c4bfe16}, !- Handle
-  Surface 59,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {078b3c2e-8590-4ff1-a5e1-54f8737144ec}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
-  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {ba46588b-7699-4d03-8dbc-1c231dcc6fc6}, !- Handle
-  Surface 60,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {325d4e67-717b-43cd-a52e-d8c499f5d54f}, !- Space Name
+  {87a43f14-e0bd-4544-b3a4-36cfd31847a6}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -1172,540 +588,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:ThermalZone,
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- Handle
-  Story 2 East Perimeter Thermal Zone,    !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {81cdf6eb-d245-4746-b5ec-ad0680eb54d0}, !- Zone Air Inlet Port List
-  {05127144-9a40-4cbe-b216-ec9993f7bcc2}, !- Zone Air Exhaust Port List
-  {c2d2400b-169a-4730-947f-563843aec6cd}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {c48bec1b-afad-4083-9264-8bfde163092f}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
-
-OS:Node,
-  {9a13553f-26ec-4389-9c35-ea6de9a9eebc}, !- Handle
-  Node 1,                                 !- Name
-  {c2d2400b-169a-4730-947f-563843aec6cd}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {c2d2400b-169a-4730-947f-563843aec6cd}, !- Handle
-  {f5ad5b0e-3758-4ca5-b961-93edaf90e114}, !- Name
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- Source Object
-  11,                                     !- Outlet Port
-  {9a13553f-26ec-4389-9c35-ea6de9a9eebc}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {81cdf6eb-d245-4746-b5ec-ad0680eb54d0}, !- Handle
-  {4dce5667-1409-4e23-8c96-748557e0f878}, !- Name
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- HVAC Component
-  {75a7ab1d-9917-4704-8409-1ca91b7a1990}; !- Port 1
-
-OS:PortList,
-  {05127144-9a40-4cbe-b216-ec9993f7bcc2}, !- Handle
-  {6d413984-f397-4d0a-8092-c780530bb669}, !- Name
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- HVAC Component
-  {da16c84b-3269-48fc-886c-b88fee1df790}; !- Port 1
-
-OS:Sizing:Zone,
-  {ea308f0c-af26-4fbe-8977-c01c759caa0e}, !- Handle
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {1c082d16-7d2d-4720-bc62-e291994b709b}, !- Handle
-  Zone HVAC Equipment List 1,             !- Name
-  {3a42c799-3cd3-49ee-a807-0d759064ace5}, !- Thermal Zone
-  {e3fcaade-8089-410c-8464-b5383eb70207}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
-
-OS:ThermalZone,
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- Handle
-  Story 1 South Perimeter Thermal Zone,   !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {fd53d6c1-1cca-4bf3-94f9-42352dd33ab4}, !- Zone Air Inlet Port List
-  {124ba351-a8bd-462e-982c-1c211f9954f2}, !- Zone Air Exhaust Port List
-  {1de1e91e-2025-4368-9448-17aa6e756fdb}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {c94704c5-461e-4482-a2ad-c111b7b07414}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
-
-OS:Node,
-  {a842032e-9ab7-435a-a526-7b3ff86ff40f}, !- Handle
-  Node 2,                                 !- Name
-  {1de1e91e-2025-4368-9448-17aa6e756fdb}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {1de1e91e-2025-4368-9448-17aa6e756fdb}, !- Handle
-  {aa9ac73a-075e-46a3-811f-65dfcadd5339}, !- Name
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- Source Object
-  11,                                     !- Outlet Port
-  {a842032e-9ab7-435a-a526-7b3ff86ff40f}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {fd53d6c1-1cca-4bf3-94f9-42352dd33ab4}, !- Handle
-  {164751e6-8571-4ba4-b6ff-7113e641ea55}, !- Name
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- HVAC Component
-  {5dc1cadc-f624-4982-a0ee-7ea4d69c057e}; !- Port 1
-
-OS:PortList,
-  {124ba351-a8bd-462e-982c-1c211f9954f2}, !- Handle
-  {c803b32d-214f-40fd-867d-ffda87db2300}, !- Name
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- HVAC Component
-  {85a62a22-8f26-4016-b7d2-48c150b80872}; !- Port 1
-
-OS:Sizing:Zone,
-  {1e45ae52-64e1-4f91-a520-29cf069cc70d}, !- Handle
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {2f8d208f-ee58-434d-8a5c-00878bdb1d3d}, !- Handle
-  Zone HVAC Equipment List 2,             !- Name
-  {32b80fbc-8c27-4843-8888-50924df2dba5}, !- Thermal Zone
-  {93451506-96dd-4a2f-96d2-302680f569a9}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
-
-OS:ThermalZone,
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- Handle
-  Story 1 West Perimeter Thermal Zone,    !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {25c71059-c1f2-4c97-b453-b7205cfb1f2d}, !- Zone Air Inlet Port List
-  {1f1a3ce9-76ee-4084-8cc3-87b50190e583}, !- Zone Air Exhaust Port List
-  {f5fd0490-d3e9-4548-9cb9-fd9b62a5e6cf}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {bed0b605-f8a7-47b7-aef1-d3b63b268385}, !- Thermostat Name
-  No,                                     !- Use Ideal Air Loads
-  {4ecf77f1-57a1-456b-90c4-5b4b5a9b4e6a}; !- Humidistat Name
-
-OS:Node,
-  {45faa30c-1d83-4035-b578-58c7a9e7863c}, !- Handle
-  Node 3,                                 !- Name
-  {f5fd0490-d3e9-4548-9cb9-fd9b62a5e6cf}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {f5fd0490-d3e9-4548-9cb9-fd9b62a5e6cf}, !- Handle
-  {3b5fcc20-da1b-4395-b957-fa0fdff161fc}, !- Name
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- Source Object
-  11,                                     !- Outlet Port
-  {45faa30c-1d83-4035-b578-58c7a9e7863c}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {25c71059-c1f2-4c97-b453-b7205cfb1f2d}, !- Handle
-  {f003a6a3-a23f-42a2-b0b1-1385d5ec5d38}, !- Name
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- HVAC Component
-  {5fb4eda3-ba68-4006-ac65-356586aa21ef}, !- Port 1
-  {3105466c-dba9-4791-bd25-3303ff263aca}, !- Port 2
-  {a6416344-000c-4e9f-887d-dfec62b5e495}; !- Port 3
-
-OS:PortList,
-  {1f1a3ce9-76ee-4084-8cc3-87b50190e583}, !- Handle
-  {1ca671b2-9d05-42bd-86d3-473ccea74d45}, !- Name
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- HVAC Component
-  {89959d40-21a4-420b-ab0f-5533e212f13d}, !- Port 1
-  {ed97e2cc-1a23-40e2-89d2-87ccf2073ee2}, !- Port 2
-  {0799096d-d035-4984-a335-99762f9c6fd2}; !- Port 3
-
-OS:Sizing:Zone,
-  {6811757d-eea6-4bcb-87d9-806d3b78f390}, !- Handle
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {feaec887-37e4-41b4-afcb-198d044e7a2e}, !- Handle
-  Zone HVAC Equipment List 3,             !- Name
-  {44537ee3-44f1-46da-bd10-0463bec291d1}, !- Thermal Zone
-  {c48e896e-9d45-4a8c-8b16-21d09212385a}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {28ae44e7-45bd-4339-b64f-c39dac498bdd}, !- Zone Equipment 2
-  2,                                      !- Zone Equipment Cooling Sequence 2
-  2,                                      !- Zone Equipment Heating or No-Load Sequence 2
-  {c99ee959-6537-44d2-b73f-65baa58af9df}, !- Zone Equipment 3
-  3,                                      !- Zone Equipment Cooling Sequence 3
-  3;                                      !- Zone Equipment Heating or No-Load Sequence 3
-
-OS:ThermalZone,
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- Handle
-  Story 2 West Perimeter Thermal Zone,    !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {9ccc6d47-c84a-4972-9d7b-d187b4ee0e4b}, !- Zone Air Inlet Port List
-  {3e04170b-9ac7-4bdf-9982-cb062edcfe53}, !- Zone Air Exhaust Port List
-  {158614da-22e4-434d-b98b-3ae31e957647}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {37397690-97fc-47a7-bc4f-d242f13ab812}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
-
-OS:Node,
-  {0e97f30d-b45d-4eaa-b7cc-59b836e75937}, !- Handle
-  Node 4,                                 !- Name
-  {158614da-22e4-434d-b98b-3ae31e957647}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {158614da-22e4-434d-b98b-3ae31e957647}, !- Handle
-  {8853484f-a6a2-4daa-b35e-93cac3d0f0de}, !- Name
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- Source Object
-  11,                                     !- Outlet Port
-  {0e97f30d-b45d-4eaa-b7cc-59b836e75937}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {9ccc6d47-c84a-4972-9d7b-d187b4ee0e4b}, !- Handle
-  {72c04fd9-8260-453a-aa18-b389e9daea01}, !- Name
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- HVAC Component
-  {502406d4-6ac1-4b6f-9bef-c816b434b305}; !- Port 1
-
-OS:PortList,
-  {3e04170b-9ac7-4bdf-9982-cb062edcfe53}, !- Handle
-  {3f99b001-c1dd-4041-a959-d07a5fc02029}, !- Name
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- HVAC Component
-  {d64c33e5-49f9-4751-87ed-b9def7b7aba8}; !- Port 1
-
-OS:Sizing:Zone,
-  {562c265e-f048-4d8d-994d-549cb4b3cddf}, !- Handle
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {4c92b5f3-1c45-4ab8-ac15-d9263e363a7d}, !- Handle
-  Zone HVAC Equipment List 4,             !- Name
-  {ae67e47f-476a-45fb-b6c2-e7309aedc74c}, !- Thermal Zone
-  {ce347b13-ebca-4acd-8d58-6d8b6e9a2fe4}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
-
-OS:ThermalZone,
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- Handle
-  Story 1 North Perimeter Thermal Zone,   !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {f4d76982-320a-477e-a1e4-3731e43b3d92}, !- Zone Air Inlet Port List
-  {386262c0-4707-4ca5-990e-0f2f7dcf0c9e}, !- Zone Air Exhaust Port List
-  {34f93ced-93f6-4845-aca3-46ced062d925}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {ec0079e9-50f9-4d89-892e-077e3a414f2f}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
-
-OS:Node,
-  {e5fab101-e18f-425a-845b-0c650b824c0c}, !- Handle
-  Node 5,                                 !- Name
-  {34f93ced-93f6-4845-aca3-46ced062d925}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {34f93ced-93f6-4845-aca3-46ced062d925}, !- Handle
-  {3c294383-01a9-4fd1-a774-c6bdd9bff93a}, !- Name
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- Source Object
-  11,                                     !- Outlet Port
-  {e5fab101-e18f-425a-845b-0c650b824c0c}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {f4d76982-320a-477e-a1e4-3731e43b3d92}, !- Handle
-  {81c99bae-3eb1-4772-a895-53f1aa6ad5bc}, !- Name
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- HVAC Component
-  {3ea82e9d-1c14-4853-b327-b0d7700597f5}; !- Port 1
-
-OS:PortList,
-  {386262c0-4707-4ca5-990e-0f2f7dcf0c9e}, !- Handle
-  {1c73f032-daeb-4905-9ee1-6e73a0b9b2e6}, !- Name
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- HVAC Component
-  {dc111bda-6187-49ab-8f01-200d01da972c}; !- Port 1
-
-OS:Sizing:Zone,
-  {be7ccca6-8671-44f1-a176-25b13c3a8041}, !- Handle
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {12c2657d-40b8-45b0-b13b-9de985f6da2c}, !- Handle
-  Zone HVAC Equipment List 5,             !- Name
-  {7beb5f35-2f9c-4bfa-9a10-bce65f23590d}, !- Thermal Zone
-  {cf784a16-f8f4-4172-9496-cbaf45599740}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
-
-OS:ThermalZone,
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- Handle
-  Story 1 East Perimeter Thermal Zone,    !- Name
-  ,                                       !- Multiplier
-  ,                                       !- Ceiling Height {m}
-  ,                                       !- Volume {m3}
-  ,                                       !- Floor Area {m2}
-  ,                                       !- Zone Inside Convection Algorithm
-  ,                                       !- Zone Outside Convection Algorithm
-  ,                                       !- Zone Conditioning Equipment List Name
-  {111e5a4c-0426-4d15-bf10-745a2855fed1}, !- Zone Air Inlet Port List
-  {71130af3-15f6-4838-9dee-4fa7efcd3001}, !- Zone Air Exhaust Port List
-  {17e60f41-50df-4f31-abf4-212e9a6d0c52}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
-  ,                                       !- Primary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
-  ,                                       !- Secondary Daylighting Control Name
-  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
-  ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
-  {9f64ee4f-7edf-45dc-8b2d-de1915fe7273}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
-
-OS:Node,
-  {596eb2ab-96d7-4dca-b03d-ec61a493255d}, !- Handle
-  Node 6,                                 !- Name
-  {17e60f41-50df-4f31-abf4-212e9a6d0c52}, !- Inlet Port
-  ;                                       !- Outlet Port
-
-OS:Connection,
-  {17e60f41-50df-4f31-abf4-212e9a6d0c52}, !- Handle
-  {4e7ed8a8-d0de-4257-b11d-c6dc0b0cf03f}, !- Name
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- Source Object
-  11,                                     !- Outlet Port
-  {596eb2ab-96d7-4dca-b03d-ec61a493255d}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:PortList,
-  {111e5a4c-0426-4d15-bf10-745a2855fed1}, !- Handle
-  {5ea11c5b-5669-48a7-b8a2-590e953d48ed}, !- Name
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- HVAC Component
-  {c08911a3-9c2b-459e-87dc-4dab2eecddf0}; !- Port 1
-
-OS:PortList,
-  {71130af3-15f6-4838-9dee-4fa7efcd3001}, !- Handle
-  {c816b719-02f6-435f-b260-19f5435a80fa}, !- Name
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- HVAC Component
-  {7b560590-0dea-4739-9340-2e088ce05137}; !- Port 1
-
-OS:Sizing:Zone,
-  {49ba1bd7-aafe-4759-87bd-8a1f36f139a5}, !- Handle
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- Zone or ZoneList Name
-  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
-  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
-  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
-  40,                                     !- Zone Heating Design Supply Air Temperature {C}
-  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
-  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
-  ,                                       !- Zone Heating Sizing Factor
-  ,                                       !- Zone Cooling Sizing Factor
-  DesignDay,                              !- Cooling Design Air Flow Method
-  ,                                       !- Cooling Design Air Flow Rate {m3/s}
-  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Cooling Minimum Air Flow {m3/s}
-  ,                                       !- Cooling Minimum Air Flow Fraction
-  DesignDay,                              !- Heating Design Air Flow Method
-  ,                                       !- Heating Design Air Flow Rate {m3/s}
-  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
-  ,                                       !- Heating Maximum Air Flow {m3/s}
-  ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
-  No,                                     !- Account for Dedicated Outdoor Air System
-  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
-  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
-  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
-
-OS:ZoneHVAC:EquipmentList,
-  {47a80005-7549-4854-8f2c-8215a27e5a8b}, !- Handle
-  Zone HVAC Equipment List 6,             !- Name
-  {36a11f2e-3ee2-465a-8630-b68e1b2c0f28}, !- Thermal Zone
-  {269b11a9-9e8c-4952-a4c6-1e05f1b95a47}, !- Zone Equipment 1
-  1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
-
-OS:ThermalZone,
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- Handle
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- Handle
   Story 1 Core Thermal Zone,              !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1714,48 +597,58 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {bc42e547-e08a-4f3a-abff-5d10f7ceb4f4}, !- Zone Air Inlet Port List
-  {5180de4f-4692-4a62-a05c-40f6b90ab5d9}, !- Zone Air Exhaust Port List
-  {d511fd36-5727-46f7-a869-aabb4717f0a2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Zone Air Inlet Port List
+  {9695ed04-35b6-4772-83cd-5187282d3bc0}, !- Zone Air Exhaust Port List
+  {cbc880ca-e3d3-49b0-a652-331eaccaade6}, !- Zone Air Node Name
+  {fec772da-3099-43c0-90a3-09dc90ef244f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {512d858c-c00d-4393-a43c-d02166fd4c95}, !- Thermostat Name
-  No;                                     !- Use Ideal Air Loads
+  {aae27556-d170-4dce-aa72-b033954abc0f}, !- Thermostat Name
+  No,                                     !- Use Ideal Air Loads
+  {30ec88c2-b1d0-4368-8c8c-24f6d64b151d}; !- Humidistat Name
 
 OS:Node,
-  {21016e0c-ea55-4996-bb2c-6b9baa19f3d5}, !- Handle
-  Node 7,                                 !- Name
-  {d511fd36-5727-46f7-a869-aabb4717f0a2}, !- Inlet Port
+  {9c311065-3969-4f19-99fa-7bd90fee3281}, !- Handle
+  Node 1,                                 !- Name
+  {cbc880ca-e3d3-49b0-a652-331eaccaade6}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {d511fd36-5727-46f7-a869-aabb4717f0a2}, !- Handle
-  {5b4dd14d-8a4b-418e-9fd6-2756f0306812}, !- Name
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- Source Object
+  {cbc880ca-e3d3-49b0-a652-331eaccaade6}, !- Handle
+  {7ba88900-3050-41ea-9b1d-e4d2d17584cf}, !- Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- Source Object
   11,                                     !- Outlet Port
-  {21016e0c-ea55-4996-bb2c-6b9baa19f3d5}, !- Target Object
+  {9c311065-3969-4f19-99fa-7bd90fee3281}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {bc42e547-e08a-4f3a-abff-5d10f7ceb4f4}, !- Handle
-  {c2ed5f7e-d51c-4d1f-a5fc-8010c4699468}, !- Name
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- HVAC Component
-  {22f2be26-d21c-4e71-b83d-80ef4c7b0a29}; !- Port 1
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Handle
+  {b94122e3-51de-4db9-9862-f25b1922f649}, !- Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- HVAC Component
+  {1fd906e5-b4d4-4d4c-add0-e4dda1c8094f}, !- Port 1
+  {fbef4d93-883e-4194-8958-e500c9bda87b}, !- Port 2
+  {955ba147-d594-43b1-93ec-a5de78741e14}; !- Port 3
 
 OS:PortList,
-  {5180de4f-4692-4a62-a05c-40f6b90ab5d9}, !- Handle
-  {0605d6c3-88ee-4a0a-a8e4-afca88f8f48b}, !- Name
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- HVAC Component
-  {011b5cf9-0e06-43ea-8f19-58de8c01b601}; !- Port 1
+  {9695ed04-35b6-4772-83cd-5187282d3bc0}, !- Handle
+  {00f43a53-3ab4-4f51-8e61-779a109d52b6}, !- Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- HVAC Component
+  {af958f87-c525-481f-849c-4b43169ba2bf}, !- Port 1
+  {7eff04ad-1ac7-4d56-b488-bc20656d7de6}, !- Port 2
+  {80b14976-b463-4008-a7da-261ec3621998}; !- Port 3
+
+OS:PortList,
+  {fec772da-3099-43c0-90a3-09dc90ef244f}, !- Handle
+  {a8e43f07-79f7-4137-bd8d-82f55acd7895}, !- Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {800989d4-6be2-48b9-af41-f02df71532c2}, !- Handle
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- Zone or ZoneList Name
+  {3f1d5556-6b73-497e-a527-ff8a1bf4999c}, !- Handle
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1784,16 +677,23 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {8c18f6fa-62a4-47fd-af78-8714f4bba480}, !- Handle
-  Zone HVAC Equipment List 7,             !- Name
-  {a450f2cd-516b-46f4-934f-b3c8ce93b412}, !- Thermal Zone
-  {e392f7a7-deeb-47b4-ba3d-ba2b8849c6ee}, !- Zone Equipment 1
+  {9f46abd9-6cff-4aa5-b727-fe49b0ff5e50}, !- Handle
+  Zone HVAC Equipment List 1,             !- Name
+  {13bc2a7b-97f2-4fda-8982-c833e01d19b6}, !- Thermal Zone
+  UniformLoad,                            !- Load Distribution Scheme
+  {816ac76d-50b2-4a63-ac45-4286483c435e}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
+  {302d72d9-06d1-496e-b14b-a697d235ff87}, !- Zone Equipment 2
+  2,                                      !- Zone Equipment Cooling Sequence 2
+  2,                                      !- Zone Equipment Heating or No-Load Sequence 2
+  {a870f83f-38a0-4d83-bfa9-ec927f3fea1f}, !- Zone Equipment 3
+  3,                                      !- Zone Equipment Cooling Sequence 3
+  3;                                      !- Zone Equipment Heating or No-Load Sequence 3
 
 OS:ThermalZone,
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- Handle
-  Story 2 South Perimeter Thermal Zone,   !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- Handle
+  Story 1 East Perimeter Thermal Zone,    !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
   ,                                       !- Volume {m3}
@@ -1801,48 +701,53 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {1a1eee6b-08ce-4f55-a05a-7e9b4b24c843}, !- Zone Air Inlet Port List
-  {d1dae1a8-17c9-4e6a-8bb0-6419ac6da506}, !- Zone Air Exhaust Port List
-  {19f3ebc7-80fb-4a23-8634-e9bb7c25afd6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6349c895-bf74-4b50-a272-00c64a391a7f}, !- Zone Air Inlet Port List
+  {f124a798-5ea9-42fb-ac90-9b9002a7b403}, !- Zone Air Exhaust Port List
+  {c5664847-e8a9-4dad-93be-f8a43cc388d6}, !- Zone Air Node Name
+  {bdce8adc-2b4f-42a5-9985-4d5e607e7f1e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {8ac1fe18-32cd-42ac-b3d9-99667a6f7f9b}, !- Thermostat Name
+  {b1bb50ea-6a52-4645-8153-7ca4fd10b49d}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {b4411eb7-5ae5-46f0-80f6-1b3f000f7aa8}, !- Handle
-  Node 8,                                 !- Name
-  {19f3ebc7-80fb-4a23-8634-e9bb7c25afd6}, !- Inlet Port
+  {3c6bc7d7-6447-4c45-b377-134a43d47cb6}, !- Handle
+  Node 2,                                 !- Name
+  {c5664847-e8a9-4dad-93be-f8a43cc388d6}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {19f3ebc7-80fb-4a23-8634-e9bb7c25afd6}, !- Handle
-  {45ff3fc4-3443-4ee1-930f-254a4d41d29f}, !- Name
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- Source Object
+  {c5664847-e8a9-4dad-93be-f8a43cc388d6}, !- Handle
+  {b3dd2c9c-236d-48ba-a584-5255dfc4d075}, !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- Source Object
   11,                                     !- Outlet Port
-  {b4411eb7-5ae5-46f0-80f6-1b3f000f7aa8}, !- Target Object
+  {3c6bc7d7-6447-4c45-b377-134a43d47cb6}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {1a1eee6b-08ce-4f55-a05a-7e9b4b24c843}, !- Handle
-  {964713b2-035c-40d4-abd6-38f5a8fa6b67}, !- Name
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- HVAC Component
-  {cde1c684-991d-4376-b35e-09003a47a633}; !- Port 1
+  {6349c895-bf74-4b50-a272-00c64a391a7f}, !- Handle
+  {bdc35821-8704-4789-b89e-96747799883a}, !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- HVAC Component
+  {10fdfc95-ab7a-4668-8028-e30a4af6392c}; !- Port 1
 
 OS:PortList,
-  {d1dae1a8-17c9-4e6a-8bb0-6419ac6da506}, !- Handle
-  {d48d37ba-fd54-4864-8cb3-bb22560c08ee}, !- Name
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- HVAC Component
-  {fc7ea79a-2428-458e-9b1e-1fa4c19389e5}; !- Port 1
+  {f124a798-5ea9-42fb-ac90-9b9002a7b403}, !- Handle
+  {b78e36c9-1564-4831-8876-30f1d5d53028}, !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- HVAC Component
+  {ed4bc845-b2c1-429e-a1bf-0e4e2077f565}; !- Port 1
+
+OS:PortList,
+  {bdce8adc-2b4f-42a5-9985-4d5e607e7f1e}, !- Handle
+  {e60f2615-f50b-43b6-959a-52efe1be63c6}, !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {5340c6d7-9dfe-4894-bde0-13fcc5d5d274}, !- Handle
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- Zone or ZoneList Name
+  {c02f9c3d-3bd8-4544-85e0-e5a5507bb4f0}, !- Handle
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1871,16 +776,17 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {7f189887-456d-4372-8f8a-1e2b78f59f4b}, !- Handle
-  Zone HVAC Equipment List 8,             !- Name
-  {a417b865-e0cb-4b03-b0bf-bf6d6586e7b6}, !- Thermal Zone
-  {49f975db-a34b-4b97-bc85-282c4277d8b9}, !- Zone Equipment 1
+  {5da10121-bafd-4181-b186-b190a4b666c0}, !- Handle
+  Zone HVAC Equipment List 2,             !- Name
+  {c6eb9b2c-3467-4be1-bfaa-c9d21085074c}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {c755650f-8903-46d4-8702-5acc5fa393e4}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1;                                      !- Zone Equipment Heating or No-Load Sequence 1
 
 OS:ThermalZone,
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- Handle
-  Story 2 North Perimeter Thermal Zone,   !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- Handle
+  Story 1 North Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
   ,                                       !- Volume {m3}
@@ -1888,48 +794,53 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {cf951ab3-bc83-43c6-bfd9-8d33d7768b28}, !- Zone Air Inlet Port List
-  {a813f9c8-41cd-40b1-bd63-6c75e237d00c}, !- Zone Air Exhaust Port List
-  {b6bc5483-3866-457a-9ef7-652f6f5a9f7e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9f7124d5-ca2a-4144-ba29-d08c53642c05}, !- Zone Air Inlet Port List
+  {c45b91b9-5807-4007-80de-a17ef2d30928}, !- Zone Air Exhaust Port List
+  {9c205e04-8bde-49c0-9c11-541e0b0e6b7c}, !- Zone Air Node Name
+  {54539dca-ce9d-4316-bdfd-f92c7b495824}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {910bab7a-5ad5-43f7-ad1a-c16048b95fac}, !- Thermostat Name
+  {8e5f64d6-04a0-4d79-97b2-b1ce31d44719}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {a67177cc-9fa6-46a9-9b10-0a224c0eee19}, !- Handle
-  Node 9,                                 !- Name
-  {b6bc5483-3866-457a-9ef7-652f6f5a9f7e}, !- Inlet Port
+  {74a33c2c-f22f-46a0-88c5-d0b4eff52210}, !- Handle
+  Node 3,                                 !- Name
+  {9c205e04-8bde-49c0-9c11-541e0b0e6b7c}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {b6bc5483-3866-457a-9ef7-652f6f5a9f7e}, !- Handle
-  {cd75d947-2dd7-4d99-ba40-b7e632ff5d31}, !- Name
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- Source Object
+  {9c205e04-8bde-49c0-9c11-541e0b0e6b7c}, !- Handle
+  {3a0fe858-dd6e-4446-9fd2-968c69ea5e1c}, !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- Source Object
   11,                                     !- Outlet Port
-  {a67177cc-9fa6-46a9-9b10-0a224c0eee19}, !- Target Object
+  {74a33c2c-f22f-46a0-88c5-d0b4eff52210}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {cf951ab3-bc83-43c6-bfd9-8d33d7768b28}, !- Handle
-  {164c232e-5b56-4efa-a0a5-0104370aab2d}, !- Name
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- HVAC Component
-  {47129e19-ebe9-4b23-a360-7d334f0acbb9}; !- Port 1
+  {9f7124d5-ca2a-4144-ba29-d08c53642c05}, !- Handle
+  {ecc3f768-dc9c-461b-97e4-9c605177897d}, !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- HVAC Component
+  {2d1d5804-632e-4507-ab89-81d364544061}; !- Port 1
 
 OS:PortList,
-  {a813f9c8-41cd-40b1-bd63-6c75e237d00c}, !- Handle
-  {89a78e34-1812-411c-a380-79d7781bbd20}, !- Name
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- HVAC Component
-  {cd9fd72f-ebd0-4436-81e7-8d122b086097}; !- Port 1
+  {c45b91b9-5807-4007-80de-a17ef2d30928}, !- Handle
+  {76c742d5-fef7-4160-86fa-481b60630fce}, !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- HVAC Component
+  {3b82a4b6-71f6-40b0-92c3-6586a6c77917}; !- Port 1
+
+OS:PortList,
+  {54539dca-ce9d-4316-bdfd-f92c7b495824}, !- Handle
+  {101d916c-59b9-49d2-838e-6d9b33064ace}, !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {2ba21c39-3eb6-47fd-a78d-017ad7d56846}, !- Handle
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- Zone or ZoneList Name
+  {2835206d-f6b1-439a-8163-fd92480aace6}, !- Handle
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1958,16 +869,17 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {d067c0e7-a744-44f0-a70d-214b7a0e72fe}, !- Handle
-  Zone HVAC Equipment List 9,             !- Name
-  {5e119a23-a619-43bd-90fc-7ca644e00207}, !- Thermal Zone
-  {12c4d100-7b2e-4caa-abb3-e440c9923f3f}, !- Zone Equipment 1
+  {0037f024-112a-4a04-82ed-0a7c411217a9}, !- Handle
+  Zone HVAC Equipment List 3,             !- Name
+  {12ad962a-57a3-4ed2-9594-de3655d6a992}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {ad837a42-762e-4863-9f83-37b3da214962}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1;                                      !- Zone Equipment Heating or No-Load Sequence 1
 
 OS:ThermalZone,
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- Handle
-  Story 2 Core Thermal Zone,              !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- Handle
+  Story 1 South Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
   ,                                       !- Volume {m3}
@@ -1975,48 +887,53 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {f276d0f4-314a-4020-b20f-f685a8637706}, !- Zone Air Inlet Port List
-  {6355ef35-e3d1-4b15-803a-c5be4b4ff43e}, !- Zone Air Exhaust Port List
-  {5845358f-ea0b-4fe6-8bf2-2a49cae0f6f2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0224c5cc-b53c-4d4d-9840-f5e2b11114c7}, !- Zone Air Inlet Port List
+  {e7701c76-6c48-4d72-b386-54e809007fe1}, !- Zone Air Exhaust Port List
+  {516aae75-a18a-4722-a3e3-e941bd51ea28}, !- Zone Air Node Name
+  {cfd3ae17-61d3-485e-a76d-88b520ae3027}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {70981c80-84b2-4d10-9dba-5fcee96d7e1c}, !- Thermostat Name
+  {ab9d5e61-6237-4786-98b1-d136f7087bea}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {4d092f97-cd83-4e1d-a78f-26633291517a}, !- Handle
-  Node 10,                                !- Name
-  {5845358f-ea0b-4fe6-8bf2-2a49cae0f6f2}, !- Inlet Port
+  {fc5febdc-aac4-4315-9f53-54f0ba9054c8}, !- Handle
+  Node 4,                                 !- Name
+  {516aae75-a18a-4722-a3e3-e941bd51ea28}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {5845358f-ea0b-4fe6-8bf2-2a49cae0f6f2}, !- Handle
-  {73165b1c-6c38-4c6b-8f5f-9a0a4d7856fa}, !- Name
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- Source Object
+  {516aae75-a18a-4722-a3e3-e941bd51ea28}, !- Handle
+  {151be69a-9382-4c10-b3a5-52e136f0e925}, !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- Source Object
   11,                                     !- Outlet Port
-  {4d092f97-cd83-4e1d-a78f-26633291517a}, !- Target Object
+  {fc5febdc-aac4-4315-9f53-54f0ba9054c8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {f276d0f4-314a-4020-b20f-f685a8637706}, !- Handle
-  {9f7b6861-cdd9-4270-8788-459633a72573}, !- Name
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- HVAC Component
-  {9f372654-9de9-4a9b-ba54-5acad4246678}; !- Port 1
+  {0224c5cc-b53c-4d4d-9840-f5e2b11114c7}, !- Handle
+  {6160f4c8-cba6-445f-a373-7650298bf507}, !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- HVAC Component
+  {1eb05017-c9ac-4193-a925-71bd763d7a2c}; !- Port 1
 
 OS:PortList,
-  {6355ef35-e3d1-4b15-803a-c5be4b4ff43e}, !- Handle
-  {f924d367-d619-4643-bda3-a91656c92c9b}, !- Name
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- HVAC Component
-  {adc06aea-9e47-4776-8dd1-0f07269f29d0}; !- Port 1
+  {e7701c76-6c48-4d72-b386-54e809007fe1}, !- Handle
+  {4e40ea41-5806-4449-b6fe-ba6af624c46d}, !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- HVAC Component
+  {277530c7-6f43-4152-bcac-162493bc0e18}; !- Port 1
+
+OS:PortList,
+  {cfd3ae17-61d3-485e-a76d-88b520ae3027}, !- Handle
+  {b77b87df-d8c6-4426-8b0b-730e5815bc21}, !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {8a72f499-482f-478b-9e29-827e39a2c152}, !- Handle
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- Zone or ZoneList Name
+  {236b6f52-2d0f-4a72-bf8a-bbf6397f9b43}, !- Handle
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -2045,19 +962,113 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {5e1f15ac-3210-4f04-9423-812819e13975}, !- Handle
-  Zone HVAC Equipment List 10,            !- Name
-  {0e226f46-9cca-4634-b30c-7fc112e9b58e}, !- Thermal Zone
-  {cf66dac8-d5ab-4c26-8d58-49a9922fc410}, !- Zone Equipment 1
+  {e2df3f3e-29f4-4991-8b13-50d0925de687}, !- Handle
+  Zone HVAC Equipment List 4,             !- Name
+  {23e89c86-9d26-47e5-8b13-5dabd44878c8}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {3ea0c3fb-959a-4c43-8dd0-099a30f8ce88}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- Handle
+  Story 1 West Perimeter Thermal Zone,    !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {47219d3c-085a-494d-8e4b-891ff4fd07bf}, !- Zone Air Inlet Port List
+  {b12aca4e-88cd-459f-968b-c179e5aabbf8}, !- Zone Air Exhaust Port List
+  {f80ee6d1-43d4-49ed-8c80-c1f98d179290}, !- Zone Air Node Name
+  {6c2f272d-c34a-4b82-b36d-bda4375908d5}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {84ac8a6b-3730-4cb4-8087-b9412eb746a4}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {edb11610-0aef-42f9-945c-b5ef28360f81}, !- Handle
+  Node 5,                                 !- Name
+  {f80ee6d1-43d4-49ed-8c80-c1f98d179290}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {f80ee6d1-43d4-49ed-8c80-c1f98d179290}, !- Handle
+  {bb750d4e-d1c7-417d-9566-6104adab84c1}, !- Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- Source Object
+  11,                                     !- Outlet Port
+  {edb11610-0aef-42f9-945c-b5ef28360f81}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {47219d3c-085a-494d-8e4b-891ff4fd07bf}, !- Handle
+  {71958252-9d91-468c-bb88-48fa25093181}, !- Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- HVAC Component
+  {c36a321d-b3da-42a8-bff6-b7bb64edb8c3}; !- Port 1
+
+OS:PortList,
+  {b12aca4e-88cd-459f-968b-c179e5aabbf8}, !- Handle
+  {732418df-a8ec-4a21-8a02-2541e50522cf}, !- Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- HVAC Component
+  {c6fceee1-ce94-4825-a425-d4ec7778c180}; !- Port 1
+
+OS:PortList,
+  {6c2f272d-c34a-4b82-b36d-bda4375908d5}, !- Handle
+  {b86468c9-19ad-4c3b-9fa1-a5c1f6608108}, !- Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {4722f287-5ad1-4ded-9773-acf265fb2526}, !- Handle
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {aadb98e7-5001-4f3c-9ef2-881b99fa2ab6}, !- Handle
+  Zone HVAC Equipment List 5,             !- Name
+  {d9d819ba-cc5a-4c84-ac2f-26dde1f5e0c4}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {c09ba9ad-c353-403f-b35e-97c65b6fa720}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1;                                      !- Zone Equipment Heating or No-Load Sequence 1
 
 OS:SubSurface,
-  {eeff6a6a-17bb-44e2-9ee1-6c16ff72f13b}, !- Handle
+  {8ae4e9f9-67a6-4543-93e8-9fae16ebada8}, !- Handle
   Sub Surface 1,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {88d10f29-0ae8-495d-acdc-30ab70274148}, !- Surface Name
+  {8ac96433-7af0-4522-a165-51ffbab5705f}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2070,113 +1081,28 @@ OS:SubSurface,
   0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {90320fa1-994c-4994-a0b6-261da0ffcfba}, !- Handle
+  {93fbeb18-ab2f-43b2-9daf-582a2726a73f}, !- Handle
   Sub Surface 2,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {dfa64537-6ad2-4fb3-aaad-16d0cc939763}, !- Surface Name
+  {88923dce-7eda-44b6-95bf-339d963d97cb}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
-  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
-  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
-  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
+  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
+  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {8cb174b5-62e5-45fd-9daa-6ce290953a26}, !- Handle
+  {a8857025-7354-4097-b7a1-26baebd84b06}, !- Handle
   Sub Surface 3,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {cd6d4ff8-914d-443c-abc9-1fd054e82872}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
-  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
-  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
-  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {840389cd-7778-48c6-bb93-b64a3145f00d}, !- Handle
-  Sub Surface 4,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {e0bc5538-f918-4ec0-8d48-5ba586601d6e}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
-  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
-  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
-  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {c6f71b95-0546-4c69-b63f-ef8cb12dfb6e}, !- Handle
-  Sub Surface 5,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {41b476ed-50ae-42d3-92bf-1ee1d68d2921}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
-  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
-  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
-  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {2408e70e-7482-4fab-9770-8266cf95a01b}, !- Handle
-  Sub Surface 6,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {66f2e8a5-ee6b-411f-8f22-939283ea85a8}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  0, 49.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
-  0, 49.9746, 1,                          !- X,Y,Z Vertex 2 {m}
-  0, 0.0254000000000048, 1,               !- X,Y,Z Vertex 3 {m}
-  0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {7b0056b0-eb3a-40c5-915e-a5359efa79f3}, !- Handle
-  Sub Surface 7,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {ae816bb7-3e55-4ff2-8930-1d054678d525}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
-  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
-  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
-  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {de78e336-b781-4a7d-9013-b256311447b3}, !- Handle
-  Sub Surface 8,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {32a0c5c9-a553-4a3a-9ca7-060efe37816e}, !- Surface Name
+  {c9349cf4-ca4c-4462-87fb-6806b7ecb7aa}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2188,8 +1114,25 @@ OS:SubSurface,
   -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
   -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
 
+OS:SubSurface,
+  {deb92857-dc61-4250-8abe-c697f1882132}, !- Handle
+  Sub Surface 4,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {39d430eb-3fcd-4268-96c7-54e3b49b048c}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
+  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
+  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
+  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
+
 OS:PlantLoop,
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Handle
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Handle
   Hot Water Loop,                         !- Name
   Water,                                  !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -2197,21 +1140,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {2d8342c1-23dd-4e32-a7b9-3a289cc03691}, !- Loop Temperature Setpoint Node Name
+  {682517c4-455e-4386-80f7-d4123403e9d4}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {74540b04-f1fb-4a54-92a2-6deb030d6eb8}, !- Plant Side Inlet Node Name
-  {1d1da0e1-d226-40ea-b0bd-779e9d59c608}, !- Plant Side Outlet Node Name
+  {58ca5d90-5c48-4bce-a98a-dfeaa18649ba}, !- Plant Side Inlet Node Name
+  {d11b15e6-52b1-4d39-b240-27ae217bab92}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {7a99fb3c-9bef-40ec-bce3-d7ef860e519d}, !- Demand Side Inlet Node Name
-  {51522210-c34f-4afd-873f-434799039e54}, !- Demand Side Outlet Node Name
+  {19e14bd6-2a16-4685-91e0-5ad21920489a}, !- Demand Side Inlet Node Name
+  {f24a280c-d619-4391-bd81-ab94c60f5280}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {8bdfb36b-f616-4ed3-954c-d8cd0a65dc6c}, !- Availability Manager List Name
+  {9989e67a-37b0-453b-a5e3-32f898bc6b21}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -2219,14 +1162,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Demand Mixer Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Demand Splitter Name
-  {d4373542-4956-432f-ae08-989c920a947d}, !- Supply Mixer Name
-  {a9b930ed-2516-488e-964f-6b0c6089f68c}; !- Supply Splitter Name
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Demand Mixer Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Demand Splitter Name
+  {be708ded-64fc-4640-9dfd-757a2ae5f557}, !- Supply Mixer Name
+  {25e35328-da32-426d-81f5-af1bfb47b3a9}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {15f87937-57c1-41e4-b720-41406fa9c5d4}, !- Handle
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Plant or Condenser Loop Name
+  {2326ba7e-4bc5-4a67-9589-8a973bb0b971}, !- Handle
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Plant or Condenser Loop Name
   Heating,                                !- Loop Type
   82,                                     !- Design Loop Exit Temperature {C}
   11,                                     !- Loop Design Temperature Difference {deltaC}
@@ -2235,158 +1178,148 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {d2f634ac-6e69-4b4d-9b4f-0bc6e0c3b27e}, !- Handle
-  Node 11,                                !- Name
-  {74540b04-f1fb-4a54-92a2-6deb030d6eb8}, !- Inlet Port
-  {e5d96333-ede1-4d3a-8d1c-e08acd345e91}; !- Outlet Port
+  {9ac08aa9-6755-4f43-bdf8-83aa1d19ba6f}, !- Handle
+  Node 6,                                 !- Name
+  {58ca5d90-5c48-4bce-a98a-dfeaa18649ba}, !- Inlet Port
+  {fbd08576-ea56-41cc-b24f-09dfc29b4593}; !- Outlet Port
 
 OS:Node,
-  {2d8342c1-23dd-4e32-a7b9-3a289cc03691}, !- Handle
-  Node 12,                                !- Name
-  {2985d0de-4265-49c3-82d3-5e13b9287a9d}, !- Inlet Port
-  {1d1da0e1-d226-40ea-b0bd-779e9d59c608}; !- Outlet Port
+  {682517c4-455e-4386-80f7-d4123403e9d4}, !- Handle
+  Node 7,                                 !- Name
+  {b8760a60-f8bb-495d-a7aa-045566172c88}, !- Inlet Port
+  {d11b15e6-52b1-4d39-b240-27ae217bab92}; !- Outlet Port
 
 OS:Node,
-  {35421743-142d-4d6c-a857-5d5edd49726a}, !- Handle
-  Node 13,                                !- Name
-  {bef65a52-5a79-4d74-82ea-f5918057fe3e}, !- Inlet Port
-  {7ac8b547-32e9-46a9-8d1a-e468bc2c218d}; !- Outlet Port
+  {858ffc20-a007-4db1-995a-99adb7dd430f}, !- Handle
+  Node 8,                                 !- Name
+  {df3ed56d-416c-43fa-ad1f-cf851c373237}, !- Inlet Port
+  {0444c2ce-6a47-4d8e-b65d-b1acfded497f}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {d4373542-4956-432f-ae08-989c920a947d}, !- Handle
+  {be708ded-64fc-4640-9dfd-757a2ae5f557}, !- Handle
   Connector Mixer 1,                      !- Name
-  {a20a4a75-814f-4961-a8a0-372dc009b2e7}, !- Outlet Branch Name
-  {f34da75b-aeb7-4fd3-9b49-219f7256bc5b}, !- Inlet Branch Name 1
-  {5e520074-1dc7-498a-b7bb-9a26315157ec}; !- Inlet Branch Name 2
+  {268acdd9-d1dc-468b-8f44-11e2827c7359}, !- Outlet Branch Name
+  {41778f49-cf6c-48fb-9137-17fa0db3d749}, !- Inlet Branch Name 1
+  {70348d1f-7e06-40ae-ac06-63abad9d3a78}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {a9b930ed-2516-488e-964f-6b0c6089f68c}, !- Handle
+  {25e35328-da32-426d-81f5-af1bfb47b3a9}, !- Handle
   Connector Splitter 1,                   !- Name
-  {4795d7c7-df60-4142-98b0-6a828f99ded8}, !- Inlet Branch Name
-  {bef65a52-5a79-4d74-82ea-f5918057fe3e}, !- Outlet Branch Name 1
-  {3427ca0c-7ab0-44fd-8416-4c02559175be}; !- Outlet Branch Name 2
+  {26149770-4c53-4c04-8bd5-f4d6f340901e}, !- Inlet Branch Name
+  {df3ed56d-416c-43fa-ad1f-cf851c373237}, !- Outlet Branch Name 1
+  {d8f0018e-b8dc-4e36-b6d2-e94a20a9d395}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {74540b04-f1fb-4a54-92a2-6deb030d6eb8}, !- Handle
-  {3d6c5527-b46e-4dc6-bd35-9fff839c8886}, !- Name
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Source Object
+  {58ca5d90-5c48-4bce-a98a-dfeaa18649ba}, !- Handle
+  {6b9dc2df-86d7-44c6-a8ba-870f11d3b9c6}, !- Name
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Source Object
   14,                                     !- Outlet Port
-  {d2f634ac-6e69-4b4d-9b4f-0bc6e0c3b27e}, !- Target Object
+  {9ac08aa9-6755-4f43-bdf8-83aa1d19ba6f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bef65a52-5a79-4d74-82ea-f5918057fe3e}, !- Handle
-  {c16b2a31-fe44-4143-9ff4-f30be0fe7cb5}, !- Name
-  {a9b930ed-2516-488e-964f-6b0c6089f68c}, !- Source Object
+  {df3ed56d-416c-43fa-ad1f-cf851c373237}, !- Handle
+  {ecbcc2fc-1ab6-4985-aa44-d8e2da8c6926}, !- Name
+  {25e35328-da32-426d-81f5-af1bfb47b3a9}, !- Source Object
   3,                                      !- Outlet Port
-  {35421743-142d-4d6c-a857-5d5edd49726a}, !- Target Object
+  {858ffc20-a007-4db1-995a-99adb7dd430f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {1d1da0e1-d226-40ea-b0bd-779e9d59c608}, !- Handle
-  {3553e02e-6962-409e-a9ae-96c73b5b3a5c}, !- Name
-  {2d8342c1-23dd-4e32-a7b9-3a289cc03691}, !- Source Object
+  {d11b15e6-52b1-4d39-b240-27ae217bab92}, !- Handle
+  {fe1c5fab-9776-4b6d-b37a-36ce23583d06}, !- Name
+  {682517c4-455e-4386-80f7-d4123403e9d4}, !- Source Object
   3,                                      !- Outlet Port
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Target Object
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {be5a1ab7-e074-4c19-980e-1673fd6ceee4}, !- Handle
-  Node 14,                                !- Name
-  {7a99fb3c-9bef-40ec-bce3-d7ef860e519d}, !- Inlet Port
-  {56426463-faa7-401b-b9f5-148fa2bb1d49}; !- Outlet Port
+  {25b5dc4e-3792-4857-af4a-f1f091bc7f21}, !- Handle
+  Node 9,                                 !- Name
+  {19e14bd6-2a16-4685-91e0-5ad21920489a}, !- Inlet Port
+  {858902ff-ffcf-4e45-91ee-019967c987b3}; !- Outlet Port
 
 OS:Node,
-  {b0c283fe-37a6-48d1-9216-b32b9c447611}, !- Handle
-  Node 15,                                !- Name
-  {b0055ff6-0991-468f-9f84-ccafffb5f917}, !- Inlet Port
-  {51522210-c34f-4afd-873f-434799039e54}; !- Outlet Port
+  {b2267d0e-8c96-4fb8-ba3d-ee4e0959747f}, !- Handle
+  Node 10,                                !- Name
+  {445f5a39-6eb2-4eaa-b37f-c4bd8dc4947e}, !- Inlet Port
+  {f24a280c-d619-4391-bd81-ab94c60f5280}; !- Outlet Port
 
 OS:Node,
-  {1edf1710-0b50-494d-980f-10f567a2ff54}, !- Handle
-  Node 16,                                !- Name
-  {e5671ca2-0bc6-4c33-9e77-ba2201188a83}, !- Inlet Port
-  {b9f43f23-edaa-4d48-a7bb-b67d8881ba67}; !- Outlet Port
+  {6915aa9a-0ca1-4b4a-ab37-0893b3b61f27}, !- Handle
+  Node 11,                                !- Name
+  {1424d0f5-9fcc-481b-a9b2-2f5ef7272f2f}, !- Inlet Port
+  {456aa0d7-bb40-4a56-81cb-f23b17ec062c}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Handle
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Handle
   Connector Mixer 2,                      !- Name
-  {b0055ff6-0991-468f-9f84-ccafffb5f917}, !- Outlet Branch Name
-  {c251aa21-0cd8-4c85-a251-cdd8088d0e78}, !- Inlet Branch Name 1
-  {7d2b33c1-79a4-432f-a710-6f246eae613b}, !- Inlet Branch Name 2
-  {be5de37a-0e6a-4010-8d63-5eea0d29a771}, !- Inlet Branch Name 3
-  {f43299b3-8eb5-402e-b67f-ff8c09f74726}, !- Inlet Branch Name 4
-  {e6941a15-984f-499f-bdd8-be0fb0b25d9c}, !- Inlet Branch Name 5
-  {665f4345-03e7-4d0a-a2b4-0e2400602f38}, !- Inlet Branch Name 6
-  {97e57f8d-98f8-49fb-9146-ecfbbb8f19ca}, !- Inlet Branch Name 7
-  {69c43d0f-0937-478e-bfbc-3ec44a22794b}, !- Inlet Branch Name 8
-  {76033de2-150f-49db-851c-26c9625cdac6}, !- Inlet Branch Name 9
-  {0600a2fc-8bd1-487d-bccc-963c7503569b}; !- Inlet Branch Name 10
+  {445f5a39-6eb2-4eaa-b37f-c4bd8dc4947e}, !- Outlet Branch Name
+  {1f387dcb-eec5-4f6a-9c53-62006ae990ae}, !- Inlet Branch Name 1
+  {d3915107-2de3-436d-a61a-977fed39db12}, !- Inlet Branch Name 2
+  {c529cdb9-fa59-45f5-bfc4-e924583e8fc2}, !- Inlet Branch Name 3
+  {a6943830-47ec-498b-b1f6-0da563bf53d4}, !- Inlet Branch Name 4
+  {42880f17-061a-4a54-9902-9b9268e918d7}; !- Inlet Branch Name 5
 
 OS:Connector:Splitter,
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Handle
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Handle
   Connector Splitter 2,                   !- Name
-  {56426463-faa7-401b-b9f5-148fa2bb1d49}, !- Inlet Branch Name
-  {e5671ca2-0bc6-4c33-9e77-ba2201188a83}, !- Outlet Branch Name 1
-  {a8f71d21-3f1b-4be5-a770-7582c1223ccc}, !- Outlet Branch Name 2
-  {40da4e11-4852-4bf3-8409-265f710a581c}, !- Outlet Branch Name 3
-  {f3f96d81-cacb-441a-b2fd-d382ba7a9f97}, !- Outlet Branch Name 4
-  {dd07ea94-5d9d-47c9-8523-fa76269f2047}, !- Outlet Branch Name 5
-  {e5d49dbd-bd69-4067-a737-6bae9e40761e}, !- Outlet Branch Name 6
-  {9cfa4064-fd37-452a-a939-53be7c1d78fc}, !- Outlet Branch Name 7
-  {9012ae2e-25e3-489e-898f-89bccb6f7071}, !- Outlet Branch Name 8
-  {146f2fc4-b443-4988-bd9b-7f0aec4150f0}, !- Outlet Branch Name 9
-  {252efde4-750a-4453-bc58-4c7f69efd8ff}; !- Outlet Branch Name 10
+  {858902ff-ffcf-4e45-91ee-019967c987b3}, !- Inlet Branch Name
+  {1424d0f5-9fcc-481b-a9b2-2f5ef7272f2f}, !- Outlet Branch Name 1
+  {3d68eb99-2093-4f17-9ef0-a054ef85d369}, !- Outlet Branch Name 2
+  {af0f81ff-fcdb-498c-a7b5-af82d5a341aa}, !- Outlet Branch Name 3
+  {0b78b354-3d71-4ebe-9ed1-741ffab3fdf0}, !- Outlet Branch Name 4
+  {abacaff4-a970-41d5-8c4c-1dd09e446423}; !- Outlet Branch Name 5
 
 OS:Connection,
-  {7a99fb3c-9bef-40ec-bce3-d7ef860e519d}, !- Handle
-  {5ad6a04b-c5a5-460a-b92e-92c5bd8e6a73}, !- Name
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Source Object
+  {19e14bd6-2a16-4685-91e0-5ad21920489a}, !- Handle
+  {30d84dc3-08e1-4641-8ba3-824407afd6d1}, !- Name
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Source Object
   17,                                     !- Outlet Port
-  {be5a1ab7-e074-4c19-980e-1673fd6ceee4}, !- Target Object
+  {25b5dc4e-3792-4857-af4a-f1f091bc7f21}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {56426463-faa7-401b-b9f5-148fa2bb1d49}, !- Handle
-  {e0b59f82-e031-42aa-b493-b2f4f24917cf}, !- Name
-  {be5a1ab7-e074-4c19-980e-1673fd6ceee4}, !- Source Object
+  {858902ff-ffcf-4e45-91ee-019967c987b3}, !- Handle
+  {66c5ebcc-6321-4e5e-933c-8ebcba3a2bd7}, !- Name
+  {25b5dc4e-3792-4857-af4a-f1f091bc7f21}, !- Source Object
   3,                                      !- Outlet Port
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Target Object
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {e5671ca2-0bc6-4c33-9e77-ba2201188a83}, !- Handle
-  {df4b9f0c-d614-48d8-b808-5c2812052d8f}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
+  {1424d0f5-9fcc-481b-a9b2-2f5ef7272f2f}, !- Handle
+  {27cc3d04-b7dd-4ed5-940d-c2d4bd87a51a}, !- Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Source Object
   3,                                      !- Outlet Port
-  {1edf1710-0b50-494d-980f-10f567a2ff54}, !- Target Object
+  {6915aa9a-0ca1-4b4a-ab37-0893b3b61f27}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b0055ff6-0991-468f-9f84-ccafffb5f917}, !- Handle
-  {20ba2abc-aa9e-4e42-8e12-ac104858fd85}, !- Name
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Source Object
+  {445f5a39-6eb2-4eaa-b37f-c4bd8dc4947e}, !- Handle
+  {6e1a07c4-1113-4528-b4ac-780fa3f93f55}, !- Name
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Source Object
   2,                                      !- Outlet Port
-  {b0c283fe-37a6-48d1-9216-b32b9c447611}, !- Target Object
+  {b2267d0e-8c96-4fb8-ba3d-ee4e0959747f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {51522210-c34f-4afd-873f-434799039e54}, !- Handle
-  {a7f6587d-0839-4d2e-b033-437354efadff}, !- Name
-  {b0c283fe-37a6-48d1-9216-b32b9c447611}, !- Source Object
+  {f24a280c-d619-4391-bd81-ab94c60f5280}, !- Handle
+  {0ebd847f-3a4c-434f-bc5d-b61c53244a36}, !- Name
+  {b2267d0e-8c96-4fb8-ba3d-ee4e0959747f}, !- Source Object
   3,                                      !- Outlet Port
-  {34e1728e-a677-4e32-847a-8ba8e2e4d043}, !- Target Object
+  {710c76f8-971c-4fa6-b518-5566aa320d7f}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {8bdfb36b-f616-4ed3-954c-d8cd0a65dc6c}, !- Handle
+  {9989e67a-37b0-453b-a5e3-32f898bc6b21}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList; !- Name
 
 OS:Pump:VariableSpeed,
-  {0e0d898f-3745-4cc8-b117-2c79fd2b2baa}, !- Handle
+  {3e782b48-8ccd-4bba-8036-59369243f522}, !- Handle
   Pump Variable Speed 1,                  !- Name
-  {e5d96333-ede1-4d3a-8d1c-e08acd345e91}, !- Inlet Node Name
-  {a796031a-8cd1-4715-a058-25b08e7db4fb}, !- Outlet Node Name
+  {fbd08576-ea56-41cc-b24f-09dfc29b4593}, !- Inlet Node Name
+  {70b40c57-2845-4552-9c94-46cef8bf4cc6}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -2411,31 +1344,32 @@ OS:Pump:VariableSpeed,
   0.5,                                    !- Skin Loss Radiative Fraction
   PowerPerFlowPerPressure,                !- Design Power Sizing Method
   348701.1,                               !- Design Electric Power per Unit Flow Rate {W/(m3/s)}
-  1.282051282,                            !- Design Shaft Power per Unit Flow Rate per Unit Head {W/((m3/s)-Pa)}
+  1.282051282,                            !- Design Shaft Power per Unit Flow Rate per Unit Head {W-s/m3-Pa}
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Boiler:HotWater,
-  {1f83e033-0cf8-4084-a191-d7497bc4655e}, !- Handle
+  {ccae4818-417a-4181-bc2e-8660e665e4f9}, !- Handle
   Boiler Hot Water 1,                     !- Name
   ,                                       !- Fuel Type
   ,                                       !- Nominal Capacity {W}
   ,                                       !- Nominal Thermal Efficiency
   LeavingBoiler,                          !- Efficiency Curve Temperature Evaluation Variable
-  {f92c77ab-7ec4-4fc7-aa5f-bfbea57d5597}, !- Normalized Boiler Efficiency Curve Name
+  {3f7362e0-4d70-4875-8e86-e14883cdacdf}, !- Normalized Boiler Efficiency Curve Name
   ,                                       !- Design Water Outlet Temperature {C}
   ,                                       !- Design Water Flow Rate {m3/s}
   ,                                       !- Minimum Part Load Ratio
   ,                                       !- Maximum Part Load Ratio
   ,                                       !- Optimum Part Load Ratio
-  {7ac8b547-32e9-46a9-8d1a-e468bc2c218d}, !- Boiler Water Inlet Node Name
-  {947bfd36-c406-4360-82b7-25803ef7c97b}, !- Boiler Water Outlet Node Name
+  {0444c2ce-6a47-4d8e-b65d-b1acfded497f}, !- Boiler Water Inlet Node Name
+  {66c2d27c-e5a1-4e73-b293-807d9d92e855}, !- Boiler Water Outlet Node Name
   99,                                     !- Water Outlet Upper Temperature Limit {C}
   ConstantFlow,                           !- Boiler Flow Mode
   0,                                      !- Parasitic Electric Load {W}
-  1;                                      !- Sizing Factor
+  1,                                      !- Sizing Factor
+  General;                                !- End-Use Subcategory
 
 OS:Curve:Biquadratic,
-  {f92c77ab-7ec4-4fc7-aa5f-bfbea57d5597}, !- Handle
+  {3f7362e0-4d70-4875-8e86-e14883cdacdf}, !- Handle
   Boiler Efficiency,                      !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 x
@@ -2454,170 +1388,170 @@ OS:Curve:Biquadratic,
   Dimensionless;                          !- Output Unit Type
 
 OS:Node,
-  {84ba55bf-e7b7-4210-ba4b-56dd1f1d48f3}, !- Handle
-  Node 17,                                !- Name
-  {a796031a-8cd1-4715-a058-25b08e7db4fb}, !- Inlet Port
-  {4795d7c7-df60-4142-98b0-6a828f99ded8}; !- Outlet Port
+  {0b2b4b69-2df4-4b7d-be13-c2b345ab27f8}, !- Handle
+  Node 12,                                !- Name
+  {70b40c57-2845-4552-9c94-46cef8bf4cc6}, !- Inlet Port
+  {26149770-4c53-4c04-8bd5-f4d6f340901e}; !- Outlet Port
 
 OS:Connection,
-  {e5d96333-ede1-4d3a-8d1c-e08acd345e91}, !- Handle
-  {ac09d056-1546-41ed-8645-ac04bf8495fe}, !- Name
-  {d2f634ac-6e69-4b4d-9b4f-0bc6e0c3b27e}, !- Source Object
+  {fbd08576-ea56-41cc-b24f-09dfc29b4593}, !- Handle
+  {e59551fc-1897-4537-bc2b-f265a6a5adf0}, !- Name
+  {9ac08aa9-6755-4f43-bdf8-83aa1d19ba6f}, !- Source Object
   3,                                      !- Outlet Port
-  {0e0d898f-3745-4cc8-b117-2c79fd2b2baa}, !- Target Object
+  {3e782b48-8ccd-4bba-8036-59369243f522}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a796031a-8cd1-4715-a058-25b08e7db4fb}, !- Handle
-  {377e826b-c3a9-4d79-837e-4294c80bd914}, !- Name
-  {0e0d898f-3745-4cc8-b117-2c79fd2b2baa}, !- Source Object
+  {70b40c57-2845-4552-9c94-46cef8bf4cc6}, !- Handle
+  {848fce70-1c2f-4a56-8c41-d7a244b8c223}, !- Name
+  {3e782b48-8ccd-4bba-8036-59369243f522}, !- Source Object
   3,                                      !- Outlet Port
-  {84ba55bf-e7b7-4210-ba4b-56dd1f1d48f3}, !- Target Object
+  {0b2b4b69-2df4-4b7d-be13-c2b345ab27f8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4795d7c7-df60-4142-98b0-6a828f99ded8}, !- Handle
-  {3f65c209-27db-41e9-b0a0-cb7b79ed1e71}, !- Name
-  {84ba55bf-e7b7-4210-ba4b-56dd1f1d48f3}, !- Source Object
+  {26149770-4c53-4c04-8bd5-f4d6f340901e}, !- Handle
+  {eeb18aa3-6689-4ab0-8d4c-55a162a5c1d9}, !- Name
+  {0b2b4b69-2df4-4b7d-be13-c2b345ab27f8}, !- Source Object
   3,                                      !- Outlet Port
-  {a9b930ed-2516-488e-964f-6b0c6089f68c}, !- Target Object
+  {25e35328-da32-426d-81f5-af1bfb47b3a9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {b8dba066-da79-445c-adf9-0f1b36c6cbf3}, !- Handle
-  Node 18,                                !- Name
-  {947bfd36-c406-4360-82b7-25803ef7c97b}, !- Inlet Port
-  {f34da75b-aeb7-4fd3-9b49-219f7256bc5b}; !- Outlet Port
+  {06c9540a-503f-443e-8d0c-5c8b47727088}, !- Handle
+  Node 13,                                !- Name
+  {66c2d27c-e5a1-4e73-b293-807d9d92e855}, !- Inlet Port
+  {41778f49-cf6c-48fb-9137-17fa0db3d749}; !- Outlet Port
 
 OS:Connection,
-  {7ac8b547-32e9-46a9-8d1a-e468bc2c218d}, !- Handle
-  {284d686a-2cfb-4f50-8f3f-133778cdfa96}, !- Name
-  {35421743-142d-4d6c-a857-5d5edd49726a}, !- Source Object
+  {0444c2ce-6a47-4d8e-b65d-b1acfded497f}, !- Handle
+  {d79ab2d1-3ea4-46a0-860b-f7ac5ac980fe}, !- Name
+  {858ffc20-a007-4db1-995a-99adb7dd430f}, !- Source Object
   3,                                      !- Outlet Port
-  {1f83e033-0cf8-4084-a191-d7497bc4655e}, !- Target Object
+  {ccae4818-417a-4181-bc2e-8660e665e4f9}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Connection,
-  {947bfd36-c406-4360-82b7-25803ef7c97b}, !- Handle
-  {c4716972-7d06-41af-b894-ac272324729e}, !- Name
-  {1f83e033-0cf8-4084-a191-d7497bc4655e}, !- Source Object
+  {66c2d27c-e5a1-4e73-b293-807d9d92e855}, !- Handle
+  {6f9e554c-6003-44fb-90fe-d4d5bc233251}, !- Name
+  {ccae4818-417a-4181-bc2e-8660e665e4f9}, !- Source Object
   13,                                     !- Outlet Port
-  {b8dba066-da79-445c-adf9-0f1b36c6cbf3}, !- Target Object
+  {06c9540a-503f-443e-8d0c-5c8b47727088}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f34da75b-aeb7-4fd3-9b49-219f7256bc5b}, !- Handle
-  {dd8c70f3-7f95-4095-8a95-040f713cb021}, !- Name
-  {b8dba066-da79-445c-adf9-0f1b36c6cbf3}, !- Source Object
+  {41778f49-cf6c-48fb-9137-17fa0db3d749}, !- Handle
+  {5622c7e0-d119-496a-a2e2-b71731ce39ca}, !- Name
+  {06c9540a-503f-443e-8d0c-5c8b47727088}, !- Source Object
   3,                                      !- Outlet Port
-  {d4373542-4956-432f-ae08-989c920a947d}, !- Target Object
+  {be708ded-64fc-4640-9dfd-757a2ae5f557}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {7fea9164-2842-4720-9cbe-b5cf1beaca77}, !- Handle
+  {0164cc54-478f-407e-b042-3ef362462a32}, !- Handle
   Pipe Adiabatic 1,                       !- Name
-  {e968020c-e803-44f8-b29e-a462ef96e271}, !- Inlet Node Name
-  {889c4283-ec53-4ddd-afc8-1dd24ba183ef}; !- Outlet Node Name
+  {772d2088-4182-464a-9c6d-5a552736739c}, !- Inlet Node Name
+  {a09ef3b6-26f0-42f0-9b46-b08babcb25d7}; !- Outlet Node Name
 
 OS:Node,
-  {5dfabdc7-fcb1-4d3a-94c4-f47f2ecd65d3}, !- Handle
-  Node 19,                                !- Name
-  {3427ca0c-7ab0-44fd-8416-4c02559175be}, !- Inlet Port
-  {e968020c-e803-44f8-b29e-a462ef96e271}; !- Outlet Port
+  {e4cfa248-ea5f-4b48-a3f5-8436b384f2c8}, !- Handle
+  Node 14,                                !- Name
+  {d8f0018e-b8dc-4e36-b6d2-e94a20a9d395}, !- Inlet Port
+  {772d2088-4182-464a-9c6d-5a552736739c}; !- Outlet Port
 
 OS:Connection,
-  {3427ca0c-7ab0-44fd-8416-4c02559175be}, !- Handle
-  {76fb6dc4-72c6-4d5b-b9bf-1f2d6c1b53af}, !- Name
-  {a9b930ed-2516-488e-964f-6b0c6089f68c}, !- Source Object
+  {d8f0018e-b8dc-4e36-b6d2-e94a20a9d395}, !- Handle
+  {282e9f4a-46bc-4724-ae02-3abcc05e73d6}, !- Name
+  {25e35328-da32-426d-81f5-af1bfb47b3a9}, !- Source Object
   4,                                      !- Outlet Port
-  {5dfabdc7-fcb1-4d3a-94c4-f47f2ecd65d3}, !- Target Object
+  {e4cfa248-ea5f-4b48-a3f5-8436b384f2c8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {1d0dac04-ee73-4e84-92af-08460d68163c}, !- Handle
-  Node 20,                                !- Name
-  {889c4283-ec53-4ddd-afc8-1dd24ba183ef}, !- Inlet Port
-  {5e520074-1dc7-498a-b7bb-9a26315157ec}; !- Outlet Port
+  {8d0392b0-41f7-4587-bb15-fbcbc1281a98}, !- Handle
+  Node 15,                                !- Name
+  {a09ef3b6-26f0-42f0-9b46-b08babcb25d7}, !- Inlet Port
+  {70348d1f-7e06-40ae-ac06-63abad9d3a78}; !- Outlet Port
 
 OS:Connection,
-  {e968020c-e803-44f8-b29e-a462ef96e271}, !- Handle
-  {380304d5-8302-4dbc-b719-e06c20e6f87c}, !- Name
-  {5dfabdc7-fcb1-4d3a-94c4-f47f2ecd65d3}, !- Source Object
+  {772d2088-4182-464a-9c6d-5a552736739c}, !- Handle
+  {7fcd7088-75d3-422e-8505-0e4c47760846}, !- Name
+  {e4cfa248-ea5f-4b48-a3f5-8436b384f2c8}, !- Source Object
   3,                                      !- Outlet Port
-  {7fea9164-2842-4720-9cbe-b5cf1beaca77}, !- Target Object
+  {0164cc54-478f-407e-b042-3ef362462a32}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {889c4283-ec53-4ddd-afc8-1dd24ba183ef}, !- Handle
-  {6aea4101-7a3c-46b1-9392-71bb670e6787}, !- Name
-  {7fea9164-2842-4720-9cbe-b5cf1beaca77}, !- Source Object
+  {a09ef3b6-26f0-42f0-9b46-b08babcb25d7}, !- Handle
+  {6deb6075-e5ae-4976-a49e-cdcf1524afbd}, !- Name
+  {0164cc54-478f-407e-b042-3ef362462a32}, !- Source Object
   3,                                      !- Outlet Port
-  {1d0dac04-ee73-4e84-92af-08460d68163c}, !- Target Object
+  {8d0392b0-41f7-4587-bb15-fbcbc1281a98}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5e520074-1dc7-498a-b7bb-9a26315157ec}, !- Handle
-  {55b266b4-b6b5-4cba-ad57-9d76836e8194}, !- Name
-  {1d0dac04-ee73-4e84-92af-08460d68163c}, !- Source Object
+  {70348d1f-7e06-40ae-ac06-63abad9d3a78}, !- Handle
+  {ef0a1aad-56a1-4b2a-999c-fe3699d79215}, !- Name
+  {8d0392b0-41f7-4587-bb15-fbcbc1281a98}, !- Source Object
   3,                                      !- Outlet Port
-  {d4373542-4956-432f-ae08-989c920a947d}, !- Target Object
+  {be708ded-64fc-4640-9dfd-757a2ae5f557}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {fa13cea7-7712-427b-b944-8dea4c6b6fc7}, !- Handle
+  {5ddb499f-325e-4345-87c4-27024cda05a7}, !- Handle
   Pipe Adiabatic 2,                       !- Name
-  {782a62f1-d096-453c-9e42-3e427bb49ef8}, !- Inlet Node Name
-  {2985d0de-4265-49c3-82d3-5e13b9287a9d}; !- Outlet Node Name
+  {0ba04fa7-2379-4816-a7d3-8d446b8a2b19}, !- Inlet Node Name
+  {b8760a60-f8bb-495d-a7aa-045566172c88}; !- Outlet Node Name
 
 OS:Node,
-  {74d07b1c-580e-4772-a7ca-c91e2cc76748}, !- Handle
-  Node 21,                                !- Name
-  {a20a4a75-814f-4961-a8a0-372dc009b2e7}, !- Inlet Port
-  {782a62f1-d096-453c-9e42-3e427bb49ef8}; !- Outlet Port
+  {d0c38d9a-3abf-4be4-987f-35c55f665b5b}, !- Handle
+  Node 16,                                !- Name
+  {268acdd9-d1dc-468b-8f44-11e2827c7359}, !- Inlet Port
+  {0ba04fa7-2379-4816-a7d3-8d446b8a2b19}; !- Outlet Port
 
 OS:Connection,
-  {a20a4a75-814f-4961-a8a0-372dc009b2e7}, !- Handle
-  {37c62fe1-31b5-4d65-a3dc-8aa10e606d41}, !- Name
-  {d4373542-4956-432f-ae08-989c920a947d}, !- Source Object
+  {268acdd9-d1dc-468b-8f44-11e2827c7359}, !- Handle
+  {eb1028d1-f5e9-450c-b916-20734d3cbbba}, !- Name
+  {be708ded-64fc-4640-9dfd-757a2ae5f557}, !- Source Object
   2,                                      !- Outlet Port
-  {74d07b1c-580e-4772-a7ca-c91e2cc76748}, !- Target Object
+  {d0c38d9a-3abf-4be4-987f-35c55f665b5b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {782a62f1-d096-453c-9e42-3e427bb49ef8}, !- Handle
-  {e9d1ad5c-1288-4956-89db-fa66bdaebb68}, !- Name
-  {74d07b1c-580e-4772-a7ca-c91e2cc76748}, !- Source Object
+  {0ba04fa7-2379-4816-a7d3-8d446b8a2b19}, !- Handle
+  {88b33d79-e8ce-43e8-b590-ba51a5eea0fd}, !- Name
+  {d0c38d9a-3abf-4be4-987f-35c55f665b5b}, !- Source Object
   3,                                      !- Outlet Port
-  {fa13cea7-7712-427b-b944-8dea4c6b6fc7}, !- Target Object
+  {5ddb499f-325e-4345-87c4-27024cda05a7}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2985d0de-4265-49c3-82d3-5e13b9287a9d}, !- Handle
-  {a81bf31c-4456-4ccc-ba82-adc1f6de2b5a}, !- Name
-  {fa13cea7-7712-427b-b944-8dea4c6b6fc7}, !- Source Object
+  {b8760a60-f8bb-495d-a7aa-045566172c88}, !- Handle
+  {e47345e8-4052-4f02-9d1a-65897a9216d3}, !- Name
+  {5ddb499f-325e-4345-87c4-27024cda05a7}, !- Source Object
   3,                                      !- Outlet Port
-  {2d8342c1-23dd-4e32-a7b9-3a289cc03691}, !- Target Object
+  {682517c4-455e-4386-80f7-d4123403e9d4}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Schedule:Ruleset,
-  {6d23dc82-0d92-4f89-a346-e18d1e1831ea}, !- Handle
+  {700ff270-14ef-47fd-82b9-e98c44c4e756}, !- Handle
   Hot_Water_Temperature,                  !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
-  {6ab417ab-943b-4c7d-ab28-f63e73e56422}, !- Default Day Schedule Name
-  {d7b3487a-112f-448d-86fe-3c2b719ffba5}, !- Summer Design Day Schedule Name
-  {d4c4e745-836e-4573-bbc3-0a716813d9db}; !- Winter Design Day Schedule Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
+  {696a9445-a1e6-499f-952e-55a77388b29c}, !- Default Day Schedule Name
+  {83fc77f5-426f-4cee-ba7f-c9faeb4be6bc}, !- Summer Design Day Schedule Name
+  {2ddc5dd7-be58-42dc-9ee0-66962c57eb10}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {6ab417ab-943b-4c7d-ab28-f63e73e56422}, !- Handle
+  {696a9445-a1e6-499f-952e-55a77388b29c}, !- Handle
   Hot_Water_Temperature_Default,          !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {10a61df5-ae55-4d2c-bf81-5d5c598f2480}, !- Handle
+  {d1134078-e2ad-4657-9928-bed09a06c71b}, !- Handle
   Schedule Day 2,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -2626,16 +1560,16 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {d4c4e745-836e-4573-bbc3-0a716813d9db}, !- Handle
+  {2ddc5dd7-be58-42dc-9ee0-66962c57eb10}, !- Handle
   Hot_Water_Temperature_Winter_Design_Day, !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {bb9bed6e-bd8e-450e-bb0d-086f110abe1a}, !- Handle
+  {a0c70791-0249-4529-8ec9-202c5767ad9a}, !- Handle
   Schedule Day 3,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -2644,23 +1578,23 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {d7b3487a-112f-448d-86fe-3c2b719ffba5}, !- Handle
+  {83fc77f5-426f-4cee-ba7f-c9faeb4be6bc}, !- Handle
   Hot_Water_Temperature_Summer_Design_Day, !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:SetpointManager:Scheduled,
-  {93063921-08ed-449a-ad1d-01fb0b814bad}, !- Handle
+  {59eb5fa6-b99f-4ddb-a20b-1f6a06c5ea6e}, !- Handle
   Setpoint Manager Scheduled 1,           !- Name
   Temperature,                            !- Control Variable
-  {6d23dc82-0d92-4f89-a346-e18d1e1831ea}, !- Schedule Name
-  {2d8342c1-23dd-4e32-a7b9-3a289cc03691}; !- Setpoint Node or NodeList Name
+  {700ff270-14ef-47fd-82b9-e98c44c4e756}, !- Schedule Name
+  {682517c4-455e-4386-80f7-d4123403e9d4}; !- Setpoint Node or NodeList Name
 
 OS:ScheduleTypeLimits,
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Handle
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Handle
   Temperature,                            !- Name
   ,                                       !- Lower Limit Value
   ,                                       !- Upper Limit Value
@@ -2668,13 +1602,13 @@ OS:ScheduleTypeLimits,
   Temperature;                            !- Unit Type
 
 OS:Schedule:Constant,
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Handle
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Handle
   Always On Discrete,                     !- Name
-  {0676a5e8-e0f0-4cc2-9ba3-06cd0b613cd8}, !- Schedule Type Limits Name
+  {f5ae0cb4-57ab-4b59-ae4a-41ce43634238}, !- Schedule Type Limits Name
   1;                                      !- Value
 
 OS:ScheduleTypeLimits,
-  {0676a5e8-e0f0-4cc2-9ba3-06cd0b613cd8}, !- Handle
+  {f5ae0cb4-57ab-4b59-ae4a-41ce43634238}, !- Handle
   OnOff,                                  !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
@@ -2682,10 +1616,10 @@ OS:ScheduleTypeLimits,
   Availability;                           !- Unit Type
 
 OS:Fan:ConstantVolume,
-  {78ac48aa-d27f-4d89-a426-7dfcfe83ed60}, !- Handle
+  {b4c0cc43-0af6-4bde-aa5c-d20e91b5f3bc}, !- Handle
   Fan Constant Volume 1,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   AutoSize,                               !- Maximum Flow Rate {m3/s}
   ,                                       !- Motor Efficiency
@@ -2695,13 +1629,13 @@ OS:Fan:ConstantVolume,
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {0603403b-7af5-4450-b4ca-8c3f422065c8}, !- Handle
+  {cec18be3-218f-456f-ae1d-40240a98daa6}, !- Handle
   Coil Heating Water 1,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {b9f43f23-edaa-4d48-a7bb-b67d8881ba67}, !- Water Inlet Node Name
-  {00bc389a-9e2b-4336-ac6b-47549f3b57a6}, !- Water Outlet Node Name
+  {456aa0d7-bb40-4a56-81cb-f23b17ec062c}, !- Water Inlet Node Name
+  {0bb95161-9842-4a62-9099-8584ebfb8a3f}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -2713,9 +1647,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:DX:SingleSpeed,
-  {16e102bc-c936-4dc0-b885-66771296b9d4}, !- Handle
+  {dca18317-1ae3-4526-90c8-c704bdf60e98}, !- Handle
   Coil Cooling DX Single Speed 1,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -2723,11 +1657,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {569b2d94-2814-4d45-bb64-c31e150adad6}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {35d98d0e-4147-4fa8-b82d-0e90eaae107d}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {3255de90-998a-44d4-9f14-99233d776cac}, !- Energy Input Ratio Function of Temperature Curve Name
-  {3aa8f697-7e38-47d7-9f0a-9faa4ea4f594}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {e7c92631-2064-4bb2-8c6b-68880be66446}, !- Part Load Fraction Correlation Curve Name
+  {1d62a663-3ce0-4ffd-88c6-6337a3eebdbc}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {4f17d69b-c932-4992-817f-38243599ad47}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {1c39c926-a20b-4e55-83e5-3273f4f3ed5c}, !- Energy Input Ratio Function of Temperature Curve Name
+  {3492d675-27a4-4ec1-9031-4af52922deac}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {c7b3bced-8d80-42a5-b148-05303c24eddf}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -2746,7 +1680,7 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {569b2d94-2814-4d45-bb64-c31e150adad6}, !- Handle
+  {1d62a663-3ce0-4ffd-88c6-6337a3eebdbc}, !- Handle
   Curve Biquadratic 1,                    !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
@@ -2760,7 +1694,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {35d98d0e-4147-4fa8-b82d-0e90eaae107d}, !- Handle
+  {4f17d69b-c932-4992-817f-38243599ad47}, !- Handle
   Curve Quadratic 1,                      !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
@@ -2769,7 +1703,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {3255de90-998a-44d4-9f14-99233d776cac}, !- Handle
+  {1c39c926-a20b-4e55-83e5-3273f4f3ed5c}, !- Handle
   Curve Biquadratic 2,                    !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
@@ -2783,7 +1717,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {3aa8f697-7e38-47d7-9f0a-9faa4ea4f594}, !- Handle
+  {3492d675-27a4-4ec1-9031-4af52922deac}, !- Handle
   Curve Quadratic 2,                      !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
@@ -2792,7 +1726,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {e7c92631-2064-4bb2-8c6b-68880be66446}, !- Handle
+  {c7b3bced-8d80-42a5-b148-05303c24eddf}, !- Handle
   Curve Quadratic 3,                      !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
@@ -2801,11 +1735,11 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {c48e896e-9d45-4a8c-8b16-21d09212385a}, !- Handle
+  {816ac76d-50b2-4a63-ac45-4286483c435e}, !- Handle
   Zone HVAC Packaged Terminal Air Conditioner 1, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {94aed970-02b8-4c18-8073-2797fee26c5a}, !- Air Inlet Node Name
-  {302ead63-0429-45ce-a2c3-24df6ea29992}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {0c7c5faa-52d8-4924-a01a-5585f3ba1448}, !- Air Inlet Node Name
+  {ce56f09f-6967-46fa-a6fc-667df19b8fa3}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -2814,91 +1748,91 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {78ac48aa-d27f-4d89-a426-7dfcfe83ed60}, !- Supply Air Fan Name
-  {0603403b-7af5-4450-b4ca-8c3f422065c8}, !- Heating Coil Name
-  {16e102bc-c936-4dc0-b885-66771296b9d4}, !- Cooling Coil Name
+  {b4c0cc43-0af6-4bde-aa5c-d20e91b5f3bc}, !- Supply Air Fan Name
+  {cec18be3-218f-456f-ae1d-40240a98daa6}, !- Heating Coil Name
+  {dca18317-1ae3-4526-90c8-c704bdf60e98}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {79df4400-cef3-4c9a-a106-f8eddb8f0f36}, !- Handle
-  Node 22,                                !- Name
-  {89959d40-21a4-420b-ab0f-5533e212f13d}, !- Inlet Port
-  {94aed970-02b8-4c18-8073-2797fee26c5a}; !- Outlet Port
+  {099623b7-8068-4681-8185-02f8789cd461}, !- Handle
+  Node 17,                                !- Name
+  {af958f87-c525-481f-849c-4b43169ba2bf}, !- Inlet Port
+  {0c7c5faa-52d8-4924-a01a-5585f3ba1448}; !- Outlet Port
 
 OS:Connection,
-  {89959d40-21a4-420b-ab0f-5533e212f13d}, !- Handle
-  {fd46de41-36d0-4b66-bdf5-34686d0b74c8}, !- Name
-  {1f1a3ce9-76ee-4084-8cc3-87b50190e583}, !- Source Object
+  {af958f87-c525-481f-849c-4b43169ba2bf}, !- Handle
+  {622dad4d-5b78-4035-a0fd-bca2434ed6f4}, !- Name
+  {9695ed04-35b6-4772-83cd-5187282d3bc0}, !- Source Object
   3,                                      !- Outlet Port
-  {79df4400-cef3-4c9a-a106-f8eddb8f0f36}, !- Target Object
+  {099623b7-8068-4681-8185-02f8789cd461}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {94aed970-02b8-4c18-8073-2797fee26c5a}, !- Handle
-  {6c18e809-d772-4c60-8c3d-5104f9cbc837}, !- Name
-  {79df4400-cef3-4c9a-a106-f8eddb8f0f36}, !- Source Object
+  {0c7c5faa-52d8-4924-a01a-5585f3ba1448}, !- Handle
+  {150e0deb-e0a0-4017-8885-1d2205526764}, !- Name
+  {099623b7-8068-4681-8185-02f8789cd461}, !- Source Object
   3,                                      !- Outlet Port
-  {c48e896e-9d45-4a8c-8b16-21d09212385a}, !- Target Object
+  {816ac76d-50b2-4a63-ac45-4286483c435e}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {99970787-afa6-4414-8646-eaf849c976eb}, !- Handle
-  Node 23,                                !- Name
-  {302ead63-0429-45ce-a2c3-24df6ea29992}, !- Inlet Port
-  {5fb4eda3-ba68-4006-ac65-356586aa21ef}; !- Outlet Port
+  {0f7112ae-e134-457b-be90-5fd1a9207ded}, !- Handle
+  Node 18,                                !- Name
+  {ce56f09f-6967-46fa-a6fc-667df19b8fa3}, !- Inlet Port
+  {1fd906e5-b4d4-4d4c-add0-e4dda1c8094f}; !- Outlet Port
 
 OS:Connection,
-  {5fb4eda3-ba68-4006-ac65-356586aa21ef}, !- Handle
-  {97f60366-29a0-47c7-b251-e2a8e85e50a7}, !- Name
-  {99970787-afa6-4414-8646-eaf849c976eb}, !- Source Object
+  {1fd906e5-b4d4-4d4c-add0-e4dda1c8094f}, !- Handle
+  {081f4a91-f70b-415d-a0e9-a08afe72bffa}, !- Name
+  {0f7112ae-e134-457b-be90-5fd1a9207ded}, !- Source Object
   3,                                      !- Outlet Port
-  {25c71059-c1f2-4c97-b453-b7205cfb1f2d}, !- Target Object
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {302ead63-0429-45ce-a2c3-24df6ea29992}, !- Handle
-  {adf085ac-1710-40ee-9cb1-1314753ac9fa}, !- Name
-  {c48e896e-9d45-4a8c-8b16-21d09212385a}, !- Source Object
+  {ce56f09f-6967-46fa-a6fc-667df19b8fa3}, !- Handle
+  {90ee85b2-77b3-4ff7-9a48-108009551733}, !- Name
+  {816ac76d-50b2-4a63-ac45-4286483c435e}, !- Source Object
   4,                                      !- Outlet Port
-  {99970787-afa6-4414-8646-eaf849c976eb}, !- Target Object
+  {0f7112ae-e134-457b-be90-5fd1a9207ded}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {9d02ca7d-731f-4a15-a186-325cb8185dee}, !- Handle
-  Node 24,                                !- Name
-  {00bc389a-9e2b-4336-ac6b-47549f3b57a6}, !- Inlet Port
-  {c251aa21-0cd8-4c85-a251-cdd8088d0e78}; !- Outlet Port
+  {37673bb3-789c-4d59-aa4f-18d9f73f97cd}, !- Handle
+  Node 19,                                !- Name
+  {0bb95161-9842-4a62-9099-8584ebfb8a3f}, !- Inlet Port
+  {1f387dcb-eec5-4f6a-9c53-62006ae990ae}; !- Outlet Port
 
 OS:Connection,
-  {b9f43f23-edaa-4d48-a7bb-b67d8881ba67}, !- Handle
-  {ddce6046-9c82-4d61-aeda-188b448b56f4}, !- Name
-  {1edf1710-0b50-494d-980f-10f567a2ff54}, !- Source Object
+  {456aa0d7-bb40-4a56-81cb-f23b17ec062c}, !- Handle
+  {70fee9e4-ca0b-40db-a54f-9dc6488277f3}, !- Name
+  {6915aa9a-0ca1-4b4a-ab37-0893b3b61f27}, !- Source Object
   3,                                      !- Outlet Port
-  {0603403b-7af5-4450-b4ca-8c3f422065c8}, !- Target Object
+  {cec18be3-218f-456f-ae1d-40240a98daa6}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {00bc389a-9e2b-4336-ac6b-47549f3b57a6}, !- Handle
-  {a6827d12-4056-49f5-b42e-37f3ee99feaf}, !- Name
-  {0603403b-7af5-4450-b4ca-8c3f422065c8}, !- Source Object
+  {0bb95161-9842-4a62-9099-8584ebfb8a3f}, !- Handle
+  {752c6ca6-0063-496c-85e0-273b6aa167fd}, !- Name
+  {cec18be3-218f-456f-ae1d-40240a98daa6}, !- Source Object
   6,                                      !- Outlet Port
-  {9d02ca7d-731f-4a15-a186-325cb8185dee}, !- Target Object
+  {37673bb3-789c-4d59-aa4f-18d9f73f97cd}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c251aa21-0cd8-4c85-a251-cdd8088d0e78}, !- Handle
-  {87011a92-ad73-498e-9ff4-2275cf463e35}, !- Name
-  {9d02ca7d-731f-4a15-a186-325cb8185dee}, !- Source Object
+  {1f387dcb-eec5-4f6a-9c53-62006ae990ae}, !- Handle
+  {d8463f11-dbf6-45cd-9859-3a3a71aef5d8}, !- Name
+  {37673bb3-789c-4d59-aa4f-18d9f73f97cd}, !- Source Object
   3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Fan:ConstantVolume,
-  {890132e8-2616-4811-bfb4-1f760dc863d3}, !- Handle
+  {e54126a3-b45c-402f-b08d-3651b9b303a9}, !- Handle
   Fan Constant Volume 2,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   AutoSize,                               !- Maximum Flow Rate {m3/s}
   ,                                       !- Motor Efficiency
@@ -2908,13 +1842,13 @@ OS:Fan:ConstantVolume,
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {fc10b277-8930-4729-9c2f-533913f768aa}, !- Handle
+  {b5b47d4e-9e15-4319-b811-a23236ec0775}, !- Handle
   Coil Heating Water 2,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {950adb53-2b55-4cef-9721-7c2945485613}, !- Water Inlet Node Name
-  {5f362a01-e7f5-426f-b0cc-84e74696efb0}, !- Water Outlet Node Name
+  {4e3a175a-e196-45c6-9c5a-da52bed176b3}, !- Water Inlet Node Name
+  {b2d6eae0-7d10-4764-8e10-32c723d073bf}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -2926,9 +1860,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:DX:SingleSpeed,
-  {2ae33b4e-6f5e-4c8b-8e15-8ef799be2d2b}, !- Handle
+  {e379a805-b71a-40e3-8690-935db93b4471}, !- Handle
   Coil Cooling DX Single Speed 2,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -2936,11 +1870,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {23a9dc58-933f-450c-8df3-846cc584e603}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {f69bd29c-6630-4008-86e6-6015209d1bba}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {d707191c-2048-4e48-aa69-5d8cb3bd64ec}, !- Energy Input Ratio Function of Temperature Curve Name
-  {9745c03c-8219-43e8-8298-7380a95e2cd0}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {3560fa85-e5d1-431c-bfba-385efcc3735a}, !- Part Load Fraction Correlation Curve Name
+  {9371be88-078b-4e9c-8fec-ee8eadd45e5e}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {2316b82a-e492-40a0-9197-d5370a2dc30d}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {23482322-46e7-4588-a5d2-7c1ac9ec06be}, !- Energy Input Ratio Function of Temperature Curve Name
+  {3c091634-0b95-4bed-92a4-88914bfb1739}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {2a59c408-c81f-4283-9c50-d29bc3fa980a}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -2959,7 +1893,7 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {23a9dc58-933f-450c-8df3-846cc584e603}, !- Handle
+  {9371be88-078b-4e9c-8fec-ee8eadd45e5e}, !- Handle
   Curve Biquadratic 3,                    !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
@@ -2973,7 +1907,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {f69bd29c-6630-4008-86e6-6015209d1bba}, !- Handle
+  {2316b82a-e492-40a0-9197-d5370a2dc30d}, !- Handle
   Curve Quadratic 4,                      !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
@@ -2982,7 +1916,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {d707191c-2048-4e48-aa69-5d8cb3bd64ec}, !- Handle
+  {23482322-46e7-4588-a5d2-7c1ac9ec06be}, !- Handle
   Curve Biquadratic 4,                    !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
@@ -2996,7 +1930,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {9745c03c-8219-43e8-8298-7380a95e2cd0}, !- Handle
+  {3c091634-0b95-4bed-92a4-88914bfb1739}, !- Handle
   Curve Quadratic 5,                      !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
@@ -3005,7 +1939,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {3560fa85-e5d1-431c-bfba-385efcc3735a}, !- Handle
+  {2a59c408-c81f-4283-9c50-d29bc3fa980a}, !- Handle
   Curve Quadratic 6,                      !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
@@ -3014,11 +1948,11 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {269b11a9-9e8c-4952-a4c6-1e05f1b95a47}, !- Handle
+  {c755650f-8903-46d4-8702-5acc5fa393e4}, !- Handle
   Zone HVAC Packaged Terminal Air Conditioner 2, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {0c9c9ab8-2ba9-4526-ab6f-9f780b17472c}, !- Air Inlet Node Name
-  {80f1b448-6cdb-4eaa-ab29-5b75f9b62202}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {e726bc15-4cfe-4e35-b390-a0be5f7109c0}, !- Air Inlet Node Name
+  {a3dbbb9a-b2e5-4773-b2ae-04e7aafde834}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -3027,105 +1961,105 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {890132e8-2616-4811-bfb4-1f760dc863d3}, !- Supply Air Fan Name
-  {fc10b277-8930-4729-9c2f-533913f768aa}, !- Heating Coil Name
-  {2ae33b4e-6f5e-4c8b-8e15-8ef799be2d2b}, !- Cooling Coil Name
+  {e54126a3-b45c-402f-b08d-3651b9b303a9}, !- Supply Air Fan Name
+  {b5b47d4e-9e15-4319-b811-a23236ec0775}, !- Heating Coil Name
+  {e379a805-b71a-40e3-8690-935db93b4471}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {5dfc8922-e2c3-4556-9555-9306d9b853fd}, !- Handle
-  Node 25,                                !- Name
-  {7b560590-0dea-4739-9340-2e088ce05137}, !- Inlet Port
-  {0c9c9ab8-2ba9-4526-ab6f-9f780b17472c}; !- Outlet Port
+  {efc2061f-3e51-45ba-b4d2-2a7b89b7fc43}, !- Handle
+  Node 20,                                !- Name
+  {ed4bc845-b2c1-429e-a1bf-0e4e2077f565}, !- Inlet Port
+  {e726bc15-4cfe-4e35-b390-a0be5f7109c0}; !- Outlet Port
 
 OS:Connection,
-  {7b560590-0dea-4739-9340-2e088ce05137}, !- Handle
-  {927fe6c6-be1a-4043-9aa6-fcea9a047010}, !- Name
-  {71130af3-15f6-4838-9dee-4fa7efcd3001}, !- Source Object
+  {ed4bc845-b2c1-429e-a1bf-0e4e2077f565}, !- Handle
+  {96d93797-687e-46b3-b162-bd1f727bc294}, !- Name
+  {f124a798-5ea9-42fb-ac90-9b9002a7b403}, !- Source Object
   3,                                      !- Outlet Port
-  {5dfc8922-e2c3-4556-9555-9306d9b853fd}, !- Target Object
+  {efc2061f-3e51-45ba-b4d2-2a7b89b7fc43}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {0c9c9ab8-2ba9-4526-ab6f-9f780b17472c}, !- Handle
-  {58b44731-cb11-4778-b4f2-0a5389fd0d9d}, !- Name
-  {5dfc8922-e2c3-4556-9555-9306d9b853fd}, !- Source Object
+  {e726bc15-4cfe-4e35-b390-a0be5f7109c0}, !- Handle
+  {41935214-260c-4cb7-a6b3-cbe9b1a26b38}, !- Name
+  {efc2061f-3e51-45ba-b4d2-2a7b89b7fc43}, !- Source Object
   3,                                      !- Outlet Port
-  {269b11a9-9e8c-4952-a4c6-1e05f1b95a47}, !- Target Object
+  {c755650f-8903-46d4-8702-5acc5fa393e4}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {48f6f74a-9e8a-41f7-a8c1-3234c0ff2851}, !- Handle
-  Node 26,                                !- Name
-  {80f1b448-6cdb-4eaa-ab29-5b75f9b62202}, !- Inlet Port
-  {c08911a3-9c2b-459e-87dc-4dab2eecddf0}; !- Outlet Port
+  {483834d2-f2d6-402d-8bcd-d99c7135ebcb}, !- Handle
+  Node 21,                                !- Name
+  {a3dbbb9a-b2e5-4773-b2ae-04e7aafde834}, !- Inlet Port
+  {10fdfc95-ab7a-4668-8028-e30a4af6392c}; !- Outlet Port
 
 OS:Connection,
-  {c08911a3-9c2b-459e-87dc-4dab2eecddf0}, !- Handle
-  {32340b7d-edf3-4f4c-b436-bbd0a2763a68}, !- Name
-  {48f6f74a-9e8a-41f7-a8c1-3234c0ff2851}, !- Source Object
+  {10fdfc95-ab7a-4668-8028-e30a4af6392c}, !- Handle
+  {d2e72798-dbe6-4bb8-847b-be27ff3f6b5f}, !- Name
+  {483834d2-f2d6-402d-8bcd-d99c7135ebcb}, !- Source Object
   3,                                      !- Outlet Port
-  {111e5a4c-0426-4d15-bf10-745a2855fed1}, !- Target Object
+  {6349c895-bf74-4b50-a272-00c64a391a7f}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {80f1b448-6cdb-4eaa-ab29-5b75f9b62202}, !- Handle
-  {a877fd4a-6624-4a31-8a44-425525b348f0}, !- Name
-  {269b11a9-9e8c-4952-a4c6-1e05f1b95a47}, !- Source Object
+  {a3dbbb9a-b2e5-4773-b2ae-04e7aafde834}, !- Handle
+  {09d53888-5447-4d5d-a9de-60c841706c5a}, !- Name
+  {c755650f-8903-46d4-8702-5acc5fa393e4}, !- Source Object
   4,                                      !- Outlet Port
-  {48f6f74a-9e8a-41f7-a8c1-3234c0ff2851}, !- Target Object
+  {483834d2-f2d6-402d-8bcd-d99c7135ebcb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {a42b2689-7cf8-478a-abb3-e0a0f02e6d94}, !- Handle
-  Node 27,                                !- Name
-  {a8f71d21-3f1b-4be5-a770-7582c1223ccc}, !- Inlet Port
-  {950adb53-2b55-4cef-9721-7c2945485613}; !- Outlet Port
+  {63d593d3-6927-4747-b6f8-6897f07e877e}, !- Handle
+  Node 22,                                !- Name
+  {3d68eb99-2093-4f17-9ef0-a054ef85d369}, !- Inlet Port
+  {4e3a175a-e196-45c6-9c5a-da52bed176b3}; !- Outlet Port
 
 OS:Connection,
-  {a8f71d21-3f1b-4be5-a770-7582c1223ccc}, !- Handle
-  {2e6fc504-cca1-4797-965d-490a666419e4}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
+  {3d68eb99-2093-4f17-9ef0-a054ef85d369}, !- Handle
+  {b6b4fb00-7f3f-4a10-ad06-aba0450df4db}, !- Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Source Object
   4,                                      !- Outlet Port
-  {a42b2689-7cf8-478a-abb3-e0a0f02e6d94}, !- Target Object
+  {63d593d3-6927-4747-b6f8-6897f07e877e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {aa9a8159-ff96-4279-8e2a-b0f010efbdcc}, !- Handle
-  Node 28,                                !- Name
-  {5f362a01-e7f5-426f-b0cc-84e74696efb0}, !- Inlet Port
-  {7d2b33c1-79a4-432f-a710-6f246eae613b}; !- Outlet Port
+  {89286a6a-12be-4611-a129-1c219d7445cb}, !- Handle
+  Node 23,                                !- Name
+  {b2d6eae0-7d10-4764-8e10-32c723d073bf}, !- Inlet Port
+  {d3915107-2de3-436d-a61a-977fed39db12}; !- Outlet Port
 
 OS:Connection,
-  {950adb53-2b55-4cef-9721-7c2945485613}, !- Handle
-  {3f2564a8-46a0-4cb1-a33c-f3e24d01a3cb}, !- Name
-  {a42b2689-7cf8-478a-abb3-e0a0f02e6d94}, !- Source Object
+  {4e3a175a-e196-45c6-9c5a-da52bed176b3}, !- Handle
+  {40fcdd1c-61ae-417a-824d-3aae7234947e}, !- Name
+  {63d593d3-6927-4747-b6f8-6897f07e877e}, !- Source Object
   3,                                      !- Outlet Port
-  {fc10b277-8930-4729-9c2f-533913f768aa}, !- Target Object
+  {b5b47d4e-9e15-4319-b811-a23236ec0775}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {5f362a01-e7f5-426f-b0cc-84e74696efb0}, !- Handle
-  {4a12e2e4-c099-4a05-bdd3-11e82795596c}, !- Name
-  {fc10b277-8930-4729-9c2f-533913f768aa}, !- Source Object
+  {b2d6eae0-7d10-4764-8e10-32c723d073bf}, !- Handle
+  {815992d2-e8bf-401f-b335-10ae1cb08b82}, !- Name
+  {b5b47d4e-9e15-4319-b811-a23236ec0775}, !- Source Object
   6,                                      !- Outlet Port
-  {aa9a8159-ff96-4279-8e2a-b0f010efbdcc}, !- Target Object
+  {89286a6a-12be-4611-a129-1c219d7445cb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7d2b33c1-79a4-432f-a710-6f246eae613b}, !- Handle
-  {1eaeb652-e705-4e18-b833-16a3731bcfdf}, !- Name
-  {aa9a8159-ff96-4279-8e2a-b0f010efbdcc}, !- Source Object
+  {d3915107-2de3-436d-a61a-977fed39db12}, !- Handle
+  {99c0439d-384d-418b-887c-f813b94b2529}, !- Name
+  {89286a6a-12be-4611-a129-1c219d7445cb}, !- Source Object
   3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Fan:ConstantVolume,
-  {a686d3b5-ad69-4b33-b312-53fdafe46524}, !- Handle
+  {2d549fd3-49e7-4bb3-be90-6a09b4f6c96e}, !- Handle
   Fan Constant Volume 3,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   AutoSize,                               !- Maximum Flow Rate {m3/s}
   ,                                       !- Motor Efficiency
@@ -3135,13 +2069,13 @@ OS:Fan:ConstantVolume,
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {98ca4473-6fb5-4afc-bfe7-2bbab19dfc47}, !- Handle
+  {cac58760-9529-49e0-84b3-d4b6799cdc71}, !- Handle
   Coil Heating Water 3,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {325d1def-a7f2-4eff-9d2d-0811a8bce119}, !- Water Inlet Node Name
-  {35b63bda-dd40-4103-990d-3fe348f7e043}, !- Water Outlet Node Name
+  {c8c1fa9f-4582-48bc-9af0-754d7edeb48d}, !- Water Inlet Node Name
+  {7b7aaa31-9b94-4b99-ae53-bdebff61522e}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -3153,9 +2087,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:DX:SingleSpeed,
-  {89ba3a84-b007-4ea1-ba50-c69dfce99687}, !- Handle
+  {77114c87-21a2-4df7-bf21-f3bb14c12eed}, !- Handle
   Coil Cooling DX Single Speed 3,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -3163,11 +2097,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {f4556341-c070-448f-bbd5-b64940a7279f}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {5cc18028-40eb-4d8f-8899-ed93160a69c9}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {493c0435-7dda-4f8b-9bbf-e0199f048b3f}, !- Energy Input Ratio Function of Temperature Curve Name
-  {a7199a85-7f7a-4e0c-888b-f875c6c336c7}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {fbd5393f-2efc-40d2-9a43-81479482c958}, !- Part Load Fraction Correlation Curve Name
+  {fb134c9a-df64-4f46-8de2-3d1885703aad}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {761f3e78-3ddf-4869-8287-6b9bd1550951}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {c99023ed-11e8-4e73-a3ab-3e64f1f33a87}, !- Energy Input Ratio Function of Temperature Curve Name
+  {4770011b-1512-4671-acef-717be5e81584}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {6ade3b22-e8bb-4e69-a28e-4b3ca6bc6a27}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -3186,7 +2120,7 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {f4556341-c070-448f-bbd5-b64940a7279f}, !- Handle
+  {fb134c9a-df64-4f46-8de2-3d1885703aad}, !- Handle
   Curve Biquadratic 5,                    !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
@@ -3200,7 +2134,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {5cc18028-40eb-4d8f-8899-ed93160a69c9}, !- Handle
+  {761f3e78-3ddf-4869-8287-6b9bd1550951}, !- Handle
   Curve Quadratic 7,                      !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
@@ -3209,7 +2143,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {493c0435-7dda-4f8b-9bbf-e0199f048b3f}, !- Handle
+  {c99023ed-11e8-4e73-a3ab-3e64f1f33a87}, !- Handle
   Curve Biquadratic 6,                    !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
@@ -3223,7 +2157,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {a7199a85-7f7a-4e0c-888b-f875c6c336c7}, !- Handle
+  {4770011b-1512-4671-acef-717be5e81584}, !- Handle
   Curve Quadratic 8,                      !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
@@ -3232,7 +2166,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {fbd5393f-2efc-40d2-9a43-81479482c958}, !- Handle
+  {6ade3b22-e8bb-4e69-a28e-4b3ca6bc6a27}, !- Handle
   Curve Quadratic 9,                      !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
@@ -3241,11 +2175,11 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {e3fcaade-8089-410c-8464-b5383eb70207}, !- Handle
+  {ad837a42-762e-4863-9f83-37b3da214962}, !- Handle
   Zone HVAC Packaged Terminal Air Conditioner 3, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {2fe7b52c-21a9-4a12-9d77-c12ba856e1e3}, !- Air Inlet Node Name
-  {4b8bd618-e70c-419b-9b6d-14e7bfe8621f}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {343cd041-2b83-4017-9605-a3f3cfc6fcd4}, !- Air Inlet Node Name
+  {6a454b69-47af-4b36-985b-0f1087f64904}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -3254,105 +2188,105 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {a686d3b5-ad69-4b33-b312-53fdafe46524}, !- Supply Air Fan Name
-  {98ca4473-6fb5-4afc-bfe7-2bbab19dfc47}, !- Heating Coil Name
-  {89ba3a84-b007-4ea1-ba50-c69dfce99687}, !- Cooling Coil Name
+  {2d549fd3-49e7-4bb3-be90-6a09b4f6c96e}, !- Supply Air Fan Name
+  {cac58760-9529-49e0-84b3-d4b6799cdc71}, !- Heating Coil Name
+  {77114c87-21a2-4df7-bf21-f3bb14c12eed}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {443e6c50-79ab-45df-b9bc-3549e0ed0cd6}, !- Handle
-  Node 29,                                !- Name
-  {da16c84b-3269-48fc-886c-b88fee1df790}, !- Inlet Port
-  {2fe7b52c-21a9-4a12-9d77-c12ba856e1e3}; !- Outlet Port
+  {1ded663a-70bf-4a53-9ed6-5d93953a6f85}, !- Handle
+  Node 24,                                !- Name
+  {3b82a4b6-71f6-40b0-92c3-6586a6c77917}, !- Inlet Port
+  {343cd041-2b83-4017-9605-a3f3cfc6fcd4}; !- Outlet Port
 
 OS:Connection,
-  {da16c84b-3269-48fc-886c-b88fee1df790}, !- Handle
-  {4e24db04-ad25-4a4f-b98d-cd9349be87bc}, !- Name
-  {05127144-9a40-4cbe-b216-ec9993f7bcc2}, !- Source Object
+  {3b82a4b6-71f6-40b0-92c3-6586a6c77917}, !- Handle
+  {2ac06200-1412-43da-a319-4ef902ccf8b5}, !- Name
+  {c45b91b9-5807-4007-80de-a17ef2d30928}, !- Source Object
   3,                                      !- Outlet Port
-  {443e6c50-79ab-45df-b9bc-3549e0ed0cd6}, !- Target Object
+  {1ded663a-70bf-4a53-9ed6-5d93953a6f85}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2fe7b52c-21a9-4a12-9d77-c12ba856e1e3}, !- Handle
-  {7af0cce7-3a97-4723-b644-0e4e87ce7464}, !- Name
-  {443e6c50-79ab-45df-b9bc-3549e0ed0cd6}, !- Source Object
+  {343cd041-2b83-4017-9605-a3f3cfc6fcd4}, !- Handle
+  {bad58659-3a72-4618-bb44-4d1d5e51e551}, !- Name
+  {1ded663a-70bf-4a53-9ed6-5d93953a6f85}, !- Source Object
   3,                                      !- Outlet Port
-  {e3fcaade-8089-410c-8464-b5383eb70207}, !- Target Object
+  {ad837a42-762e-4863-9f83-37b3da214962}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {812da498-db93-4992-8fb8-9ee1a151c1ea}, !- Handle
-  Node 30,                                !- Name
-  {4b8bd618-e70c-419b-9b6d-14e7bfe8621f}, !- Inlet Port
-  {75a7ab1d-9917-4704-8409-1ca91b7a1990}; !- Outlet Port
+  {be54843d-f5d4-4268-9791-53ebb3d6324f}, !- Handle
+  Node 25,                                !- Name
+  {6a454b69-47af-4b36-985b-0f1087f64904}, !- Inlet Port
+  {2d1d5804-632e-4507-ab89-81d364544061}; !- Outlet Port
 
 OS:Connection,
-  {75a7ab1d-9917-4704-8409-1ca91b7a1990}, !- Handle
-  {dbaa8208-02c6-4052-a688-7ef6b67aae69}, !- Name
-  {812da498-db93-4992-8fb8-9ee1a151c1ea}, !- Source Object
+  {2d1d5804-632e-4507-ab89-81d364544061}, !- Handle
+  {db398b5e-0efc-40c2-aaa5-7b531569a3b9}, !- Name
+  {be54843d-f5d4-4268-9791-53ebb3d6324f}, !- Source Object
   3,                                      !- Outlet Port
-  {81cdf6eb-d245-4746-b5ec-ad0680eb54d0}, !- Target Object
+  {9f7124d5-ca2a-4144-ba29-d08c53642c05}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {4b8bd618-e70c-419b-9b6d-14e7bfe8621f}, !- Handle
-  {4a58a922-aa17-4332-9968-3fb368923922}, !- Name
-  {e3fcaade-8089-410c-8464-b5383eb70207}, !- Source Object
+  {6a454b69-47af-4b36-985b-0f1087f64904}, !- Handle
+  {59b69032-d14d-4de0-a146-fb0b462e85e0}, !- Name
+  {ad837a42-762e-4863-9f83-37b3da214962}, !- Source Object
   4,                                      !- Outlet Port
-  {812da498-db93-4992-8fb8-9ee1a151c1ea}, !- Target Object
+  {be54843d-f5d4-4268-9791-53ebb3d6324f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {76700fae-d22f-4a37-b277-895ef49eb781}, !- Handle
-  Node 31,                                !- Name
-  {40da4e11-4852-4bf3-8409-265f710a581c}, !- Inlet Port
-  {325d1def-a7f2-4eff-9d2d-0811a8bce119}; !- Outlet Port
+  {7d917e53-017f-43b9-9341-db27f399ca44}, !- Handle
+  Node 26,                                !- Name
+  {af0f81ff-fcdb-498c-a7b5-af82d5a341aa}, !- Inlet Port
+  {c8c1fa9f-4582-48bc-9af0-754d7edeb48d}; !- Outlet Port
 
 OS:Connection,
-  {40da4e11-4852-4bf3-8409-265f710a581c}, !- Handle
-  {26939d8c-54d2-4f2f-8f00-acddd4a5fcbd}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
+  {af0f81ff-fcdb-498c-a7b5-af82d5a341aa}, !- Handle
+  {5ce7ba4f-fda4-4549-8dc8-670201d52853}, !- Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Source Object
   5,                                      !- Outlet Port
-  {76700fae-d22f-4a37-b277-895ef49eb781}, !- Target Object
+  {7d917e53-017f-43b9-9341-db27f399ca44}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {8e7c3dbd-3cf1-46e0-b606-b21dfd6b3b3f}, !- Handle
-  Node 32,                                !- Name
-  {35b63bda-dd40-4103-990d-3fe348f7e043}, !- Inlet Port
-  {be5de37a-0e6a-4010-8d63-5eea0d29a771}; !- Outlet Port
+  {8b113793-e757-4c7c-aeda-51758129935d}, !- Handle
+  Node 27,                                !- Name
+  {7b7aaa31-9b94-4b99-ae53-bdebff61522e}, !- Inlet Port
+  {c529cdb9-fa59-45f5-bfc4-e924583e8fc2}; !- Outlet Port
 
 OS:Connection,
-  {325d1def-a7f2-4eff-9d2d-0811a8bce119}, !- Handle
-  {be98c6c6-d02d-4658-96c5-31b42f3f8259}, !- Name
-  {76700fae-d22f-4a37-b277-895ef49eb781}, !- Source Object
+  {c8c1fa9f-4582-48bc-9af0-754d7edeb48d}, !- Handle
+  {79fe1965-f8da-42ab-93c4-20566e372a6f}, !- Name
+  {7d917e53-017f-43b9-9341-db27f399ca44}, !- Source Object
   3,                                      !- Outlet Port
-  {98ca4473-6fb5-4afc-bfe7-2bbab19dfc47}, !- Target Object
+  {cac58760-9529-49e0-84b3-d4b6799cdc71}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {35b63bda-dd40-4103-990d-3fe348f7e043}, !- Handle
-  {b196e013-2bb5-4c9a-b723-2edc1c50a770}, !- Name
-  {98ca4473-6fb5-4afc-bfe7-2bbab19dfc47}, !- Source Object
+  {7b7aaa31-9b94-4b99-ae53-bdebff61522e}, !- Handle
+  {d2b9b47a-5045-4eb2-9c67-6dcee10daf9f}, !- Name
+  {cac58760-9529-49e0-84b3-d4b6799cdc71}, !- Source Object
   6,                                      !- Outlet Port
-  {8e7c3dbd-3cf1-46e0-b606-b21dfd6b3b3f}, !- Target Object
+  {8b113793-e757-4c7c-aeda-51758129935d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {be5de37a-0e6a-4010-8d63-5eea0d29a771}, !- Handle
-  {13e80630-d63d-4825-bb9a-74455fee94d5}, !- Name
-  {8e7c3dbd-3cf1-46e0-b606-b21dfd6b3b3f}, !- Source Object
+  {c529cdb9-fa59-45f5-bfc4-e924583e8fc2}, !- Handle
+  {6d08364e-38ab-4a7a-86d6-efa3d0c222a3}, !- Name
+  {8b113793-e757-4c7c-aeda-51758129935d}, !- Source Object
   3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Fan:ConstantVolume,
-  {319a4733-010c-48f8-aaf6-93f04981de0f}, !- Handle
+  {63c174d4-6561-46cf-af10-1a005f9c6966}, !- Handle
   Fan Constant Volume 4,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   AutoSize,                               !- Maximum Flow Rate {m3/s}
   ,                                       !- Motor Efficiency
@@ -3362,13 +2296,13 @@ OS:Fan:ConstantVolume,
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {b47f534c-e1ca-42d3-9741-c180aa438056}, !- Handle
+  {15d8ffb4-c6eb-4194-b631-176bea6f2664}, !- Handle
   Coil Heating Water 4,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {075231ba-5bbf-47cc-a966-23603c2de337}, !- Water Inlet Node Name
-  {74b6ab92-5c02-4ead-98ac-cc6d9cab79e3}, !- Water Outlet Node Name
+  {de4e40dc-ff65-4253-bca8-6e7883538e71}, !- Water Inlet Node Name
+  {24dbcc4b-a852-4e25-af69-f3fe6ace6559}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -3380,9 +2314,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:DX:SingleSpeed,
-  {93f226c4-089e-469f-8b81-5f30033a9a9d}, !- Handle
+  {c4f06e52-8418-4503-946d-ef24ecbe6000}, !- Handle
   Coil Cooling DX Single Speed 4,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -3390,11 +2324,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {f1f0532b-138d-4dba-be9f-2cca95e44c60}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {70bd4b12-9967-4019-8fa9-64ad7b65798b}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {08fd5605-6a3a-45da-97fa-57521b37c6b7}, !- Energy Input Ratio Function of Temperature Curve Name
-  {fbc56e49-c279-43ef-990d-3d14f6606437}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {fe996d5d-637b-416f-abb7-9f013572bb89}, !- Part Load Fraction Correlation Curve Name
+  {7732a9ed-6104-4867-a4d8-2eb390f2472c}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {730ca420-4864-41e5-9e4b-6851ce978516}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {39807966-e75c-42c2-adf5-fcdebf926045}, !- Energy Input Ratio Function of Temperature Curve Name
+  {aca49969-e7d3-4ce0-acc1-7f3b8a033105}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {420f8a50-838a-4744-8869-f2578cd83467}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -3413,7 +2347,7 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {f1f0532b-138d-4dba-be9f-2cca95e44c60}, !- Handle
+  {7732a9ed-6104-4867-a4d8-2eb390f2472c}, !- Handle
   Curve Biquadratic 7,                    !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
@@ -3427,7 +2361,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {70bd4b12-9967-4019-8fa9-64ad7b65798b}, !- Handle
+  {730ca420-4864-41e5-9e4b-6851ce978516}, !- Handle
   Curve Quadratic 10,                     !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
@@ -3436,7 +2370,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {08fd5605-6a3a-45da-97fa-57521b37c6b7}, !- Handle
+  {39807966-e75c-42c2-adf5-fcdebf926045}, !- Handle
   Curve Biquadratic 8,                    !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
@@ -3450,7 +2384,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {fbc56e49-c279-43ef-990d-3d14f6606437}, !- Handle
+  {aca49969-e7d3-4ce0-acc1-7f3b8a033105}, !- Handle
   Curve Quadratic 11,                     !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
@@ -3459,7 +2393,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {fe996d5d-637b-416f-abb7-9f013572bb89}, !- Handle
+  {420f8a50-838a-4744-8869-f2578cd83467}, !- Handle
   Curve Quadratic 12,                     !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
@@ -3468,11 +2402,11 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {12c4d100-7b2e-4caa-abb3-e440c9923f3f}, !- Handle
+  {3ea0c3fb-959a-4c43-8dd0-099a30f8ce88}, !- Handle
   Zone HVAC Packaged Terminal Air Conditioner 4, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {db3110ce-803e-44c0-a208-69529f0eeb20}, !- Air Inlet Node Name
-  {dc477fd9-d9d2-4629-8167-a25f7c3baff2}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {70517ae5-e34d-4e26-bb7a-cf3dad07eaf2}, !- Air Inlet Node Name
+  {26d42e9f-0b5c-4e2c-8e99-ad54c1b924bf}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -3481,105 +2415,105 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {319a4733-010c-48f8-aaf6-93f04981de0f}, !- Supply Air Fan Name
-  {b47f534c-e1ca-42d3-9741-c180aa438056}, !- Heating Coil Name
-  {93f226c4-089e-469f-8b81-5f30033a9a9d}, !- Cooling Coil Name
+  {63c174d4-6561-46cf-af10-1a005f9c6966}, !- Supply Air Fan Name
+  {15d8ffb4-c6eb-4194-b631-176bea6f2664}, !- Heating Coil Name
+  {c4f06e52-8418-4503-946d-ef24ecbe6000}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {ae65697b-f7b7-44b4-bb30-616c5fe05bca}, !- Handle
-  Node 33,                                !- Name
-  {cd9fd72f-ebd0-4436-81e7-8d122b086097}, !- Inlet Port
-  {db3110ce-803e-44c0-a208-69529f0eeb20}; !- Outlet Port
+  {ce2342e9-dc2b-4824-a97b-9f2b53be6858}, !- Handle
+  Node 28,                                !- Name
+  {277530c7-6f43-4152-bcac-162493bc0e18}, !- Inlet Port
+  {70517ae5-e34d-4e26-bb7a-cf3dad07eaf2}; !- Outlet Port
 
 OS:Connection,
-  {cd9fd72f-ebd0-4436-81e7-8d122b086097}, !- Handle
-  {cbe585cd-7181-4dda-a2f2-1c523f65e060}, !- Name
-  {a813f9c8-41cd-40b1-bd63-6c75e237d00c}, !- Source Object
+  {277530c7-6f43-4152-bcac-162493bc0e18}, !- Handle
+  {c5972302-270a-47af-85b5-f4738e92e353}, !- Name
+  {e7701c76-6c48-4d72-b386-54e809007fe1}, !- Source Object
   3,                                      !- Outlet Port
-  {ae65697b-f7b7-44b4-bb30-616c5fe05bca}, !- Target Object
+  {ce2342e9-dc2b-4824-a97b-9f2b53be6858}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {db3110ce-803e-44c0-a208-69529f0eeb20}, !- Handle
-  {90f5ae12-66e6-434a-9b64-e87af37364e0}, !- Name
-  {ae65697b-f7b7-44b4-bb30-616c5fe05bca}, !- Source Object
+  {70517ae5-e34d-4e26-bb7a-cf3dad07eaf2}, !- Handle
+  {975198dd-89f6-47c4-8892-2ce7680a3964}, !- Name
+  {ce2342e9-dc2b-4824-a97b-9f2b53be6858}, !- Source Object
   3,                                      !- Outlet Port
-  {12c4d100-7b2e-4caa-abb3-e440c9923f3f}, !- Target Object
+  {3ea0c3fb-959a-4c43-8dd0-099a30f8ce88}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {da0006f6-facc-47b3-b769-f02551110141}, !- Handle
-  Node 34,                                !- Name
-  {dc477fd9-d9d2-4629-8167-a25f7c3baff2}, !- Inlet Port
-  {47129e19-ebe9-4b23-a360-7d334f0acbb9}; !- Outlet Port
+  {28751564-2df9-4639-96b3-d11a60965f73}, !- Handle
+  Node 29,                                !- Name
+  {26d42e9f-0b5c-4e2c-8e99-ad54c1b924bf}, !- Inlet Port
+  {1eb05017-c9ac-4193-a925-71bd763d7a2c}; !- Outlet Port
 
 OS:Connection,
-  {47129e19-ebe9-4b23-a360-7d334f0acbb9}, !- Handle
-  {bf0ee156-5916-4643-badf-30b677a165e8}, !- Name
-  {da0006f6-facc-47b3-b769-f02551110141}, !- Source Object
+  {1eb05017-c9ac-4193-a925-71bd763d7a2c}, !- Handle
+  {3a4288af-a25e-4b18-b974-dc930e3aafc9}, !- Name
+  {28751564-2df9-4639-96b3-d11a60965f73}, !- Source Object
   3,                                      !- Outlet Port
-  {cf951ab3-bc83-43c6-bfd9-8d33d7768b28}, !- Target Object
+  {0224c5cc-b53c-4d4d-9840-f5e2b11114c7}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {dc477fd9-d9d2-4629-8167-a25f7c3baff2}, !- Handle
-  {7d7d89ca-03bd-4164-8676-da3877e82a85}, !- Name
-  {12c4d100-7b2e-4caa-abb3-e440c9923f3f}, !- Source Object
+  {26d42e9f-0b5c-4e2c-8e99-ad54c1b924bf}, !- Handle
+  {3f770411-435f-482f-a5d6-631f3db1cd21}, !- Name
+  {3ea0c3fb-959a-4c43-8dd0-099a30f8ce88}, !- Source Object
   4,                                      !- Outlet Port
-  {da0006f6-facc-47b3-b769-f02551110141}, !- Target Object
+  {28751564-2df9-4639-96b3-d11a60965f73}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {ef94d26a-3afc-4151-8eee-bfa3dc0cfb76}, !- Handle
-  Node 35,                                !- Name
-  {f3f96d81-cacb-441a-b2fd-d382ba7a9f97}, !- Inlet Port
-  {075231ba-5bbf-47cc-a966-23603c2de337}; !- Outlet Port
+  {5f71fa57-d591-41af-b39f-2f0b7d89fbb2}, !- Handle
+  Node 30,                                !- Name
+  {0b78b354-3d71-4ebe-9ed1-741ffab3fdf0}, !- Inlet Port
+  {de4e40dc-ff65-4253-bca8-6e7883538e71}; !- Outlet Port
 
 OS:Connection,
-  {f3f96d81-cacb-441a-b2fd-d382ba7a9f97}, !- Handle
-  {f2f697c4-3b28-4a68-a60f-16c762bbc8fd}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
+  {0b78b354-3d71-4ebe-9ed1-741ffab3fdf0}, !- Handle
+  {fe1fae31-fa9e-40b1-8794-34a9faba2652}, !- Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Source Object
   6,                                      !- Outlet Port
-  {ef94d26a-3afc-4151-8eee-bfa3dc0cfb76}, !- Target Object
+  {5f71fa57-d591-41af-b39f-2f0b7d89fbb2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {b1936cff-a8d5-4dc3-b524-20659e13b96a}, !- Handle
-  Node 36,                                !- Name
-  {74b6ab92-5c02-4ead-98ac-cc6d9cab79e3}, !- Inlet Port
-  {f43299b3-8eb5-402e-b67f-ff8c09f74726}; !- Outlet Port
+  {7f764513-d9e8-431c-83f6-df03ed471a24}, !- Handle
+  Node 31,                                !- Name
+  {24dbcc4b-a852-4e25-af69-f3fe6ace6559}, !- Inlet Port
+  {a6943830-47ec-498b-b1f6-0da563bf53d4}; !- Outlet Port
 
 OS:Connection,
-  {075231ba-5bbf-47cc-a966-23603c2de337}, !- Handle
-  {16bde2ea-4b3c-4802-9998-f9244a31d2bd}, !- Name
-  {ef94d26a-3afc-4151-8eee-bfa3dc0cfb76}, !- Source Object
+  {de4e40dc-ff65-4253-bca8-6e7883538e71}, !- Handle
+  {1a53a8e7-8ae7-4e0f-863e-9965f86e16b1}, !- Name
+  {5f71fa57-d591-41af-b39f-2f0b7d89fbb2}, !- Source Object
   3,                                      !- Outlet Port
-  {b47f534c-e1ca-42d3-9741-c180aa438056}, !- Target Object
+  {15d8ffb4-c6eb-4194-b631-176bea6f2664}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {74b6ab92-5c02-4ead-98ac-cc6d9cab79e3}, !- Handle
-  {54468b43-09e7-4600-a07c-c1c7d4c725e3}, !- Name
-  {b47f534c-e1ca-42d3-9741-c180aa438056}, !- Source Object
+  {24dbcc4b-a852-4e25-af69-f3fe6ace6559}, !- Handle
+  {45ee919a-9816-4cae-962e-9c485a23aa22}, !- Name
+  {15d8ffb4-c6eb-4194-b631-176bea6f2664}, !- Source Object
   6,                                      !- Outlet Port
-  {b1936cff-a8d5-4dc3-b524-20659e13b96a}, !- Target Object
+  {7f764513-d9e8-431c-83f6-df03ed471a24}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f43299b3-8eb5-402e-b67f-ff8c09f74726}, !- Handle
-  {a24c4d4b-780f-435d-9f2c-1a15a3b60d34}, !- Name
-  {b1936cff-a8d5-4dc3-b524-20659e13b96a}, !- Source Object
+  {a6943830-47ec-498b-b1f6-0da563bf53d4}, !- Handle
+  {f94ea916-5504-434d-ad2d-c8b0fa70bca2}, !- Name
+  {7f764513-d9e8-431c-83f6-df03ed471a24}, !- Source Object
   3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Fan:ConstantVolume,
-  {eed2d317-65b6-4571-a87d-6118ce568bb4}, !- Handle
+  {0d8d394c-53a6-44e5-ae57-79df78388bbd}, !- Handle
   Fan Constant Volume 5,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   AutoSize,                               !- Maximum Flow Rate {m3/s}
   ,                                       !- Motor Efficiency
@@ -3589,13 +2523,13 @@ OS:Fan:ConstantVolume,
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {4b0845ce-27a5-49b8-b7c3-6ea9a7620e8f}, !- Handle
+  {e6e5a2de-dbe7-4f0d-9d27-ff3ef8476f74}, !- Handle
   Coil Heating Water 5,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {fb7e00bd-729c-4d83-9717-27b5ded842ad}, !- Water Inlet Node Name
-  {752d0f03-7869-4e8b-a7c6-33ff902ba9cc}, !- Water Outlet Node Name
+  {812d0bf8-5df2-4a59-90be-c57ed8321036}, !- Water Inlet Node Name
+  {d523245d-de30-4e2a-b415-bc5f37b04418}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -3607,9 +2541,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:DX:SingleSpeed,
-  {db0bdbeb-0ef5-4305-80a5-c883cb52c41a}, !- Handle
+  {12f5404e-d5f9-4ff1-bd52-3d0529d7a722}, !- Handle
   Coil Cooling DX Single Speed 5,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -3617,11 +2551,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {93ccaf6b-cd89-4b0c-bf42-e68617c36e06}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {2037c35a-13b5-4d44-992a-22991dc838f8}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {af11a214-31fb-4bca-b15a-6e2257c1de43}, !- Energy Input Ratio Function of Temperature Curve Name
-  {af38353c-1925-4b6c-928b-50ce74fb13f0}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {344c8084-9ca2-42c5-a2ac-a07083d643c1}, !- Part Load Fraction Correlation Curve Name
+  {3d383f65-516e-4604-9cba-c923518daca5}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {dfbf2470-16c6-44e5-b3c1-f5c2b595df4c}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {0dda2954-d8e4-49e5-b1c4-0d0d2a87ce4c}, !- Energy Input Ratio Function of Temperature Curve Name
+  {ecfd1cfd-eba7-412d-82f7-0a8e3f4f0a4e}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {7ca8720c-f450-457a-a2d8-c6113af2eff7}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -3640,7 +2574,7 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {93ccaf6b-cd89-4b0c-bf42-e68617c36e06}, !- Handle
+  {3d383f65-516e-4604-9cba-c923518daca5}, !- Handle
   Curve Biquadratic 9,                    !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
@@ -3654,7 +2588,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {2037c35a-13b5-4d44-992a-22991dc838f8}, !- Handle
+  {dfbf2470-16c6-44e5-b3c1-f5c2b595df4c}, !- Handle
   Curve Quadratic 13,                     !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
@@ -3663,7 +2597,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {af11a214-31fb-4bca-b15a-6e2257c1de43}, !- Handle
+  {0dda2954-d8e4-49e5-b1c4-0d0d2a87ce4c}, !- Handle
   Curve Biquadratic 10,                   !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
@@ -3677,7 +2611,7 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {af38353c-1925-4b6c-928b-50ce74fb13f0}, !- Handle
+  {ecfd1cfd-eba7-412d-82f7-0a8e3f4f0a4e}, !- Handle
   Curve Quadratic 14,                     !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
@@ -3686,7 +2620,7 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {344c8084-9ca2-42c5-a2ac-a07083d643c1}, !- Handle
+  {7ca8720c-f450-457a-a2d8-c6113af2eff7}, !- Handle
   Curve Quadratic 15,                     !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
@@ -3695,11 +2629,11 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {e392f7a7-deeb-47b4-ba3d-ba2b8849c6ee}, !- Handle
+  {c09ba9ad-c353-403f-b35e-97c65b6fa720}, !- Handle
   Zone HVAC Packaged Terminal Air Conditioner 5, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {52f7d2d5-eb1e-4331-b344-3a6c064c09d7}, !- Air Inlet Node Name
-  {03c88691-1853-467b-b1cb-0bf2bea7137a}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {81d9c421-4291-4b1b-a914-4a1ed0c0885c}, !- Air Inlet Node Name
+  {e7b2e03d-c55d-42c9-9041-07be0e50e57a}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -3708,1471 +2642,306 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {eed2d317-65b6-4571-a87d-6118ce568bb4}, !- Supply Air Fan Name
-  {4b0845ce-27a5-49b8-b7c3-6ea9a7620e8f}, !- Heating Coil Name
-  {db0bdbeb-0ef5-4305-80a5-c883cb52c41a}, !- Cooling Coil Name
+  {0d8d394c-53a6-44e5-ae57-79df78388bbd}, !- Supply Air Fan Name
+  {e6e5a2de-dbe7-4f0d-9d27-ff3ef8476f74}, !- Heating Coil Name
+  {12f5404e-d5f9-4ff1-bd52-3d0529d7a722}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {28117841-37cc-4732-86b5-1b64af9af010}, !- Handle
-  Node 37,                                !- Name
-  {011b5cf9-0e06-43ea-8f19-58de8c01b601}, !- Inlet Port
-  {52f7d2d5-eb1e-4331-b344-3a6c064c09d7}; !- Outlet Port
+  {887f6158-7974-4e91-b15b-d60f0d8198ef}, !- Handle
+  Node 32,                                !- Name
+  {c6fceee1-ce94-4825-a425-d4ec7778c180}, !- Inlet Port
+  {81d9c421-4291-4b1b-a914-4a1ed0c0885c}; !- Outlet Port
 
 OS:Connection,
-  {011b5cf9-0e06-43ea-8f19-58de8c01b601}, !- Handle
-  {11e5eb13-f9ce-42ae-8323-19f4d57efa4f}, !- Name
-  {5180de4f-4692-4a62-a05c-40f6b90ab5d9}, !- Source Object
+  {c6fceee1-ce94-4825-a425-d4ec7778c180}, !- Handle
+  {5dc705a4-283b-4f98-96f3-d085e2aa6d95}, !- Name
+  {b12aca4e-88cd-459f-968b-c179e5aabbf8}, !- Source Object
   3,                                      !- Outlet Port
-  {28117841-37cc-4732-86b5-1b64af9af010}, !- Target Object
+  {887f6158-7974-4e91-b15b-d60f0d8198ef}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {52f7d2d5-eb1e-4331-b344-3a6c064c09d7}, !- Handle
-  {4436d16d-b16a-45b9-94a4-5aee95e16c67}, !- Name
-  {28117841-37cc-4732-86b5-1b64af9af010}, !- Source Object
+  {81d9c421-4291-4b1b-a914-4a1ed0c0885c}, !- Handle
+  {a01b4671-56ab-4824-87f1-7e5c089d9d93}, !- Name
+  {887f6158-7974-4e91-b15b-d60f0d8198ef}, !- Source Object
   3,                                      !- Outlet Port
-  {e392f7a7-deeb-47b4-ba3d-ba2b8849c6ee}, !- Target Object
+  {c09ba9ad-c353-403f-b35e-97c65b6fa720}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {2e7f90ca-d6b2-4163-999a-f62112f1a274}, !- Handle
-  Node 38,                                !- Name
-  {03c88691-1853-467b-b1cb-0bf2bea7137a}, !- Inlet Port
-  {22f2be26-d21c-4e71-b83d-80ef4c7b0a29}; !- Outlet Port
+  {70a8cc46-7149-4e49-8c93-56a9d9f965db}, !- Handle
+  Node 33,                                !- Name
+  {e7b2e03d-c55d-42c9-9041-07be0e50e57a}, !- Inlet Port
+  {c36a321d-b3da-42a8-bff6-b7bb64edb8c3}; !- Outlet Port
 
 OS:Connection,
-  {22f2be26-d21c-4e71-b83d-80ef4c7b0a29}, !- Handle
-  {437dabd4-1d16-491c-81a5-f9218b5a39e5}, !- Name
-  {2e7f90ca-d6b2-4163-999a-f62112f1a274}, !- Source Object
+  {c36a321d-b3da-42a8-bff6-b7bb64edb8c3}, !- Handle
+  {0d1621eb-a49a-4400-a419-78638ae8af8c}, !- Name
+  {70a8cc46-7149-4e49-8c93-56a9d9f965db}, !- Source Object
   3,                                      !- Outlet Port
-  {bc42e547-e08a-4f3a-abff-5d10f7ceb4f4}, !- Target Object
+  {47219d3c-085a-494d-8e4b-891ff4fd07bf}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {03c88691-1853-467b-b1cb-0bf2bea7137a}, !- Handle
-  {7774968d-c261-40f5-bd3e-3b0b43fed4f5}, !- Name
-  {e392f7a7-deeb-47b4-ba3d-ba2b8849c6ee}, !- Source Object
+  {e7b2e03d-c55d-42c9-9041-07be0e50e57a}, !- Handle
+  {f5571d52-7e31-42c5-9fd2-5e17403af89a}, !- Name
+  {c09ba9ad-c353-403f-b35e-97c65b6fa720}, !- Source Object
   4,                                      !- Outlet Port
-  {2e7f90ca-d6b2-4163-999a-f62112f1a274}, !- Target Object
+  {70a8cc46-7149-4e49-8c93-56a9d9f965db}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {a8d2a472-7d4e-4f30-9f21-0224fb4209da}, !- Handle
-  Node 39,                                !- Name
-  {dd07ea94-5d9d-47c9-8523-fa76269f2047}, !- Inlet Port
-  {fb7e00bd-729c-4d83-9717-27b5ded842ad}; !- Outlet Port
+  {d8dc6041-29ca-4ab1-a8ae-8dbce5ff93db}, !- Handle
+  Node 34,                                !- Name
+  {abacaff4-a970-41d5-8c4c-1dd09e446423}, !- Inlet Port
+  {812d0bf8-5df2-4a59-90be-c57ed8321036}; !- Outlet Port
 
 OS:Connection,
-  {dd07ea94-5d9d-47c9-8523-fa76269f2047}, !- Handle
-  {4a1db68c-e57d-442e-bbc2-6113d6da922e}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
+  {abacaff4-a970-41d5-8c4c-1dd09e446423}, !- Handle
+  {ef23926d-2989-40ae-b64b-35f560f4c60d}, !- Name
+  {8f5357e3-bf2f-41a1-a311-ea3523996d32}, !- Source Object
   7,                                      !- Outlet Port
-  {a8d2a472-7d4e-4f30-9f21-0224fb4209da}, !- Target Object
+  {d8dc6041-29ca-4ab1-a8ae-8dbce5ff93db}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {8667bb5e-b96b-43c9-80d0-bc98337e77b6}, !- Handle
-  Node 40,                                !- Name
-  {752d0f03-7869-4e8b-a7c6-33ff902ba9cc}, !- Inlet Port
-  {e6941a15-984f-499f-bdd8-be0fb0b25d9c}; !- Outlet Port
+  {6fd9f9f5-09f3-4748-a10a-8d092f2b767a}, !- Handle
+  Node 35,                                !- Name
+  {d523245d-de30-4e2a-b415-bc5f37b04418}, !- Inlet Port
+  {42880f17-061a-4a54-9902-9b9268e918d7}; !- Outlet Port
 
 OS:Connection,
-  {fb7e00bd-729c-4d83-9717-27b5ded842ad}, !- Handle
-  {9365aac3-5c59-4292-8132-99e568172463}, !- Name
-  {a8d2a472-7d4e-4f30-9f21-0224fb4209da}, !- Source Object
+  {812d0bf8-5df2-4a59-90be-c57ed8321036}, !- Handle
+  {d8c79984-3dc9-4132-94d4-275a669448b7}, !- Name
+  {d8dc6041-29ca-4ab1-a8ae-8dbce5ff93db}, !- Source Object
   3,                                      !- Outlet Port
-  {4b0845ce-27a5-49b8-b7c3-6ea9a7620e8f}, !- Target Object
+  {e6e5a2de-dbe7-4f0d-9d27-ff3ef8476f74}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {752d0f03-7869-4e8b-a7c6-33ff902ba9cc}, !- Handle
-  {9d8fa2fd-2372-4137-90e8-d01d6ab85246}, !- Name
-  {4b0845ce-27a5-49b8-b7c3-6ea9a7620e8f}, !- Source Object
+  {d523245d-de30-4e2a-b415-bc5f37b04418}, !- Handle
+  {8c7703c5-7a23-48d7-99da-334a773ed20b}, !- Name
+  {e6e5a2de-dbe7-4f0d-9d27-ff3ef8476f74}, !- Source Object
   6,                                      !- Outlet Port
-  {8667bb5e-b96b-43c9-80d0-bc98337e77b6}, !- Target Object
+  {6fd9f9f5-09f3-4748-a10a-8d092f2b767a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {e6941a15-984f-499f-bdd8-be0fb0b25d9c}, !- Handle
-  {bc69b21a-95ef-4f0d-89ee-1cf7f5489467}, !- Name
-  {8667bb5e-b96b-43c9-80d0-bc98337e77b6}, !- Source Object
+  {42880f17-061a-4a54-9902-9b9268e918d7}, !- Handle
+  {0306d1cf-ca5e-47e8-9b9f-1d3c45430b18}, !- Name
+  {6fd9f9f5-09f3-4748-a10a-8d092f2b767a}, !- Source Object
   3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
+  {51c4965e-f651-46ee-b0a1-3e8acd52632b}, !- Target Object
   7;                                      !- Inlet Port
 
-OS:Fan:ConstantVolume,
-  {540d60db-d306-484c-ba59-ee6c46c1415f}, !- Handle
-  Fan Constant Volume 6,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
-  500,                                    !- Pressure Rise {Pa}
-  AutoSize,                               !- Maximum Flow Rate {m3/s}
-  ,                                       !- Motor Efficiency
-  ,                                       !- Motor In Airstream Fraction
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ;                                       !- End-Use Subcategory
-
-OS:Coil:Heating:Water,
-  {28c38fa7-0d38-4c8e-9087-2c45310acd33}, !- Handle
-  Coil Heating Water 6,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- U-Factor Times Area Value {W/K}
-  ,                                       !- Maximum Water Flow Rate {m3/s}
-  {6ea24e1c-8e51-416a-a77a-68a8efa39917}, !- Water Inlet Node Name
-  {6d26c40d-9bbb-418b-9cff-d9a17a030351}, !- Water Outlet Node Name
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ,                                       !- Performance Input Method
-  ,                                       !- Rated Capacity {W}
-  ,                                       !- Rated Inlet Water Temperature {C}
-  ,                                       !- Rated Inlet Air Temperature {C}
-  ,                                       !- Rated Outlet Water Temperature {C}
-  ,                                       !- Rated Outlet Air Temperature {C}
-  ;                                       !- Rated Ratio for Air and Water Convection
-
-OS:Coil:Cooling:DX:SingleSpeed,
-  {43a3fa2b-3e21-46a0-8e52-aa67f6be87cb}, !- Handle
-  Coil Cooling DX Single Speed 6,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  autosize,                               !- Rated Total Cooling Capacity {W}
-  autosize,                               !- Rated Sensible Heat Ratio
-  3,                                      !- Rated COP {W/W}
-  autosize,                               !- Rated Air Flow Rate {m3/s}
-  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  {6d873b22-83de-451d-bd0d-1956c5408cca}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {c47edfe9-bd6a-448d-9390-b65b5d45f72a}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {d568a1ef-d00e-4841-b9be-7a00d85bd47a}, !- Energy Input Ratio Function of Temperature Curve Name
-  {820d50c9-ed2e-4188-9932-43afac380f19}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {1967b97d-6630-4d2e-a6c4-6d32e77e44d6}, !- Part Load Fraction Correlation Curve Name
-  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
-  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
-  ,                                       !- Maximum Cycling Rate {cycles/hr}
-  ,                                       !- Latent Capacity Time Constant {s}
-  ,                                       !- Condenser Air Inlet Node Name
-  AirCooled,                              !- Condenser Type
-  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
-  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
-  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
-  0,                                      !- Crankcase Heater Capacity {W}
-  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
-  ,                                       !- Supply Water Storage Tank Name
-  ,                                       !- Condensate Collection Water Storage Tank Name
-  0,                                      !- Basin Heater Capacity {W/K}
-  10,                                     !- Basin Heater Setpoint Temperature {C}
-  ;                                       !- Basin Heater Operating Schedule Name
-
-OS:Curve:Biquadratic,
-  {6d873b22-83de-451d-bd0d-1956c5408cca}, !- Handle
-  Curve Biquadratic 11,                   !- Name
-  0.942587793,                            !- Coefficient1 Constant
-  0.009543347,                            !- Coefficient2 x
-  0.00068377,                             !- Coefficient3 x**2
-  -0.011042676,                           !- Coefficient4 y
-  5.249e-006,                             !- Coefficient5 y**2
-  -9.72e-006,                             !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {c47edfe9-bd6a-448d-9390-b65b5d45f72a}, !- Handle
-  Curve Quadratic 16,                     !- Name
-  0.8,                                    !- Coefficient1 Constant
-  0.2,                                    !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Biquadratic,
-  {d568a1ef-d00e-4841-b9be-7a00d85bd47a}, !- Handle
-  Curve Biquadratic 12,                   !- Name
-  0.342414409,                            !- Coefficient1 Constant
-  0.034885008,                            !- Coefficient2 x
-  -0.0006237,                             !- Coefficient3 x**2
-  0.004977216,                            !- Coefficient4 y
-  0.000437951,                            !- Coefficient5 y**2
-  -0.000728028,                           !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {820d50c9-ed2e-4188-9932-43afac380f19}, !- Handle
-  Curve Quadratic 17,                     !- Name
-  1.1552,                                 !- Coefficient1 Constant
-  -0.1808,                                !- Coefficient2 x
-  0.0256,                                 !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Quadratic,
-  {1967b97d-6630-4d2e-a6c4-6d32e77e44d6}, !- Handle
-  Curve Quadratic 18,                     !- Name
-  0.85,                                   !- Coefficient1 Constant
-  0.15,                                   !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0,                                      !- Minimum Value of x
-  1;                                      !- Maximum Value of x
-
-OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {93451506-96dd-4a2f-96d2-302680f569a9}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 6, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {ddc62318-75d6-4dc6-948e-42affc13fe6c}, !- Air Inlet Node Name
-  {1bf086b5-ec00-4a25-947e-866e3c9038fa}, !- Air Outlet Node Name
-  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
-  ,                                       !- Outdoor Air Mixer Name
-  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {540d60db-d306-484c-ba59-ee6c46c1415f}, !- Supply Air Fan Name
-  {28c38fa7-0d38-4c8e-9087-2c45310acd33}, !- Heating Coil Name
-  {43a3fa2b-3e21-46a0-8e52-aa67f6be87cb}, !- Cooling Coil Name
-  DrawThrough,                            !- Fan Placement
-  ;                                       !- Supply Air Fan Operating Mode Schedule Name
-
-OS:Node,
-  {bba7ccf8-7cc8-42cf-8a82-aaab595c005b}, !- Handle
-  Node 41,                                !- Name
-  {85a62a22-8f26-4016-b7d2-48c150b80872}, !- Inlet Port
-  {ddc62318-75d6-4dc6-948e-42affc13fe6c}; !- Outlet Port
-
-OS:Connection,
-  {85a62a22-8f26-4016-b7d2-48c150b80872}, !- Handle
-  {789c0f9b-feff-4d0b-a117-f30ee37c97c8}, !- Name
-  {124ba351-a8bd-462e-982c-1c211f9954f2}, !- Source Object
-  3,                                      !- Outlet Port
-  {bba7ccf8-7cc8-42cf-8a82-aaab595c005b}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {ddc62318-75d6-4dc6-948e-42affc13fe6c}, !- Handle
-  {ab82112f-15d1-4897-87fe-7393c0906c4d}, !- Name
-  {bba7ccf8-7cc8-42cf-8a82-aaab595c005b}, !- Source Object
-  3,                                      !- Outlet Port
-  {93451506-96dd-4a2f-96d2-302680f569a9}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Node,
-  {1b921557-0a29-43ae-833a-20700d04cba3}, !- Handle
-  Node 42,                                !- Name
-  {1bf086b5-ec00-4a25-947e-866e3c9038fa}, !- Inlet Port
-  {5dc1cadc-f624-4982-a0ee-7ea4d69c057e}; !- Outlet Port
-
-OS:Connection,
-  {5dc1cadc-f624-4982-a0ee-7ea4d69c057e}, !- Handle
-  {88095ed1-5d72-49af-9069-42bd2cf9a020}, !- Name
-  {1b921557-0a29-43ae-833a-20700d04cba3}, !- Source Object
-  3,                                      !- Outlet Port
-  {fd53d6c1-1cca-4bf3-94f9-42352dd33ab4}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Connection,
-  {1bf086b5-ec00-4a25-947e-866e3c9038fa}, !- Handle
-  {350423b2-6344-4c39-9488-2d00f3267a5a}, !- Name
-  {93451506-96dd-4a2f-96d2-302680f569a9}, !- Source Object
-  4,                                      !- Outlet Port
-  {1b921557-0a29-43ae-833a-20700d04cba3}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {02e86cc5-33c1-44a0-b7f4-49d2c31f4479}, !- Handle
-  Node 43,                                !- Name
-  {e5d49dbd-bd69-4067-a737-6bae9e40761e}, !- Inlet Port
-  {6ea24e1c-8e51-416a-a77a-68a8efa39917}; !- Outlet Port
-
-OS:Connection,
-  {e5d49dbd-bd69-4067-a737-6bae9e40761e}, !- Handle
-  {0169c763-a678-4984-8653-786d7d90beb8}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
-  8,                                      !- Outlet Port
-  {02e86cc5-33c1-44a0-b7f4-49d2c31f4479}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {8d47d286-feda-4d6c-809b-ffb135e86dad}, !- Handle
-  Node 44,                                !- Name
-  {6d26c40d-9bbb-418b-9cff-d9a17a030351}, !- Inlet Port
-  {665f4345-03e7-4d0a-a2b4-0e2400602f38}; !- Outlet Port
-
-OS:Connection,
-  {6ea24e1c-8e51-416a-a77a-68a8efa39917}, !- Handle
-  {20cb648a-d1e0-44df-a15c-4e9ef08d2f53}, !- Name
-  {02e86cc5-33c1-44a0-b7f4-49d2c31f4479}, !- Source Object
-  3,                                      !- Outlet Port
-  {28c38fa7-0d38-4c8e-9087-2c45310acd33}, !- Target Object
-  5;                                      !- Inlet Port
-
-OS:Connection,
-  {6d26c40d-9bbb-418b-9cff-d9a17a030351}, !- Handle
-  {74c8a1a1-270f-48c2-b088-165cb2bedd3c}, !- Name
-  {28c38fa7-0d38-4c8e-9087-2c45310acd33}, !- Source Object
-  6,                                      !- Outlet Port
-  {8d47d286-feda-4d6c-809b-ffb135e86dad}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {665f4345-03e7-4d0a-a2b4-0e2400602f38}, !- Handle
-  {dd537267-296c-431a-b765-ff29af4161c6}, !- Name
-  {8d47d286-feda-4d6c-809b-ffb135e86dad}, !- Source Object
-  3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
-  8;                                      !- Inlet Port
-
-OS:Fan:ConstantVolume,
-  {b195485e-39e3-467f-afa6-3af9a4921a1b}, !- Handle
-  Fan Constant Volume 7,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
-  500,                                    !- Pressure Rise {Pa}
-  AutoSize,                               !- Maximum Flow Rate {m3/s}
-  ,                                       !- Motor Efficiency
-  ,                                       !- Motor In Airstream Fraction
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ;                                       !- End-Use Subcategory
-
-OS:Coil:Heating:Water,
-  {c446e6b9-f143-4671-8795-a23c1fb61f6c}, !- Handle
-  Coil Heating Water 7,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- U-Factor Times Area Value {W/K}
-  ,                                       !- Maximum Water Flow Rate {m3/s}
-  {b5e3aa9a-5e90-4d27-8560-54b146b4ee9e}, !- Water Inlet Node Name
-  {168097c8-aea5-4d79-8619-f43cf7d834be}, !- Water Outlet Node Name
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ,                                       !- Performance Input Method
-  ,                                       !- Rated Capacity {W}
-  ,                                       !- Rated Inlet Water Temperature {C}
-  ,                                       !- Rated Inlet Air Temperature {C}
-  ,                                       !- Rated Outlet Water Temperature {C}
-  ,                                       !- Rated Outlet Air Temperature {C}
-  ;                                       !- Rated Ratio for Air and Water Convection
-
-OS:Coil:Cooling:DX:SingleSpeed,
-  {a4c870b0-eeff-4dba-81ba-03921c80a9cf}, !- Handle
-  Coil Cooling DX Single Speed 7,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  autosize,                               !- Rated Total Cooling Capacity {W}
-  autosize,                               !- Rated Sensible Heat Ratio
-  3,                                      !- Rated COP {W/W}
-  autosize,                               !- Rated Air Flow Rate {m3/s}
-  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  {c63ecd2b-f3b5-43da-8322-6b0619e0096f}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {f03422c8-47ff-4c22-b6c8-946c77327f36}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {dc3eda93-e80e-4755-a04a-817c9f983895}, !- Energy Input Ratio Function of Temperature Curve Name
-  {55e3765e-85e5-4b5e-961a-0a54b18d5e03}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {0226cfd5-d82e-4509-a39d-c0ace6a35836}, !- Part Load Fraction Correlation Curve Name
-  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
-  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
-  ,                                       !- Maximum Cycling Rate {cycles/hr}
-  ,                                       !- Latent Capacity Time Constant {s}
-  ,                                       !- Condenser Air Inlet Node Name
-  AirCooled,                              !- Condenser Type
-  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
-  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
-  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
-  0,                                      !- Crankcase Heater Capacity {W}
-  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
-  ,                                       !- Supply Water Storage Tank Name
-  ,                                       !- Condensate Collection Water Storage Tank Name
-  0,                                      !- Basin Heater Capacity {W/K}
-  10,                                     !- Basin Heater Setpoint Temperature {C}
-  ;                                       !- Basin Heater Operating Schedule Name
-
-OS:Curve:Biquadratic,
-  {c63ecd2b-f3b5-43da-8322-6b0619e0096f}, !- Handle
-  Curve Biquadratic 13,                   !- Name
-  0.942587793,                            !- Coefficient1 Constant
-  0.009543347,                            !- Coefficient2 x
-  0.00068377,                             !- Coefficient3 x**2
-  -0.011042676,                           !- Coefficient4 y
-  5.249e-006,                             !- Coefficient5 y**2
-  -9.72e-006,                             !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {f03422c8-47ff-4c22-b6c8-946c77327f36}, !- Handle
-  Curve Quadratic 19,                     !- Name
-  0.8,                                    !- Coefficient1 Constant
-  0.2,                                    !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Biquadratic,
-  {dc3eda93-e80e-4755-a04a-817c9f983895}, !- Handle
-  Curve Biquadratic 14,                   !- Name
-  0.342414409,                            !- Coefficient1 Constant
-  0.034885008,                            !- Coefficient2 x
-  -0.0006237,                             !- Coefficient3 x**2
-  0.004977216,                            !- Coefficient4 y
-  0.000437951,                            !- Coefficient5 y**2
-  -0.000728028,                           !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {55e3765e-85e5-4b5e-961a-0a54b18d5e03}, !- Handle
-  Curve Quadratic 20,                     !- Name
-  1.1552,                                 !- Coefficient1 Constant
-  -0.1808,                                !- Coefficient2 x
-  0.0256,                                 !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Quadratic,
-  {0226cfd5-d82e-4509-a39d-c0ace6a35836}, !- Handle
-  Curve Quadratic 21,                     !- Name
-  0.85,                                   !- Coefficient1 Constant
-  0.15,                                   !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0,                                      !- Minimum Value of x
-  1;                                      !- Maximum Value of x
-
-OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {ce347b13-ebca-4acd-8d58-6d8b6e9a2fe4}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 7, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {5bab3317-8764-4954-87e5-ea834d30197e}, !- Air Inlet Node Name
-  {79a8faca-4a46-4888-ae7d-24463551f7dc}, !- Air Outlet Node Name
-  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
-  ,                                       !- Outdoor Air Mixer Name
-  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {b195485e-39e3-467f-afa6-3af9a4921a1b}, !- Supply Air Fan Name
-  {c446e6b9-f143-4671-8795-a23c1fb61f6c}, !- Heating Coil Name
-  {a4c870b0-eeff-4dba-81ba-03921c80a9cf}, !- Cooling Coil Name
-  DrawThrough,                            !- Fan Placement
-  ;                                       !- Supply Air Fan Operating Mode Schedule Name
-
-OS:Node,
-  {947b7252-5cff-4376-9898-6c5f94e4bc68}, !- Handle
-  Node 45,                                !- Name
-  {d64c33e5-49f9-4751-87ed-b9def7b7aba8}, !- Inlet Port
-  {5bab3317-8764-4954-87e5-ea834d30197e}; !- Outlet Port
-
-OS:Connection,
-  {d64c33e5-49f9-4751-87ed-b9def7b7aba8}, !- Handle
-  {cda9805f-1c0e-4b35-99c3-78d8c31654a7}, !- Name
-  {3e04170b-9ac7-4bdf-9982-cb062edcfe53}, !- Source Object
-  3,                                      !- Outlet Port
-  {947b7252-5cff-4376-9898-6c5f94e4bc68}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {5bab3317-8764-4954-87e5-ea834d30197e}, !- Handle
-  {2d8877ec-9b35-4e49-957f-b236743a4e6a}, !- Name
-  {947b7252-5cff-4376-9898-6c5f94e4bc68}, !- Source Object
-  3,                                      !- Outlet Port
-  {ce347b13-ebca-4acd-8d58-6d8b6e9a2fe4}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Node,
-  {638e72cd-04a9-4efd-bfae-da93d80dd9cd}, !- Handle
-  Node 46,                                !- Name
-  {79a8faca-4a46-4888-ae7d-24463551f7dc}, !- Inlet Port
-  {502406d4-6ac1-4b6f-9bef-c816b434b305}; !- Outlet Port
-
-OS:Connection,
-  {502406d4-6ac1-4b6f-9bef-c816b434b305}, !- Handle
-  {77039a5a-0452-45b8-b1c2-83d3ae6b8b43}, !- Name
-  {638e72cd-04a9-4efd-bfae-da93d80dd9cd}, !- Source Object
-  3,                                      !- Outlet Port
-  {9ccc6d47-c84a-4972-9d7b-d187b4ee0e4b}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Connection,
-  {79a8faca-4a46-4888-ae7d-24463551f7dc}, !- Handle
-  {49c1ba7f-392c-4459-857b-a283712ca7ca}, !- Name
-  {ce347b13-ebca-4acd-8d58-6d8b6e9a2fe4}, !- Source Object
-  4,                                      !- Outlet Port
-  {638e72cd-04a9-4efd-bfae-da93d80dd9cd}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {09bb4884-0d90-435a-9698-ed1da78c1e8f}, !- Handle
-  Node 47,                                !- Name
-  {9cfa4064-fd37-452a-a939-53be7c1d78fc}, !- Inlet Port
-  {b5e3aa9a-5e90-4d27-8560-54b146b4ee9e}; !- Outlet Port
-
-OS:Connection,
-  {9cfa4064-fd37-452a-a939-53be7c1d78fc}, !- Handle
-  {e6202c59-4379-4abb-b199-04e639b8096e}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
-  9,                                      !- Outlet Port
-  {09bb4884-0d90-435a-9698-ed1da78c1e8f}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {f632b620-65ca-471a-bcf2-e346b5b075aa}, !- Handle
-  Node 48,                                !- Name
-  {168097c8-aea5-4d79-8619-f43cf7d834be}, !- Inlet Port
-  {97e57f8d-98f8-49fb-9146-ecfbbb8f19ca}; !- Outlet Port
-
-OS:Connection,
-  {b5e3aa9a-5e90-4d27-8560-54b146b4ee9e}, !- Handle
-  {b0e34fda-32c4-4a33-9b0e-5f8bcd34a707}, !- Name
-  {09bb4884-0d90-435a-9698-ed1da78c1e8f}, !- Source Object
-  3,                                      !- Outlet Port
-  {c446e6b9-f143-4671-8795-a23c1fb61f6c}, !- Target Object
-  5;                                      !- Inlet Port
-
-OS:Connection,
-  {168097c8-aea5-4d79-8619-f43cf7d834be}, !- Handle
-  {bc7db7e9-67f4-4921-a088-4e2add4621cb}, !- Name
-  {c446e6b9-f143-4671-8795-a23c1fb61f6c}, !- Source Object
-  6,                                      !- Outlet Port
-  {f632b620-65ca-471a-bcf2-e346b5b075aa}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {97e57f8d-98f8-49fb-9146-ecfbbb8f19ca}, !- Handle
-  {a07c3119-8916-4e68-a6df-a2ac5725feb8}, !- Name
-  {f632b620-65ca-471a-bcf2-e346b5b075aa}, !- Source Object
-  3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
-  9;                                      !- Inlet Port
-
-OS:Fan:ConstantVolume,
-  {bf889778-9c66-4324-8f8f-ddcade4b3c7e}, !- Handle
-  Fan Constant Volume 8,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
-  500,                                    !- Pressure Rise {Pa}
-  AutoSize,                               !- Maximum Flow Rate {m3/s}
-  ,                                       !- Motor Efficiency
-  ,                                       !- Motor In Airstream Fraction
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ;                                       !- End-Use Subcategory
-
-OS:Coil:Heating:Water,
-  {32d1cd19-5242-4af6-bdfe-bcf92481aa4b}, !- Handle
-  Coil Heating Water 8,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- U-Factor Times Area Value {W/K}
-  ,                                       !- Maximum Water Flow Rate {m3/s}
-  {7f7b190b-6ffe-4c95-acd0-1fd078745323}, !- Water Inlet Node Name
-  {a504ffa8-8634-4b9b-8042-0398662f16bd}, !- Water Outlet Node Name
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ,                                       !- Performance Input Method
-  ,                                       !- Rated Capacity {W}
-  ,                                       !- Rated Inlet Water Temperature {C}
-  ,                                       !- Rated Inlet Air Temperature {C}
-  ,                                       !- Rated Outlet Water Temperature {C}
-  ,                                       !- Rated Outlet Air Temperature {C}
-  ;                                       !- Rated Ratio for Air and Water Convection
-
-OS:Coil:Cooling:DX:SingleSpeed,
-  {5c3295d5-2778-4119-91d0-7c2e4e212c14}, !- Handle
-  Coil Cooling DX Single Speed 8,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  autosize,                               !- Rated Total Cooling Capacity {W}
-  autosize,                               !- Rated Sensible Heat Ratio
-  3,                                      !- Rated COP {W/W}
-  autosize,                               !- Rated Air Flow Rate {m3/s}
-  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  {456f13c7-8ade-4871-9443-d2e4f2be7239}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {89844299-29da-41b7-b7cc-ad5b77648ee4}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {0cddb026-27cc-4fc4-a884-cb9a3523bad7}, !- Energy Input Ratio Function of Temperature Curve Name
-  {519274fc-ee9d-4cf9-b1ef-432aeed0e1b0}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {b88d83f6-66e9-4a30-a7fd-9b75d76e8530}, !- Part Load Fraction Correlation Curve Name
-  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
-  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
-  ,                                       !- Maximum Cycling Rate {cycles/hr}
-  ,                                       !- Latent Capacity Time Constant {s}
-  ,                                       !- Condenser Air Inlet Node Name
-  AirCooled,                              !- Condenser Type
-  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
-  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
-  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
-  0,                                      !- Crankcase Heater Capacity {W}
-  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
-  ,                                       !- Supply Water Storage Tank Name
-  ,                                       !- Condensate Collection Water Storage Tank Name
-  0,                                      !- Basin Heater Capacity {W/K}
-  10,                                     !- Basin Heater Setpoint Temperature {C}
-  ;                                       !- Basin Heater Operating Schedule Name
-
-OS:Curve:Biquadratic,
-  {456f13c7-8ade-4871-9443-d2e4f2be7239}, !- Handle
-  Curve Biquadratic 15,                   !- Name
-  0.942587793,                            !- Coefficient1 Constant
-  0.009543347,                            !- Coefficient2 x
-  0.00068377,                             !- Coefficient3 x**2
-  -0.011042676,                           !- Coefficient4 y
-  5.249e-006,                             !- Coefficient5 y**2
-  -9.72e-006,                             !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {89844299-29da-41b7-b7cc-ad5b77648ee4}, !- Handle
-  Curve Quadratic 22,                     !- Name
-  0.8,                                    !- Coefficient1 Constant
-  0.2,                                    !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Biquadratic,
-  {0cddb026-27cc-4fc4-a884-cb9a3523bad7}, !- Handle
-  Curve Biquadratic 16,                   !- Name
-  0.342414409,                            !- Coefficient1 Constant
-  0.034885008,                            !- Coefficient2 x
-  -0.0006237,                             !- Coefficient3 x**2
-  0.004977216,                            !- Coefficient4 y
-  0.000437951,                            !- Coefficient5 y**2
-  -0.000728028,                           !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {519274fc-ee9d-4cf9-b1ef-432aeed0e1b0}, !- Handle
-  Curve Quadratic 23,                     !- Name
-  1.1552,                                 !- Coefficient1 Constant
-  -0.1808,                                !- Coefficient2 x
-  0.0256,                                 !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Quadratic,
-  {b88d83f6-66e9-4a30-a7fd-9b75d76e8530}, !- Handle
-  Curve Quadratic 24,                     !- Name
-  0.85,                                   !- Coefficient1 Constant
-  0.15,                                   !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0,                                      !- Minimum Value of x
-  1;                                      !- Maximum Value of x
-
-OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {cf784a16-f8f4-4172-9496-cbaf45599740}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 8, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {7251df00-ffdc-4a98-86f2-293d33c40fc1}, !- Air Inlet Node Name
-  {9999be3c-70a8-4122-9cae-5a256c6d7f0f}, !- Air Outlet Node Name
-  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
-  ,                                       !- Outdoor Air Mixer Name
-  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {bf889778-9c66-4324-8f8f-ddcade4b3c7e}, !- Supply Air Fan Name
-  {32d1cd19-5242-4af6-bdfe-bcf92481aa4b}, !- Heating Coil Name
-  {5c3295d5-2778-4119-91d0-7c2e4e212c14}, !- Cooling Coil Name
-  DrawThrough,                            !- Fan Placement
-  ;                                       !- Supply Air Fan Operating Mode Schedule Name
-
-OS:Node,
-  {964fdc7f-e090-4858-ba51-11a75f4d06a2}, !- Handle
-  Node 49,                                !- Name
-  {dc111bda-6187-49ab-8f01-200d01da972c}, !- Inlet Port
-  {7251df00-ffdc-4a98-86f2-293d33c40fc1}; !- Outlet Port
-
-OS:Connection,
-  {dc111bda-6187-49ab-8f01-200d01da972c}, !- Handle
-  {5ec0a89a-a74f-4789-8486-e0053505ef8b}, !- Name
-  {386262c0-4707-4ca5-990e-0f2f7dcf0c9e}, !- Source Object
-  3,                                      !- Outlet Port
-  {964fdc7f-e090-4858-ba51-11a75f4d06a2}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {7251df00-ffdc-4a98-86f2-293d33c40fc1}, !- Handle
-  {065c4d7b-487d-4003-bfd9-db0564929035}, !- Name
-  {964fdc7f-e090-4858-ba51-11a75f4d06a2}, !- Source Object
-  3,                                      !- Outlet Port
-  {cf784a16-f8f4-4172-9496-cbaf45599740}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Node,
-  {57baa286-287e-4032-8776-f6de85182bbc}, !- Handle
-  Node 50,                                !- Name
-  {9999be3c-70a8-4122-9cae-5a256c6d7f0f}, !- Inlet Port
-  {3ea82e9d-1c14-4853-b327-b0d7700597f5}; !- Outlet Port
-
-OS:Connection,
-  {3ea82e9d-1c14-4853-b327-b0d7700597f5}, !- Handle
-  {afc2e448-4481-4160-9d5d-1274deb3f02c}, !- Name
-  {57baa286-287e-4032-8776-f6de85182bbc}, !- Source Object
-  3,                                      !- Outlet Port
-  {f4d76982-320a-477e-a1e4-3731e43b3d92}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Connection,
-  {9999be3c-70a8-4122-9cae-5a256c6d7f0f}, !- Handle
-  {33002716-d523-4ed5-8a93-d0355b2032da}, !- Name
-  {cf784a16-f8f4-4172-9496-cbaf45599740}, !- Source Object
-  4,                                      !- Outlet Port
-  {57baa286-287e-4032-8776-f6de85182bbc}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {4125276d-48c2-4931-929a-07ff07b27bb2}, !- Handle
-  Node 51,                                !- Name
-  {9012ae2e-25e3-489e-898f-89bccb6f7071}, !- Inlet Port
-  {7f7b190b-6ffe-4c95-acd0-1fd078745323}; !- Outlet Port
-
-OS:Connection,
-  {9012ae2e-25e3-489e-898f-89bccb6f7071}, !- Handle
-  {1b97b57f-0230-415e-b89e-7ea6839da639}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
-  10,                                     !- Outlet Port
-  {4125276d-48c2-4931-929a-07ff07b27bb2}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {3c370269-64bc-4e05-84fe-9266432c5d1a}, !- Handle
-  Node 52,                                !- Name
-  {a504ffa8-8634-4b9b-8042-0398662f16bd}, !- Inlet Port
-  {69c43d0f-0937-478e-bfbc-3ec44a22794b}; !- Outlet Port
-
-OS:Connection,
-  {7f7b190b-6ffe-4c95-acd0-1fd078745323}, !- Handle
-  {55a870da-2e12-4eda-96d0-f73dbd740c78}, !- Name
-  {4125276d-48c2-4931-929a-07ff07b27bb2}, !- Source Object
-  3,                                      !- Outlet Port
-  {32d1cd19-5242-4af6-bdfe-bcf92481aa4b}, !- Target Object
-  5;                                      !- Inlet Port
-
-OS:Connection,
-  {a504ffa8-8634-4b9b-8042-0398662f16bd}, !- Handle
-  {309adf9a-94fa-456b-868b-fa0dc9c0e1bd}, !- Name
-  {32d1cd19-5242-4af6-bdfe-bcf92481aa4b}, !- Source Object
-  6,                                      !- Outlet Port
-  {3c370269-64bc-4e05-84fe-9266432c5d1a}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {69c43d0f-0937-478e-bfbc-3ec44a22794b}, !- Handle
-  {04d8290a-abaf-4d00-b323-08dd997a67ea}, !- Name
-  {3c370269-64bc-4e05-84fe-9266432c5d1a}, !- Source Object
-  3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
-  10;                                     !- Inlet Port
-
-OS:Fan:ConstantVolume,
-  {2caca5b7-b49d-4a43-bfa1-b9fa5ed0ab4c}, !- Handle
-  Fan Constant Volume 9,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
-  500,                                    !- Pressure Rise {Pa}
-  AutoSize,                               !- Maximum Flow Rate {m3/s}
-  ,                                       !- Motor Efficiency
-  ,                                       !- Motor In Airstream Fraction
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ;                                       !- End-Use Subcategory
-
-OS:Coil:Heating:Water,
-  {ddafb777-752e-43de-941d-8537ed03165e}, !- Handle
-  Coil Heating Water 9,                   !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- U-Factor Times Area Value {W/K}
-  ,                                       !- Maximum Water Flow Rate {m3/s}
-  {f3dcb189-c4f8-463a-b173-b17651ff2421}, !- Water Inlet Node Name
-  {75679525-80b7-40a2-b8f9-1a72dbf07cb2}, !- Water Outlet Node Name
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ,                                       !- Performance Input Method
-  ,                                       !- Rated Capacity {W}
-  ,                                       !- Rated Inlet Water Temperature {C}
-  ,                                       !- Rated Inlet Air Temperature {C}
-  ,                                       !- Rated Outlet Water Temperature {C}
-  ,                                       !- Rated Outlet Air Temperature {C}
-  ;                                       !- Rated Ratio for Air and Water Convection
-
-OS:Coil:Cooling:DX:SingleSpeed,
-  {d7f9fca1-1454-478e-9299-187fd7fb5ac5}, !- Handle
-  Coil Cooling DX Single Speed 9,         !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  autosize,                               !- Rated Total Cooling Capacity {W}
-  autosize,                               !- Rated Sensible Heat Ratio
-  3,                                      !- Rated COP {W/W}
-  autosize,                               !- Rated Air Flow Rate {m3/s}
-  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  {9072e6e5-135d-4bf3-b747-2ab7569f157e}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {645ecbbb-67c4-4283-b968-c70dfe5a9d6c}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {8821ecd9-1e69-4e72-bbb7-5d19af9e7155}, !- Energy Input Ratio Function of Temperature Curve Name
-  {9a6608de-1b3a-4994-a6a5-7500c21d09ca}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {73c0e531-0712-4c3b-b12f-8c0c179e42a1}, !- Part Load Fraction Correlation Curve Name
-  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
-  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
-  ,                                       !- Maximum Cycling Rate {cycles/hr}
-  ,                                       !- Latent Capacity Time Constant {s}
-  ,                                       !- Condenser Air Inlet Node Name
-  AirCooled,                              !- Condenser Type
-  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
-  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
-  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
-  0,                                      !- Crankcase Heater Capacity {W}
-  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
-  ,                                       !- Supply Water Storage Tank Name
-  ,                                       !- Condensate Collection Water Storage Tank Name
-  0,                                      !- Basin Heater Capacity {W/K}
-  10,                                     !- Basin Heater Setpoint Temperature {C}
-  ;                                       !- Basin Heater Operating Schedule Name
-
-OS:Curve:Biquadratic,
-  {9072e6e5-135d-4bf3-b747-2ab7569f157e}, !- Handle
-  Curve Biquadratic 17,                   !- Name
-  0.942587793,                            !- Coefficient1 Constant
-  0.009543347,                            !- Coefficient2 x
-  0.00068377,                             !- Coefficient3 x**2
-  -0.011042676,                           !- Coefficient4 y
-  5.249e-006,                             !- Coefficient5 y**2
-  -9.72e-006,                             !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {645ecbbb-67c4-4283-b968-c70dfe5a9d6c}, !- Handle
-  Curve Quadratic 25,                     !- Name
-  0.8,                                    !- Coefficient1 Constant
-  0.2,                                    !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Biquadratic,
-  {8821ecd9-1e69-4e72-bbb7-5d19af9e7155}, !- Handle
-  Curve Biquadratic 18,                   !- Name
-  0.342414409,                            !- Coefficient1 Constant
-  0.034885008,                            !- Coefficient2 x
-  -0.0006237,                             !- Coefficient3 x**2
-  0.004977216,                            !- Coefficient4 y
-  0.000437951,                            !- Coefficient5 y**2
-  -0.000728028,                           !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {9a6608de-1b3a-4994-a6a5-7500c21d09ca}, !- Handle
-  Curve Quadratic 26,                     !- Name
-  1.1552,                                 !- Coefficient1 Constant
-  -0.1808,                                !- Coefficient2 x
-  0.0256,                                 !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Quadratic,
-  {73c0e531-0712-4c3b-b12f-8c0c179e42a1}, !- Handle
-  Curve Quadratic 27,                     !- Name
-  0.85,                                   !- Coefficient1 Constant
-  0.15,                                   !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0,                                      !- Minimum Value of x
-  1;                                      !- Maximum Value of x
-
-OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {49f975db-a34b-4b97-bc85-282c4277d8b9}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 9, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {16e80c11-b7a6-4234-9b54-a28760bd42c8}, !- Air Inlet Node Name
-  {5def4685-4e84-4340-a0ca-5147d62cc2d8}, !- Air Outlet Node Name
-  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
-  ,                                       !- Outdoor Air Mixer Name
-  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {2caca5b7-b49d-4a43-bfa1-b9fa5ed0ab4c}, !- Supply Air Fan Name
-  {ddafb777-752e-43de-941d-8537ed03165e}, !- Heating Coil Name
-  {d7f9fca1-1454-478e-9299-187fd7fb5ac5}, !- Cooling Coil Name
-  DrawThrough,                            !- Fan Placement
-  ;                                       !- Supply Air Fan Operating Mode Schedule Name
-
-OS:Node,
-  {fb3dc71b-fb01-4265-989d-d3a3d559308f}, !- Handle
-  Node 53,                                !- Name
-  {fc7ea79a-2428-458e-9b1e-1fa4c19389e5}, !- Inlet Port
-  {16e80c11-b7a6-4234-9b54-a28760bd42c8}; !- Outlet Port
-
-OS:Connection,
-  {fc7ea79a-2428-458e-9b1e-1fa4c19389e5}, !- Handle
-  {5a1db016-73bc-4cfd-8707-ee0cadc0858f}, !- Name
-  {d1dae1a8-17c9-4e6a-8bb0-6419ac6da506}, !- Source Object
-  3,                                      !- Outlet Port
-  {fb3dc71b-fb01-4265-989d-d3a3d559308f}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {16e80c11-b7a6-4234-9b54-a28760bd42c8}, !- Handle
-  {84396da4-ea78-4e17-88a9-d50e9ae80558}, !- Name
-  {fb3dc71b-fb01-4265-989d-d3a3d559308f}, !- Source Object
-  3,                                      !- Outlet Port
-  {49f975db-a34b-4b97-bc85-282c4277d8b9}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Node,
-  {00ade827-141d-4501-b1ac-57467b655acf}, !- Handle
-  Node 54,                                !- Name
-  {5def4685-4e84-4340-a0ca-5147d62cc2d8}, !- Inlet Port
-  {cde1c684-991d-4376-b35e-09003a47a633}; !- Outlet Port
-
-OS:Connection,
-  {cde1c684-991d-4376-b35e-09003a47a633}, !- Handle
-  {1bb17b6a-1fe2-4cc1-ba70-d012ef868f56}, !- Name
-  {00ade827-141d-4501-b1ac-57467b655acf}, !- Source Object
-  3,                                      !- Outlet Port
-  {1a1eee6b-08ce-4f55-a05a-7e9b4b24c843}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Connection,
-  {5def4685-4e84-4340-a0ca-5147d62cc2d8}, !- Handle
-  {81c740ea-0013-4d03-8d75-463998034bad}, !- Name
-  {49f975db-a34b-4b97-bc85-282c4277d8b9}, !- Source Object
-  4,                                      !- Outlet Port
-  {00ade827-141d-4501-b1ac-57467b655acf}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {3d62aae4-8ee5-43cf-90a2-3eceb11a50d6}, !- Handle
-  Node 55,                                !- Name
-  {146f2fc4-b443-4988-bd9b-7f0aec4150f0}, !- Inlet Port
-  {f3dcb189-c4f8-463a-b173-b17651ff2421}; !- Outlet Port
-
-OS:Connection,
-  {146f2fc4-b443-4988-bd9b-7f0aec4150f0}, !- Handle
-  {1a1fb7e0-40bb-466e-90ba-1008cb64b495}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
-  11,                                     !- Outlet Port
-  {3d62aae4-8ee5-43cf-90a2-3eceb11a50d6}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {141780d6-8b4a-42ef-812d-1d54ba8d4a9c}, !- Handle
-  Node 56,                                !- Name
-  {75679525-80b7-40a2-b8f9-1a72dbf07cb2}, !- Inlet Port
-  {76033de2-150f-49db-851c-26c9625cdac6}; !- Outlet Port
-
-OS:Connection,
-  {f3dcb189-c4f8-463a-b173-b17651ff2421}, !- Handle
-  {55e8b02a-cef0-433a-9dcd-20649d784c6f}, !- Name
-  {3d62aae4-8ee5-43cf-90a2-3eceb11a50d6}, !- Source Object
-  3,                                      !- Outlet Port
-  {ddafb777-752e-43de-941d-8537ed03165e}, !- Target Object
-  5;                                      !- Inlet Port
-
-OS:Connection,
-  {75679525-80b7-40a2-b8f9-1a72dbf07cb2}, !- Handle
-  {820adfa2-84ec-4f8c-8b07-81ff3267f544}, !- Name
-  {ddafb777-752e-43de-941d-8537ed03165e}, !- Source Object
-  6,                                      !- Outlet Port
-  {141780d6-8b4a-42ef-812d-1d54ba8d4a9c}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {76033de2-150f-49db-851c-26c9625cdac6}, !- Handle
-  {976efac5-2c9f-4052-9174-001492853d86}, !- Name
-  {141780d6-8b4a-42ef-812d-1d54ba8d4a9c}, !- Source Object
-  3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
-  11;                                     !- Inlet Port
-
-OS:Fan:ConstantVolume,
-  {63e7143d-aeb1-478f-b6a5-760396b34542}, !- Handle
-  Fan Constant Volume 10,                 !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- Fan Efficiency
-  500,                                    !- Pressure Rise {Pa}
-  AutoSize,                               !- Maximum Flow Rate {m3/s}
-  ,                                       !- Motor Efficiency
-  ,                                       !- Motor In Airstream Fraction
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ;                                       !- End-Use Subcategory
-
-OS:Coil:Heating:Water,
-  {c9143bee-0fe6-491d-8f82-18b39847db1a}, !- Handle
-  Coil Heating Water 10,                  !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  ,                                       !- U-Factor Times Area Value {W/K}
-  ,                                       !- Maximum Water Flow Rate {m3/s}
-  {60bdb8da-1859-4378-b6eb-b24851f7b0bc}, !- Water Inlet Node Name
-  {efdd2ad1-96b6-447c-a13a-7405f2cde95b}, !- Water Outlet Node Name
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  ,                                       !- Performance Input Method
-  ,                                       !- Rated Capacity {W}
-  ,                                       !- Rated Inlet Water Temperature {C}
-  ,                                       !- Rated Inlet Air Temperature {C}
-  ,                                       !- Rated Outlet Water Temperature {C}
-  ,                                       !- Rated Outlet Air Temperature {C}
-  ;                                       !- Rated Ratio for Air and Water Convection
-
-OS:Coil:Cooling:DX:SingleSpeed,
-  {eae366ae-c33b-4479-bfab-fd9544c6fddd}, !- Handle
-  Coil Cooling DX Single Speed 10,        !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  autosize,                               !- Rated Total Cooling Capacity {W}
-  autosize,                               !- Rated Sensible Heat Ratio
-  3,                                      !- Rated COP {W/W}
-  autosize,                               !- Rated Air Flow Rate {m3/s}
-  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
-  ,                                       !- Air Inlet Node Name
-  ,                                       !- Air Outlet Node Name
-  {adb584c4-df86-466c-aace-fdb0bb56ac15}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {0b97e96a-e5d8-4190-b87c-7a0d259ada4e}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {443883a4-9f4d-4b6b-a7f1-ca6541b33b43}, !- Energy Input Ratio Function of Temperature Curve Name
-  {fa2998de-5092-444e-9bc5-3c0130e6a522}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {97ba0d7c-6196-4858-aed2-5084527f4b9b}, !- Part Load Fraction Correlation Curve Name
-  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
-  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
-  ,                                       !- Maximum Cycling Rate {cycles/hr}
-  ,                                       !- Latent Capacity Time Constant {s}
-  ,                                       !- Condenser Air Inlet Node Name
-  AirCooled,                              !- Condenser Type
-  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
-  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
-  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
-  0,                                      !- Crankcase Heater Capacity {W}
-  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
-  ,                                       !- Supply Water Storage Tank Name
-  ,                                       !- Condensate Collection Water Storage Tank Name
-  0,                                      !- Basin Heater Capacity {W/K}
-  10,                                     !- Basin Heater Setpoint Temperature {C}
-  ;                                       !- Basin Heater Operating Schedule Name
-
-OS:Curve:Biquadratic,
-  {adb584c4-df86-466c-aace-fdb0bb56ac15}, !- Handle
-  Curve Biquadratic 19,                   !- Name
-  0.942587793,                            !- Coefficient1 Constant
-  0.009543347,                            !- Coefficient2 x
-  0.00068377,                             !- Coefficient3 x**2
-  -0.011042676,                           !- Coefficient4 y
-  5.249e-006,                             !- Coefficient5 y**2
-  -9.72e-006,                             !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {0b97e96a-e5d8-4190-b87c-7a0d259ada4e}, !- Handle
-  Curve Quadratic 28,                     !- Name
-  0.8,                                    !- Coefficient1 Constant
-  0.2,                                    !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Biquadratic,
-  {443883a4-9f4d-4b6b-a7f1-ca6541b33b43}, !- Handle
-  Curve Biquadratic 20,                   !- Name
-  0.342414409,                            !- Coefficient1 Constant
-  0.034885008,                            !- Coefficient2 x
-  -0.0006237,                             !- Coefficient3 x**2
-  0.004977216,                            !- Coefficient4 y
-  0.000437951,                            !- Coefficient5 y**2
-  -0.000728028,                           !- Coefficient6 x*y
-  17,                                     !- Minimum Value of x
-  22,                                     !- Maximum Value of x
-  13,                                     !- Minimum Value of y
-  46;                                     !- Maximum Value of y
-
-OS:Curve:Quadratic,
-  {fa2998de-5092-444e-9bc5-3c0130e6a522}, !- Handle
-  Curve Quadratic 29,                     !- Name
-  1.1552,                                 !- Coefficient1 Constant
-  -0.1808,                                !- Coefficient2 x
-  0.0256,                                 !- Coefficient3 x**2
-  0.5,                                    !- Minimum Value of x
-  1.5;                                    !- Maximum Value of x
-
-OS:Curve:Quadratic,
-  {97ba0d7c-6196-4858-aed2-5084527f4b9b}, !- Handle
-  Curve Quadratic 30,                     !- Name
-  0.85,                                   !- Coefficient1 Constant
-  0.15,                                   !- Coefficient2 x
-  0,                                      !- Coefficient3 x**2
-  0,                                      !- Minimum Value of x
-  1;                                      !- Maximum Value of x
-
-OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {cf66dac8-d5ab-4c26-8d58-49a9922fc410}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 10, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {3ae0b5c4-8cf0-4b37-bfc2-8544b1bea84a}, !- Air Inlet Node Name
-  {7e022178-9e57-4553-9700-0a43ad046295}, !- Air Outlet Node Name
-  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
-  ,                                       !- Outdoor Air Mixer Name
-  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
-  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {63e7143d-aeb1-478f-b6a5-760396b34542}, !- Supply Air Fan Name
-  {c9143bee-0fe6-491d-8f82-18b39847db1a}, !- Heating Coil Name
-  {eae366ae-c33b-4479-bfab-fd9544c6fddd}, !- Cooling Coil Name
-  DrawThrough,                            !- Fan Placement
-  ;                                       !- Supply Air Fan Operating Mode Schedule Name
-
-OS:Node,
-  {11dc8498-d3e2-46e7-b2ea-b8f7948a5b08}, !- Handle
-  Node 57,                                !- Name
-  {adc06aea-9e47-4776-8dd1-0f07269f29d0}, !- Inlet Port
-  {3ae0b5c4-8cf0-4b37-bfc2-8544b1bea84a}; !- Outlet Port
-
-OS:Connection,
-  {adc06aea-9e47-4776-8dd1-0f07269f29d0}, !- Handle
-  {6ed16512-b10a-42de-8c51-c24265db6d17}, !- Name
-  {6355ef35-e3d1-4b15-803a-c5be4b4ff43e}, !- Source Object
-  3,                                      !- Outlet Port
-  {11dc8498-d3e2-46e7-b2ea-b8f7948a5b08}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {3ae0b5c4-8cf0-4b37-bfc2-8544b1bea84a}, !- Handle
-  {4707f09f-5cf3-49fb-93c2-f53951b486ec}, !- Name
-  {11dc8498-d3e2-46e7-b2ea-b8f7948a5b08}, !- Source Object
-  3,                                      !- Outlet Port
-  {cf66dac8-d5ab-4c26-8d58-49a9922fc410}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Node,
-  {8bb4bd0f-b5cf-4315-bb42-0744d9a26ca0}, !- Handle
-  Node 58,                                !- Name
-  {7e022178-9e57-4553-9700-0a43ad046295}, !- Inlet Port
-  {9f372654-9de9-4a9b-ba54-5acad4246678}; !- Outlet Port
-
-OS:Connection,
-  {9f372654-9de9-4a9b-ba54-5acad4246678}, !- Handle
-  {47217e8f-201a-4b46-b99d-b15f3b97bc72}, !- Name
-  {8bb4bd0f-b5cf-4315-bb42-0744d9a26ca0}, !- Source Object
-  3,                                      !- Outlet Port
-  {f276d0f4-314a-4020-b20f-f685a8637706}, !- Target Object
-  3;                                      !- Inlet Port
-
-OS:Connection,
-  {7e022178-9e57-4553-9700-0a43ad046295}, !- Handle
-  {689fee0d-79c2-4265-9d80-6828816174fb}, !- Name
-  {cf66dac8-d5ab-4c26-8d58-49a9922fc410}, !- Source Object
-  4,                                      !- Outlet Port
-  {8bb4bd0f-b5cf-4315-bb42-0744d9a26ca0}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {354cc289-80f4-4ad2-bc43-1b588d28eb03}, !- Handle
-  Node 59,                                !- Name
-  {252efde4-750a-4453-bc58-4c7f69efd8ff}, !- Inlet Port
-  {60bdb8da-1859-4378-b6eb-b24851f7b0bc}; !- Outlet Port
-
-OS:Connection,
-  {252efde4-750a-4453-bc58-4c7f69efd8ff}, !- Handle
-  {e16496fc-d579-4dfe-9fcc-358b9f9b240a}, !- Name
-  {1e3ed366-53c6-495b-8fd1-46fec12be11b}, !- Source Object
-  12,                                     !- Outlet Port
-  {354cc289-80f4-4ad2-bc43-1b588d28eb03}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Node,
-  {bb43cb69-0876-4a75-a0ef-e533a16af043}, !- Handle
-  Node 60,                                !- Name
-  {efdd2ad1-96b6-447c-a13a-7405f2cde95b}, !- Inlet Port
-  {0600a2fc-8bd1-487d-bccc-963c7503569b}; !- Outlet Port
-
-OS:Connection,
-  {60bdb8da-1859-4378-b6eb-b24851f7b0bc}, !- Handle
-  {8fcfc137-d26c-400c-bc2f-1f9660b40cf4}, !- Name
-  {354cc289-80f4-4ad2-bc43-1b588d28eb03}, !- Source Object
-  3,                                      !- Outlet Port
-  {c9143bee-0fe6-491d-8f82-18b39847db1a}, !- Target Object
-  5;                                      !- Inlet Port
-
-OS:Connection,
-  {efdd2ad1-96b6-447c-a13a-7405f2cde95b}, !- Handle
-  {554278cf-3784-446d-9e6b-1c2d42d40d85}, !- Name
-  {c9143bee-0fe6-491d-8f82-18b39847db1a}, !- Source Object
-  6,                                      !- Outlet Port
-  {bb43cb69-0876-4a75-a0ef-e533a16af043}, !- Target Object
-  2;                                      !- Inlet Port
-
-OS:Connection,
-  {0600a2fc-8bd1-487d-bccc-963c7503569b}, !- Handle
-  {2ccd8816-acd8-4744-943a-ec413defe5ae}, !- Name
-  {bb43cb69-0876-4a75-a0ef-e533a16af043}, !- Source Object
-  3,                                      !- Outlet Port
-  {81f5d84c-19b9-4e36-99c0-51ac88d23d6c}, !- Target Object
-  12;                                     !- Inlet Port
-
 OS:Schedule:Ruleset,
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}, !- Handle
+  {be33479d-4f8e-4990-85eb-e647625e6741}, !- Handle
   Cooling Sch,                            !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
-  {151d21d0-ea95-4f56-8de2-74d2eaf2584d}; !- Default Day Schedule Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
+  {494d797f-01e6-40be-ab29-af53f48c48e5}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {151d21d0-ea95-4f56-8de2-74d2eaf2584d}, !- Handle
+  {494d797f-01e6-40be-ab29-af53f48c48e5}, !- Handle
   Cooling Sch Default,                    !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   28;                                     !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Handle
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Handle
   Heating Sch,                            !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
-  {6876c411-37dc-4580-ae85-8649aca46b81}; !- Default Day Schedule Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
+  {4bea8a74-9814-4577-8908-d68192b0b3e4}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {6876c411-37dc-4580-ae85-8649aca46b81}, !- Handle
+  {4bea8a74-9814-4577-8908-d68192b0b3e4}, !- Handle
   Heating Sch Default,                    !- Name
-  {a79e2d1d-2b98-47c3-b90b-45fb7ba55b8d}, !- Schedule Type Limits Name
+  {13072123-b23a-4a2b-ac43-24512bb381b6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   24;                                     !- Value Until Time 1
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {bed0b605-f8a7-47b7-aef1-d3b63b268385}, !- Handle
+  {aae27556-d170-4dce-aa72-b033954abc0f}, !- Handle
   Thermostat Setpoint Dual Setpoint 1,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Heating Setpoint Temperature Schedule Name
+  {be33479d-4f8e-4990-85eb-e647625e6741}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {9f64ee4f-7edf-45dc-8b2d-de1915fe7273}, !- Handle
+  {b1bb50ea-6a52-4645-8153-7ca4fd10b49d}, !- Handle
   Thermostat Setpoint Dual Setpoint 2,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Heating Setpoint Temperature Schedule Name
+  {be33479d-4f8e-4990-85eb-e647625e6741}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {c48bec1b-afad-4083-9264-8bfde163092f}, !- Handle
+  {8e5f64d6-04a0-4d79-97b2-b1ce31d44719}, !- Handle
   Thermostat Setpoint Dual Setpoint 3,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Heating Setpoint Temperature Schedule Name
+  {be33479d-4f8e-4990-85eb-e647625e6741}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {910bab7a-5ad5-43f7-ad1a-c16048b95fac}, !- Handle
+  {ab9d5e61-6237-4786-98b1-d136f7087bea}, !- Handle
   Thermostat Setpoint Dual Setpoint 4,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Heating Setpoint Temperature Schedule Name
+  {be33479d-4f8e-4990-85eb-e647625e6741}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {512d858c-c00d-4393-a43c-d02166fd4c95}, !- Handle
+  {84ac8a6b-3730-4cb4-8087-b9412eb746a4}, !- Handle
   Thermostat Setpoint Dual Setpoint 5,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:ThermostatSetpoint:DualSetpoint,
-  {c94704c5-461e-4482-a2ad-c111b7b07414}, !- Handle
-  Thermostat Setpoint Dual Setpoint 6,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:ThermostatSetpoint:DualSetpoint,
-  {37397690-97fc-47a7-bc4f-d242f13ab812}, !- Handle
-  Thermostat Setpoint Dual Setpoint 7,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:ThermostatSetpoint:DualSetpoint,
-  {ec0079e9-50f9-4d89-892e-077e3a414f2f}, !- Handle
-  Thermostat Setpoint Dual Setpoint 8,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:ThermostatSetpoint:DualSetpoint,
-  {8ac1fe18-32cd-42ac-b3d9-99667a6f7f9b}, !- Handle
-  Thermostat Setpoint Dual Setpoint 9,    !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
-
-OS:ThermostatSetpoint:DualSetpoint,
-  {70981c80-84b2-4d10-9dba-5fcee96d7e1c}, !- Handle
-  Thermostat Setpoint Dual Setpoint 10,   !- Name
-  {01d899e0-ffc5-4e02-a233-23476b8ebdfa}, !- Heating Setpoint Temperature Schedule Name
-  {1491e89c-8bab-442b-8bfd-6b25279f4e66}; !- Cooling Setpoint Temperature Schedule Name
+  {7fcfc640-761c-4cb5-837d-bcdc9145ed23}, !- Heating Setpoint Temperature Schedule Name
+  {be33479d-4f8e-4990-85eb-e647625e6741}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:DefaultConstructionSet,
-  {82ddd438-0845-4ab2-b530-1fbbcb61f489}, ! Handle
+  {8e16f99d-7f51-451a-b8a2-0d1eaccda44e}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_ConstSet, ! Name
-  {c5fec95b-ada0-4f24-9716-9cd37146c6e9}, ! Default Exterior Surface Constructions Name
-  {acc6e102-c45a-4cac-89fe-4b8c7cd3f616}, ! Default Interior Surface Constructions Name
-  {48369205-0139-46ce-a6ad-58f183b30c7d}, ! Default Ground Contact Surface Constructions Name
-  {43e91753-6fba-43a4-9490-edeb217df465}, ! Default Exterior SubSurface Constructions Name
-  {e52419e5-d416-47ce-a09f-db8861912c90}, ! Default Interior SubSurface Constructions Name
-  {12d33c26-b3ce-4657-ab3b-992bd26fe422}, ! Interior Partition Construction Name
+  {dfcbdcca-e73e-4144-bcfe-7786ced80463}, ! Default Exterior Surface Constructions Name
+  {055d655b-8f6c-490c-a070-3ebf98a94e48}, ! Default Interior Surface Constructions Name
+  {9918704b-26d3-40e2-b8e0-f3cbe94ae2d6}, ! Default Ground Contact Surface Constructions Name
+  {44a14867-c10c-4bc3-aa35-7b51a9d8a03a}, ! Default Exterior SubSurface Constructions Name
+  {c4837a8b-6db9-4aa2-9272-420667e6c645}, ! Default Interior SubSurface Constructions Name
+  {82f23212-78f9-4c07-ad39-e25cc41edfc1}, ! Interior Partition Construction Name
   ,                                       ! Space Shading Construction Name
   ,                                       ! Building Shading Construction Name
   ;                                       ! Site Shading Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {c5fec95b-ada0-4f24-9716-9cd37146c6e9}, ! Handle
+  {dfcbdcca-e73e-4144-bcfe-7786ced80463}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSurfCons, ! Name
-  {e49e13e2-06e6-48c3-bdbf-bd6dc1ecd75e}, ! Floor Construction Name
-  {0c20ae5f-17a2-4371-8cbf-230be2da9a01}, ! Wall Construction Name
-  {8bf09872-be7e-4040-b6c6-340a46ec46d4}; ! Roof Ceiling Construction Name
+  {e4f76876-e0ac-4a90-b12e-2f06d95609e1}, ! Floor Construction Name
+  {44a805e1-222a-4f48-b7cb-a60b3d527ed1}, ! Wall Construction Name
+  {eb27ad07-9483-444d-a87f-429828f0811f}; ! Roof Ceiling Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {acc6e102-c45a-4cac-89fe-4b8c7cd3f616}, ! Handle
+  {055d655b-8f6c-490c-a070-3ebf98a94e48}, ! Handle
   000_Interior_DefSurfCons,               ! Name
-  {88ec2268-d00c-4152-8d28-d4f3f9fe62e5}, ! Floor Construction Name
-  {121b88f7-1bd4-4df9-be12-e7e081947fd7}, ! Wall Construction Name
-  {68042db8-241e-4c07-aebc-32d1fa3d2a00}; ! Roof Ceiling Construction Name
+  {e3d5080c-2924-4139-a923-a8c061d921cc}, ! Floor Construction Name
+  {4b50c788-485a-49ee-9e34-92ccf9a588b5}, ! Wall Construction Name
+  {2a461233-5695-4b4b-8fd4-2e4a3394c078}; ! Roof Ceiling Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {48369205-0139-46ce-a6ad-58f183b30c7d}, ! Handle
+  {9918704b-26d3-40e2-b8e0-f3cbe94ae2d6}, ! Handle
   000_Ground_DefSurfCons,                 ! Name
-  {e49e13e2-06e6-48c3-bdbf-bd6dc1ecd75e}, ! Floor Construction Name
-  {e49e13e2-06e6-48c3-bdbf-bd6dc1ecd75e}, ! Wall Construction Name
-  {e49e13e2-06e6-48c3-bdbf-bd6dc1ecd75e}; ! Roof Ceiling Construction Name
+  {e4f76876-e0ac-4a90-b12e-2f06d95609e1}, ! Floor Construction Name
+  {e4f76876-e0ac-4a90-b12e-2f06d95609e1}, ! Wall Construction Name
+  {e4f76876-e0ac-4a90-b12e-2f06d95609e1}; ! Roof Ceiling Construction Name
 
 OS:DefaultSubSurfaceConstructions,
-  {43e91753-6fba-43a4-9490-edeb217df465}, ! Handle
+  {44a14867-c10c-4bc3-aa35-7b51a9d8a03a}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSubCons, ! Name
-  {9fb083ec-6cd2-443b-bce2-1af9742a6922}, ! Fixed Window Construction Name
-  {9fb083ec-6cd2-443b-bce2-1af9742a6922}, ! Operable Window Construction Name
-  {dca18647-b256-48f8-9412-c707ff956666}, ! Door Construction Name
-  {789d2b30-d66d-4606-9b07-ce59999fb22a}, ! Glass Door Construction Name
+  {e58df250-1a29-4f22-8324-8357e8d1efc3}, ! Fixed Window Construction Name
+  {e58df250-1a29-4f22-8324-8357e8d1efc3}, ! Operable Window Construction Name
+  {62fe7b23-50c2-49c0-a831-962adec3925e}, ! Door Construction Name
+  {85e421aa-5753-436c-b44c-38b5d0517a05}, ! Glass Door Construction Name
   ,                                       ! Overhead Door Construction Name
-  {789d2b30-d66d-4606-9b07-ce59999fb22a}, ! Skylight Construction Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}, ! Tubular Daylight Dome Construction Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}; ! Tubular Daylight Diffuser Construction Name
+  {85e421aa-5753-436c-b44c-38b5d0517a05}, ! Skylight Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}, ! Tubular Daylight Dome Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}; ! Tubular Daylight Diffuser Construction Name
 
 OS:DefaultSubSurfaceConstructions,
-  {e52419e5-d416-47ce-a09f-db8861912c90}, ! Handle
+  {c4837a8b-6db9-4aa2-9272-420667e6c645}, ! Handle
   000_Interior_DefSubCons,                ! Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}, ! Fixed Window Construction Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}, ! Operable Window Construction Name
-  {5903f599-9cd2-4905-a60a-f63ddb384a25}, ! Door Construction Name
-  {789d2b30-d66d-4606-9b07-ce59999fb22a}, ! Glass Door Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}, ! Fixed Window Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}, ! Operable Window Construction Name
+  {ff9885cd-addd-4163-b9c1-ce3e0ba9f2c3}, ! Door Construction Name
+  {85e421aa-5753-436c-b44c-38b5d0517a05}, ! Glass Door Construction Name
   ,                                       ! Overhead Door Construction Name
-  {789d2b30-d66d-4606-9b07-ce59999fb22a}, ! Skylight Construction Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}, ! Tubular Daylight Dome Construction Name
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}; ! Tubular Daylight Diffuser Construction Name
+  {85e421aa-5753-436c-b44c-38b5d0517a05}, ! Skylight Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}, ! Tubular Daylight Dome Construction Name
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}; ! Tubular Daylight Diffuser Construction Name
 
 OS:Construction,
-  {12d33c26-b3ce-4657-ab3b-992bd26fe422}, ! Handle
+  {82f23212-78f9-4c07-ad39-e25cc41edfc1}, ! Handle
   000_Interior Partition,                 ! Name
   ,                                       ! Surface Rendering Name
-  {7f2dd5ea-284f-4ad5-a44a-28d7b93d78a1}; ! Layer 1
+  {c37ff251-ea9a-4a2c-ad46-dfccc63ac14b}; ! Layer 1
 
 OS:Construction,
-  {e49e13e2-06e6-48c3-bdbf-bd6dc1ecd75e}, ! Handle
+  {e4f76876-e0ac-4a90-b12e-2f06d95609e1}, ! Handle
   000_ExtSlabCarpet_4in_ClimateZone 1-8,  ! Name
   ,                                       ! Surface Rendering Name
-  {9b9c2966-7e8a-4c47-9fa7-c34aa74c305f}, ! Layer 1
-  {2047a824-818b-4954-8596-88d1c54bd4e0}; ! Layer 2
+  {ad01420f-94c6-4f18-bd3f-e8bcfbfe92ed}, ! Layer 1
+  {b19671e1-d4c5-418e-8db6-e4b949aa71ea}; ! Layer 2
 
 OS:Construction,
-  {0c20ae5f-17a2-4371-8cbf-230be2da9a01}, ! Handle
+  {44a805e1-222a-4f48-b7cb-a60b3d527ed1}, ! Handle
   ASHRAE_189.1-2009_ExtWall_SteelFrame_ClimateZone 4-8, ! Name
   ,                                       ! Surface Rendering Name
-  {3aa4534a-0e50-4f71-a82a-21528396dc2a}, ! Layer 1
-  {c6dcc785-89ba-4d40-b7a2-23684b1d39f1}, ! Layer 2
-  {3d1bd931-d14c-4e35-bdb4-9bf5c74a5e09}; ! Layer 3
+  {b698e3b9-7243-438e-b3e4-86cd4d0d6cfa}, ! Layer 1
+  {d5ffd0f2-990c-4db4-8d9f-10980f2b4b16}, ! Layer 2
+  {7e628842-91ce-41a6-8892-b12fde4dd39f}; ! Layer 3
 
 OS:Construction,
-  {8bf09872-be7e-4040-b6c6-340a46ec46d4}, ! Handle
+  {eb27ad07-9483-444d-a87f-429828f0811f}, ! Handle
   ASHRAE_189.1-2009_ExtRoof_IEAD_ClimateZone 2-5, ! Name
   ,                                       ! Surface Rendering Name
-  {ad8d8cd5-0a39-4c9b-9df5-cc79604248f6}, ! Layer 1
-  {d58def87-50fd-4dad-80f7-01119a3a6dda}, ! Layer 2
-  {20b5c0f6-a2bd-4239-ad59-296b0bb72b1d}; ! Layer 3
+  {74b24f8d-bfd1-41c9-8c73-3391f7e4a09f}, ! Layer 1
+  {92cc7211-0b1a-486f-94cd-be37acee953c}, ! Layer 2
+  {aaf89846-d3ba-4e57-8c1d-7c340aee2f40}; ! Layer 3
 
 OS:Construction,
-  {88ec2268-d00c-4152-8d28-d4f3f9fe62e5}, ! Handle
+  {e3d5080c-2924-4139-a923-a8c061d921cc}, ! Handle
   000_Interior Floor,                     ! Name
   ,                                       ! Surface Rendering Name
-  {48c44660-c40c-467c-a52a-382c94b51d5d}, ! Layer 1
-  {bab537d5-4f76-4e19-b8f5-4e7ede7dfc83}, ! Layer 2
-  {712cf58d-348e-4533-81e4-1c50ec05975f}; ! Layer 3
+  {1a38d2e7-3104-41fd-91e4-e8fd884c5464}, ! Layer 1
+  {0496cc4b-105d-42a9-a4ba-4b0d92438b45}, ! Layer 2
+  {97f9c813-aa3b-4bb6-a2ee-c3b0a4554fb3}; ! Layer 3
 
 OS:Construction,
-  {121b88f7-1bd4-4df9-be12-e7e081947fd7}, ! Handle
+  {4b50c788-485a-49ee-9e34-92ccf9a588b5}, ! Handle
   000_Interior Wall,                      ! Name
   ,                                       ! Surface Rendering Name
-  {ebb22584-cff0-4145-b7df-a72925af091f}, ! Layer 1
-  {daa71c78-604e-46ed-9dcc-788add33cdcc}, ! Layer 2
-  {ebb22584-cff0-4145-b7df-a72925af091f}; ! Layer 3
+  {1562b6c3-b36f-45f2-97b9-3b0b28bf59b1}, ! Layer 1
+  {f99330c8-204a-4e73-b145-4ca79632caf0}, ! Layer 2
+  {1562b6c3-b36f-45f2-97b9-3b0b28bf59b1}; ! Layer 3
 
 OS:Construction,
-  {68042db8-241e-4c07-aebc-32d1fa3d2a00}, ! Handle
+  {2a461233-5695-4b4b-8fd4-2e4a3394c078}, ! Handle
   000_Interior Ceiling,                   ! Name
   ,                                       ! Surface Rendering Name
-  {712cf58d-348e-4533-81e4-1c50ec05975f}, ! Layer 1
-  {bab537d5-4f76-4e19-b8f5-4e7ede7dfc83}, ! Layer 2
-  {48c44660-c40c-467c-a52a-382c94b51d5d}; ! Layer 3
+  {97f9c813-aa3b-4bb6-a2ee-c3b0a4554fb3}, ! Layer 1
+  {0496cc4b-105d-42a9-a4ba-4b0d92438b45}, ! Layer 2
+  {1a38d2e7-3104-41fd-91e4-e8fd884c5464}; ! Layer 3
 
 OS:Construction,
-  {9fb083ec-6cd2-443b-bce2-1af9742a6922}, ! Handle
+  {e58df250-1a29-4f22-8324-8357e8d1efc3}, ! Handle
   ASHRAE_189.1-2009_ExtWindow_ClimateZone 4-5, ! Name
   ,                                       ! Surface Rendering Name
-  {cfc7b8b7-2a03-4a54-8f2f-95079c78e9a5}; ! Layer 1
+  {3aa597a0-e39e-4e12-a149-21720e8178e3}; ! Layer 1
 
 OS:Construction,
-  {dca18647-b256-48f8-9412-c707ff956666}, ! Handle
+  {62fe7b23-50c2-49c0-a831-962adec3925e}, ! Handle
   000_Exterior Door,                      ! Name
   ,                                       ! Surface Rendering Name
-  {ee51a1bd-df25-4330-9a86-1ae82950d77e}, ! Layer 1
-  {3d295a0c-42c3-4adf-96f7-cada0b2c1e5c}; ! Layer 2
+  {df77a0a5-4d93-4ed9-874a-daf77fdac654}, ! Layer 1
+  {deee908b-f60e-4ed1-a4e2-c417c737f30f}; ! Layer 2
 
 OS:Construction,
-  {789d2b30-d66d-4606-9b07-ce59999fb22a}, ! Handle
+  {85e421aa-5753-436c-b44c-38b5d0517a05}, ! Handle
   000_Exterior Window,                    ! Name
   ,                                       ! Surface Rendering Name
-  {8c175519-8e79-4462-8a1d-06939ec6c3e5}, ! Layer 1
-  {6d75d980-26ae-42c5-b638-f53fdeedfaf4}, ! Layer 2
-  {8c175519-8e79-4462-8a1d-06939ec6c3e5}; ! Layer 3
+  {54271728-116c-4052-84b9-a4b0c3ff1964}, ! Layer 1
+  {4038ffce-b382-44a1-b246-bd6fd566cc54}, ! Layer 2
+  {54271728-116c-4052-84b9-a4b0c3ff1964}; ! Layer 3
 
 OS:Construction,
-  {94b37593-7a00-4398-9d4a-c84fd43fdf48}, ! Handle
+  {b8e19ccf-73ff-484b-9e67-5e74e8cbd6af}, ! Handle
   000_Interior Window,                    ! Name
   ,                                       ! Surface Rendering Name
-  {8c175519-8e79-4462-8a1d-06939ec6c3e5}; ! Layer 1
+  {54271728-116c-4052-84b9-a4b0c3ff1964}; ! Layer 1
 
 OS:Construction,
-  {5903f599-9cd2-4905-a60a-f63ddb384a25}, ! Handle
+  {ff9885cd-addd-4163-b9c1-ce3e0ba9f2c3}, ! Handle
   000_Interior Door,                      ! Name
   ,                                       ! Surface Rendering Name
-  {7f2dd5ea-284f-4ad5-a44a-28d7b93d78a1}; ! Layer 1
+  {c37ff251-ea9a-4a2c-ad46-dfccc63ac14b}; ! Layer 1
 
 OS:Material,
-  {7f2dd5ea-284f-4ad5-a44a-28d7b93d78a1}, ! Handle
+  {c37ff251-ea9a-4a2c-ad46-dfccc63ac14b}, ! Handle
   000_G05 25mm wood,                      ! Name
   MediumSmooth,                           ! Roughness
   0.025399999999999999,                   ! Thickness
@@ -5181,7 +2950,7 @@ OS:Material,
   1630;                                   ! Specific Heat
 
 OS:Material,
-  {9b9c2966-7e8a-4c47-9fa7-c34aa74c305f}, ! Handle
+  {ad01420f-94c6-4f18-bd3f-e8bcfbfe92ed}, ! Handle
   MAT-CC05 4 HW CONCRETE,                 ! Name
   Rough,                                  ! Roughness
   0.1016,                                 ! Thickness
@@ -5193,7 +2962,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material:NoMass,
-  {2047a824-818b-4954-8596-88d1c54bd4e0}, ! Handle
+  {b19671e1-d4c5-418e-8db6-e4b949aa71ea}, ! Handle
   CP02 CARPET PAD,                        ! Name
   VeryRough,                              ! Roughness
   0.2165,                                 ! Thermal Resistance
@@ -5202,7 +2971,7 @@ OS:Material:NoMass,
   0.80000000000000004;                    ! Visible Absorptance
 
 OS:Material:NoMass,
-  {3aa4534a-0e50-4f71-a82a-21528396dc2a}, ! Handle
+  {b698e3b9-7243-438e-b3e4-86cd4d0d6cfa}, ! Handle
   MAT-SHEATH,                             ! Name
   Rough,                                  ! Roughness
   0.36259999999999998,                    ! Thermal Resistance
@@ -5211,7 +2980,7 @@ OS:Material:NoMass,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {c6dcc785-89ba-4d40-b7a2-23684b1d39f1}, ! Handle
+  {d5ffd0f2-990c-4db4-8d9f-10980f2b4b16}, ! Handle
   Wall Insulation [39],                   ! Name
   MediumRough,                            ! Roughness
   0.11840000000000001,                    ! Thickness
@@ -5223,7 +2992,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {3d1bd931-d14c-4e35-bdb4-9bf5c74a5e09}, ! Handle
+  {7e628842-91ce-41a6-8892-b12fde4dd39f}, ! Handle
   1/2IN Gypsum,                           ! Name
   Smooth,                                 ! Roughness
   0.012699999999999999,                   ! Thickness
@@ -5235,7 +3004,7 @@ OS:Material,
   0.92000000000000004;                    ! Visible Absorptance
 
 OS:Material,
-  {ad8d8cd5-0a39-4c9b-9df5-cc79604248f6}, ! Handle
+  {74b24f8d-bfd1-41c9-8c73-3391f7e4a09f}, ! Handle
   Roof Membrane,                          ! Name
   VeryRough,                              ! Roughness
   0.0094999999999999998,                  ! Thickness
@@ -5247,7 +3016,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {d58def87-50fd-4dad-80f7-01119a3a6dda}, ! Handle
+  {92cc7211-0b1a-486f-94cd-be37acee953c}, ! Handle
   Roof Insulation [21],                   ! Name
   MediumRough,                            ! Roughness
   0.21049999999999999,                    ! Thickness
@@ -5259,7 +3028,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {20b5c0f6-a2bd-4239-ad59-296b0bb72b1d}, ! Handle
+  {aaf89846-d3ba-4e57-8c1d-7c340aee2f40}, ! Handle
   Metal Decking,                          ! Name
   MediumSmooth,                           ! Roughness
   0.0015,                                 ! Thickness
@@ -5271,7 +3040,7 @@ OS:Material,
   0.29999999999999999;                    ! Visible Absorptance
 
 OS:Material,
-  {48c44660-c40c-467c-a52a-382c94b51d5d}, ! Handle
+  {1a38d2e7-3104-41fd-91e4-e8fd884c5464}, ! Handle
   000_F16 Acoustic tile,                  ! Name
   MediumSmooth,                           ! Roughness
   0.019099999999999999,                   ! Thickness
@@ -5280,12 +3049,12 @@ OS:Material,
   590;                                    ! Specific Heat
 
 OS:Material:AirGap,
-  {bab537d5-4f76-4e19-b8f5-4e7ede7dfc83}, ! Handle
+  {0496cc4b-105d-42a9-a4ba-4b0d92438b45}, ! Handle
   000_F05 Ceiling air space resistance,   ! Name
   0.17999999999999999;                    ! Thermal Resistance
 
 OS:Material,
-  {712cf58d-348e-4533-81e4-1c50ec05975f}, ! Handle
+  {97f9c813-aa3b-4bb6-a2ee-c3b0a4554fb3}, ! Handle
   000_M11 100mm lightweight concrete,     ! Name
   MediumRough,                            ! Roughness
   0.1016,                                 ! Thickness
@@ -5294,7 +3063,7 @@ OS:Material,
   840;                                    ! Specific Heat
 
 OS:Material,
-  {ebb22584-cff0-4145-b7df-a72925af091f}, ! Handle
+  {1562b6c3-b36f-45f2-97b9-3b0b28bf59b1}, ! Handle
   000_G01a 19mm gypsum board,             ! Name
   MediumSmooth,                           ! Roughness
   0.019,                                  ! Thickness
@@ -5303,12 +3072,12 @@ OS:Material,
   1090;                                   ! Specific Heat
 
 OS:Material:AirGap,
-  {daa71c78-604e-46ed-9dcc-788add33cdcc}, ! Handle
+  {f99330c8-204a-4e73-b145-4ca79632caf0}, ! Handle
   000_F04 Wall air space resistance,      ! Name
   0.14999999999999999;                    ! Thermal Resistance
 
 OS:WindowMaterial:Glazing,
-  {cfc7b8b7-2a03-4a54-8f2f-95079c78e9a5}, ! Handle
+  {3aa597a0-e39e-4e12-a149-21720e8178e3}, ! Handle
   Theoretical Glass [207],                ! Name
   SpectralAverage,                        ! Optical Data Type
   ,                                       ! Window Glass Spectral Data Set Name
@@ -5327,7 +3096,7 @@ OS:WindowMaterial:Glazing,
   No;                                     ! Solar Diffusing
 
 OS:Material,
-  {ee51a1bd-df25-4330-9a86-1ae82950d77e}, ! Handle
+  {df77a0a5-4d93-4ed9-874a-daf77fdac654}, ! Handle
   000_F08 Metal surface,                  ! Name
   Smooth,                                 ! Roughness
   0.00080000000000000004,                 ! Thickness
@@ -5336,7 +3105,7 @@ OS:Material,
   500;                                    ! Specific Heat
 
 OS:Material,
-  {3d295a0c-42c3-4adf-96f7-cada0b2c1e5c}, ! Handle
+  {deee908b-f60e-4ed1-a4e2-c417c737f30f}, ! Handle
   000_I01 25mm insulation board,          ! Name
   MediumRough,                            ! Roughness
   0.025399999999999999,                   ! Thickness
@@ -5345,7 +3114,7 @@ OS:Material,
   1210;                                   ! Specific Heat
 
 OS:WindowMaterial:Glazing,
-  {8c175519-8e79-4462-8a1d-06939ec6c3e5}, ! Handle
+  {54271728-116c-4052-84b9-a4b0c3ff1964}, ! Handle
   000_Clear 3mm,                          ! Name
   SpectralAverage,                        ! Optical Data Type
   ,                                       ! Window Glass Spectral Data Set Name
@@ -5364,65 +3133,65 @@ OS:WindowMaterial:Glazing,
   ;                                       ! Solar Diffusing
 
 OS:WindowMaterial:Gas,
-  {6d75d980-26ae-42c5-b638-f53fdeedfaf4}, ! Handle
+  {4038ffce-b382-44a1-b246-bd6fd566cc54}, ! Handle
   000_Air 13mm,                           ! Name
   Air,                                    ! Gas Type
   0.012699999999999999;                   ! Thickness
 
 OS:Building,
-  {bd73302f-f161-495b-8962-c4350eb3ef9f}, !- Handle
+  {cb3e2a2e-f6c1-4f98-bffa-1aecb6264b00}, !- Handle
   Building 1,                             !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Space Type Name
-  {82ddd438-0845-4ab2-b530-1fbbcb61f489}, !- Default Construction Set Name
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Space Type Name
+  {8e16f99d-7f51-451a-b8a2-0d1eaccda44e}, !- Default Construction Set Name
   ;                                       !- Default Schedule Set Name
 
 OS:Construction,
-  {0b5e8dd1-d189-454a-bfac-ca97d9ba655d}, ! Handle
+  {61b58852-a3c5-4074-a735-3555b63d8bef}, ! Handle
   Air_Wall,                               ! Name
   ,                                       ! Surface Rendering Name
-  {ef9d6999-18d7-4d9b-9707-c012729038fb}; ! Layer 1
+  {3788a5f4-d9d7-4154-a4e6-b756e057c6ca}; ! Layer 1
 
 OS:Material:AirWall,
-  {ef9d6999-18d7-4d9b-9707-c012729038fb}, ! Handle
+  {3788a5f4-d9d7-4154-a4e6-b756e057c6ca}, ! Handle
   OS:Material:AirWall 1;                  ! Name
 
 OS:SpaceType,
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Handle
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Handle
   Baseline Model Space Type,              !- Name
   ,                                       !- Default Construction Set Name
-  {dcb2614d-ab37-4d10-ac2f-1999d4c80ea5}, !- Default Schedule Set Name
+  {61610213-be30-498d-8e06-f02ff73df7a5}, !- Default Schedule Set Name
   ,                                       !- Group Rendering Name
-  {8e4fc21f-acf6-444b-a3fe-84450f02eb37}; !- Design Specification Outdoor Air Object Name
+  {03832ccf-35e3-4f06-948a-a242d17f5bd0}; !- Design Specification Outdoor Air Object Name
 
 OS:DefaultScheduleSet,
-  {dcb2614d-ab37-4d10-ac2f-1999d4c80ea5}, !- Handle
+  {61610213-be30-498d-8e06-f02ff73df7a5}, !- Handle
   Baseline Model Schedule Set,            !- Name
   ,                                       !- Hours of Operation Schedule Name
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Number of People Schedule Name
-  {fd6f5810-c442-43a6-8c21-57ebe9bed988}, !- People Activity Level Schedule Name
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Lighting Schedule Name
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Electric Equipment Schedule Name
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Number of People Schedule Name
+  {f96f661a-8b27-41d9-98bd-6555a5c99e75}, !- People Activity Level Schedule Name
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Lighting Schedule Name
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Electric Equipment Schedule Name
   ,                                       !- Gas Equipment Schedule Name
   ,                                       !- Hot Water Equipment Schedule Name
-  {5831d14f-7f89-4309-9209-e44c0370fd9c}, !- Infiltration Schedule Name
+  {705ef2da-7444-4f59-bc7b-bcf32a6e883e}, !- Infiltration Schedule Name
   ,                                       !- Steam Equipment Schedule Name
   ;                                       !- Other Equipment Schedule Name
 
 OS:Schedule:Ruleset,
-  {5831d14f-7f89-4309-9209-e44c0370fd9c}, !- Handle
+  {705ef2da-7444-4f59-bc7b-bcf32a6e883e}, !- Handle
   Baseline Model Infiltration Schedule,   !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
-  {df875fe3-9ad8-4de1-a7de-172b7e6b21db}, !- Default Day Schedule Name
-  {af7163d7-ab70-4784-a2d4-8c8df0271977}, !- Summer Design Day Schedule Name
-  {16fd88fa-889c-4c37-934d-e8515496f5aa}; !- Winter Design Day Schedule Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
+  {e32cbcd6-5006-4687-8111-df19d429cea9}, !- Default Day Schedule Name
+  {8f64d2b9-1a78-4e82-b458-b24c8a66e2fb}, !- Summer Design Day Schedule Name
+  {cddce445-e880-40eb-88d5-85eec61dd555}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {df875fe3-9ad8-4de1-a7de-172b7e6b21db}, !- Handle
+  {e32cbcd6-5006-4687-8111-df19d429cea9}, !- Handle
   Baseline Model Infiltration Schedule Schedule All Days, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -5435,7 +3204,7 @@ OS:Schedule:Day,
   1;                                      !- Value Until Time 3
 
 OS:Schedule:Day,
-  {c163cf76-90b3-4be4-b573-ddd569ebf178}, !- Handle
+  {4f41653b-ecd9-48bc-8de8-fdd49d97195b}, !- Handle
   Schedule Day 4,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -5444,16 +3213,16 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {16fd88fa-889c-4c37-934d-e8515496f5aa}, !- Handle
+  {cddce445-e880-40eb-88d5-85eec61dd555}, !- Handle
   Baseline Model Infiltration Schedule Winter Design Day, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {9d04e070-0edc-4922-95a1-dbef2963c14e}, !- Handle
+  {3637dfed-6a62-4260-b835-b6633eecfbc8}, !- Handle
   Schedule Day 5,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -5462,33 +3231,33 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {af7163d7-ab70-4784-a2d4-8c8df0271977}, !- Handle
+  {8f64d2b9-1a78-4e82-b458-b24c8a66e2fb}, !- Handle
   Baseline Model Infiltration Schedule Summer Design Day, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:ScheduleTypeLimits,
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Handle
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Handle
   Fractional,                             !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
   Continuous;                             !- Numeric Type
 
 OS:Schedule:Ruleset,
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Handle
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Handle
   Baseline Model People Lights and Equipment Schedule, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
-  {e7d7a526-a046-453d-99d5-747bdc232a82}, !- Default Day Schedule Name
-  {d17abe6b-964f-4e30-9fb9-8e9092978f27}, !- Summer Design Day Schedule Name
-  {9c582255-9073-41a6-ae6a-44d9a61abd13}; !- Winter Design Day Schedule Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
+  {253847e7-bb62-4966-a06b-6549b90f62f8}, !- Default Day Schedule Name
+  {67ef2c86-5fd3-424e-9f75-af9d301e25b0}, !- Summer Design Day Schedule Name
+  {fb139371-962f-45ba-89c6-891e310697f2}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {e7d7a526-a046-453d-99d5-747bdc232a82}, !- Handle
+  {253847e7-bb62-4966-a06b-6549b90f62f8}, !- Handle
   Baseline Model People Lights and Equipment Schedule Schedule Week Day, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -5522,7 +3291,7 @@ OS:Schedule:Day,
   0.05;                                   !- Value Until Time 10
 
 OS:Schedule:Day,
-  {4896f702-4e4f-4a35-80f3-53a34266737c}, !- Handle
+  {0ba5207b-1473-4720-8839-6681363c0cdc}, !- Handle
   Schedule Day 6,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -5531,16 +3300,16 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {9c582255-9073-41a6-ae6a-44d9a61abd13}, !- Handle
+  {fb139371-962f-45ba-89c6-891e310697f2}, !- Handle
   Baseline Model People Lights and Equipment Schedule Winter Design Day, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {1aca828a-af23-483d-9343-c49334f9b13a}, !- Handle
+  {f7068227-92c5-45d2-b0ae-8e478ec7f7d0}, !- Handle
   Schedule Day 7,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -5549,20 +3318,20 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {d17abe6b-964f-4e30-9fb9-8e9092978f27}, !- Handle
+  {67ef2c86-5fd3-424e-9f75-af9d301e25b0}, !- Handle
   Baseline Model People Lights and Equipment Schedule Summer Design Day, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:Schedule:Rule,
-  {fa35011e-2ddf-4c64-b31f-2366c02b882f}, !- Handle
+  {55a7a22d-c8ed-46bc-8eb0-c78893a0d5b6}, !- Handle
   Baseline Model People Lights and Equipment Schedule Saturday Rule, !- Name
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Schedule Ruleset Name
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Schedule Ruleset Name
   1,                                      !- Rule Order
-  {ca2a3c1a-2a72-4897-9007-6a6d5f5930ac}, !- Day Schedule Name
+  {a706f43e-9fe5-49de-99cb-6d6257d8c73d}, !- Day Schedule Name
   ,                                       !- Apply Sunday
   ,                                       !- Apply Monday
   ,                                       !- Apply Tuesday
@@ -5572,9 +3341,9 @@ OS:Schedule:Rule,
   Yes;                                    !- Apply Saturday
 
 OS:Schedule:Day,
-  {ca2a3c1a-2a72-4897-9007-6a6d5f5930ac}, !- Handle
+  {a706f43e-9fe5-49de-99cb-6d6257d8c73d}, !- Handle
   Baseline Model People Lights and Equipment Schedule Saturday, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -5593,39 +3362,39 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 5
 
 OS:Schedule:Rule,
-  {4328801e-306b-4d16-bb7b-b5cb8dc9d635}, !- Handle
+  {544f78dc-852c-4adf-bc84-b47a4893b257}, !- Handle
   Baseline Model People Lights and Equipment Schedule Sunday Rule, !- Name
-  {120f9a37-914b-4b7b-b30c-01edb9bc102e}, !- Schedule Ruleset Name
+  {1739807a-478d-4ebc-b818-09d0d251a6fa}, !- Schedule Ruleset Name
   0,                                      !- Rule Order
-  {0b985d93-14fb-4c57-ae49-e4117003f763}, !- Day Schedule Name
+  {52340979-9a2c-45be-81d6-5630ec1224a8}, !- Day Schedule Name
   Yes;                                    !- Apply Sunday
 
 OS:Schedule:Day,
-  {0b985d93-14fb-4c57-ae49-e4117003f763}, !- Handle
+  {52340979-9a2c-45be-81d6-5630ec1224a8}, !- Handle
   Baseline Model People Lights and Equipment Schedule Schedule Sunday, !- Name
-  {1fc86e66-785b-4b2b-ae3f-fa8575ce00a4}, !- Schedule Type Limits Name
+  {ff87dd15-cdd9-4ea8-8ea2-e4d2b3a690d6}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {fd6f5810-c442-43a6-8c21-57ebe9bed988}, !- Handle
+  {f96f661a-8b27-41d9-98bd-6555a5c99e75}, !- Handle
   Baseline Model People Activity Schedule, !- Name
-  {ac63e016-7e89-4ae3-a200-c9135274f37a}, !- Schedule Type Limits Name
-  {2427dd8b-88c3-4cae-84d4-3088e7d108f3}; !- Default Day Schedule Name
+  {a2850812-f138-43b4-8480-3023cc423f64}, !- Schedule Type Limits Name
+  {63c6e13a-b19d-43dd-946e-10082a198c1b}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {2427dd8b-88c3-4cae-84d4-3088e7d108f3}, !- Handle
+  {63c6e13a-b19d-43dd-946e-10082a198c1b}, !- Handle
   Baseline Model People Activity Schedule Default, !- Name
-  {ac63e016-7e89-4ae3-a200-c9135274f37a}, !- Schedule Type Limits Name
+  {a2850812-f138-43b4-8480-3023cc423f64}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   120;                                    !- Value Until Time 1
 
 OS:ScheduleTypeLimits,
-  {ac63e016-7e89-4ae3-a200-c9135274f37a}, !- Handle
+  {a2850812-f138-43b4-8480-3023cc423f64}, !- Handle
   ActivityLevel,                          !- Name
   0,                                      !- Lower Limit Value
   ,                                       !- Upper Limit Value
@@ -5633,7 +3402,7 @@ OS:ScheduleTypeLimits,
   ActivityLevel;                          !- Unit Type
 
 OS:DesignSpecification:OutdoorAir,
-  {8e4fc21f-acf6-444b-a3fe-84450f02eb37}, !- Handle
+  {03832ccf-35e3-4f06-948a-a242d17f5bd0}, !- Handle
   Baseline Model OA,                      !- Name
   Sum,                                    !- Outdoor Air Method
   0.009438948864,                         !- Outdoor Air Flow per Person {m3/s-person}
@@ -5643,9 +3412,9 @@ OS:DesignSpecification:OutdoorAir,
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
 OS:SpaceInfiltration:DesignFlowRate,
-  {3a06a25e-5389-4927-bb9b-b026231c57ba}, !- Handle
+  {401d9dba-b8b7-4655-9ec9-fc6413e630f4}, !- Handle
   Baseline Model Infiltration,            !- Name
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Space or SpaceType Name
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
   ,                                       !- Design Flow Rate {m3/s}
@@ -5658,7 +3427,7 @@ OS:SpaceInfiltration:DesignFlowRate,
   ;                                       !- Velocity Squared Term Coefficient
 
 OS:People:Definition,
-  {97f6b7da-ceb2-4012-adb4-1675ff1760ec}, !- Handle
+  {18c6b916-e62f-4c09-a8c7-ef33afae115b}, !- Handle
   Baseline Model People Definition,       !- Name
   People/Area,                            !- Number of People Calculation Method
   ,                                       !- Number of People {people}
@@ -5667,10 +3436,10 @@ OS:People:Definition,
   0.3;                                    !- Fraction Radiant
 
 OS:People,
-  {28806bd4-3893-4dcd-b042-516c4e0d6550}, !- Handle
+  {fa7483ca-7fb0-4247-9e7c-45bb69b4aec7}, !- Handle
   Baseline Model People,                  !- Name
-  {97f6b7da-ceb2-4012-adb4-1675ff1760ec}, !- People Definition Name
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Space or SpaceType Name
+  {18c6b916-e62f-4c09-a8c7-ef33afae115b}, !- People Definition Name
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Space or SpaceType Name
   ,                                       !- Number of People Schedule Name
   ,                                       !- Activity Level Schedule Name
   ,                                       !- Surface Name/Angle Factor List Name
@@ -5680,7 +3449,7 @@ OS:People,
   1;                                      !- Multiplier
 
 OS:Lights:Definition,
-  {865d6585-d53b-4cea-81f6-f60bccf7fbaa}, !- Handle
+  {9bc4dab8-3a9a-44ff-ba13-9da3626559f8}, !- Handle
   Baseline Model Lights Definition,       !- Name
   Watts/Area,                             !- Design Level Calculation Method
   ,                                       !- Lighting Level {W}
@@ -5688,17 +3457,17 @@ OS:Lights:Definition,
   ;                                       !- Watts per Person {W/person}
 
 OS:Lights,
-  {d1e4bc43-9d42-49e1-a48a-e8883be9f0a0}, !- Handle
+  {ee8cb14f-7fd4-42ab-8cb7-1e1e64e8f664}, !- Handle
   Baseline Model Lights,                  !- Name
-  {865d6585-d53b-4cea-81f6-f60bccf7fbaa}, !- Lights Definition Name
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Space or SpaceType Name
+  {9bc4dab8-3a9a-44ff-ba13-9da3626559f8}, !- Lights Definition Name
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   1,                                      !- Fraction Replaceable
   ,                                       !- Multiplier
   General;                                !- End-Use Subcategory
 
 OS:ElectricEquipment:Definition,
-  {e2411356-a20c-4fbc-a389-ccc302881c21}, !- Handle
+  {fff1cc61-b92a-4cf2-9ca1-4835cfdc7836}, !- Handle
   Baseline Model Electric Equipment Definition, !- Name
   Watts/Area,                             !- Design Level Calculation Method
   ,                                       !- Design Level {W}
@@ -5706,16 +3475,16 @@ OS:ElectricEquipment:Definition,
   ;                                       !- Watts per Person {W/person}
 
 OS:ElectricEquipment,
-  {124e165b-eb8c-43fa-9f30-874026c115e8}, !- Handle
+  {47aa0417-1678-4ca0-807d-15eef28e61e4}, !- Handle
   Baseline Model Electric Equipment,      !- Name
-  {e2411356-a20c-4fbc-a389-ccc302881c21}, !- Electric Equipment Definition Name
-  {33a4bafe-942c-4da5-8755-dceae8e9c4f4}, !- Space or SpaceType Name
+  {fff1cc61-b92a-4cf2-9ca1-4835cfdc7836}, !- Electric Equipment Definition Name
+  {46d75be5-2bc7-45bb-80bf-523b08969eb3}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   ,                                       !- Multiplier
   General;                                !- End-Use Subcategory
 
 OS:SizingPeriod:DesignDay,
-  {e0a80a99-52f6-4931-93b8-d95a5bbeb5ac}, !- Handle
+  {5703ff0d-10fe-46c6-824f-163418aa7ee6}, !- Handle
   Chicago Ohare Intl Ap Ann Htg 99.6% Condns DB, !- Name
   -20,                                    !- Maximum Dry-Bulb Temperature {C}
   0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
@@ -5737,51 +3506,7 @@ OS:SizingPeriod:DesignDay,
   ASHRAEClearSky;                         !- Solar Model Indicator
 
 OS:SizingPeriod:DesignDay,
-  {bd51e00b-dc83-4c0c-8d33-92dfa27cf95c}, !- Handle
-  Chicago Ohare Intl Ap Ann Htg Wind 99.6% Condns WS=>MCDB, !- Name
-  -3.5,                                   !- Maximum Dry-Bulb Temperature {C}
-  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  -3.5,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  12.4,                                   !- Wind Speed {m/s}
-  270,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  1,                                      !- Month
-  WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAEClearSky;                         !- Solar Model Indicator
-
-OS:SizingPeriod:DesignDay,
-  {748a91e8-ec5d-44e6-a3ad-cfc5c954e715}, !- Handle
-  Chicago Ohare Intl Ap Ann Hum_n 99.6% Condns DP=>MCDB, !- Name
-  -19.2,                                  !- Maximum Dry-Bulb Temperature {C}
-  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  -25.7,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  4.9,                                    !- Wind Speed {m/s}
-  270,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  1,                                      !- Month
-  WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Dewpoint,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAEClearSky;                         !- Solar Model Indicator
-
-OS:SizingPeriod:DesignDay,
-  {3647e5d1-e6fe-40ad-b0ac-2eb78c29d1c9}, !- Handle
+  {9555eb3d-f076-46f9-9692-a17d33a1ecac}, !- Handle
   Chicago Ohare Intl Ap Ann Clg .4% Condns DB=>MWB, !- Name
   33.3,                                   !- Maximum Dry-Bulb Temperature {C}
   10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
@@ -5806,86 +3531,20 @@ OS:SizingPeriod:DesignDay,
   0.455,                                  !- ASHRAE Taub {dimensionless}
   2.05;                                   !- ASHRAE Taud {dimensionless}
 
-OS:SizingPeriod:DesignDay,
-  {aa3e8287-199e-42ea-b7e8-122cd8961f54}, !- Handle
-  Chicago Ohare Intl Ap Ann Clg .4% Condns WB=>MDB, !- Name
-  31.2,                                   !- Maximum Dry-Bulb Temperature {C}
-  10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  25.5,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  5.2,                                    !- Wind Speed {m/s}
-  230,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  7,                                      !- Month
-  SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAETau,                              !- Solar Model Indicator
-  ,                                       !- Beam Solar Day Schedule Name
-  ,                                       !- Diffuse Solar Day Schedule Name
-  0.455,                                  !- ASHRAE Taub {dimensionless}
-  2.05;                                   !- ASHRAE Taud {dimensionless}
+OS:SimulationControl,
+  {7c0b6380-b393-43cd-9fca-1ad161145ff0}, !- Handle
+  ,                                       !- Do Zone Sizing Calculation
+  ,                                       !- Do System Sizing Calculation
+  ,                                       !- Do Plant Sizing Calculation
+  No,                                     !- Run Simulation for Sizing Periods
+  Yes;                                    !- Run Simulation for Weather File Run Periods
 
-OS:SizingPeriod:DesignDay,
-  {280cabc4-eea7-4067-9ef8-bc1564085c5d}, !- Handle
-  Chicago Ohare Intl Ap Ann Clg .4% Condns DP=>MDB, !- Name
-  28.9,                                   !- Maximum Dry-Bulb Temperature {C}
-  10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  23.8,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  5.2,                                    !- Wind Speed {m/s}
-  230,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  7,                                      !- Month
-  SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Dewpoint,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAETau,                              !- Solar Model Indicator
-  ,                                       !- Beam Solar Day Schedule Name
-  ,                                       !- Diffuse Solar Day Schedule Name
-  0.455,                                  !- ASHRAE Taub {dimensionless}
-  2.05;                                   !- ASHRAE Taud {dimensionless}
-
-OS:SizingPeriod:DesignDay,
-  {4201a998-badb-4b48-9728-d318ffd1c3c8}, !- Handle
-  Chicago Ohare Intl Ap Ann Clg .4% Condns Enth=>MDB, !- Name
-  31.4,                                   !- Maximum Dry-Bulb Temperature {C}
-  10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  79200,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  5.2,                                    !- Wind Speed {m/s}
-  230,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  7,                                      !- Month
-  SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Enthalpy,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAETau,                              !- Solar Model Indicator
-  ,                                       !- Beam Solar Day Schedule Name
-  ,                                       !- Diffuse Solar Day Schedule Name
-  0.455,                                  !- ASHRAE Taub {dimensionless}
-  2.05;                                   !- ASHRAE Taud {dimensionless}
+OS:Timestep,
+  {c9345468-ef31-4a6c-8a74-d8dc4801d917}, !- Handle
+  4;                                      !- Number of Timesteps per Hour
 
 OS:Curve:Exponent,
-  {7043a46e-2c32-46f7-9e39-e2c2816b44b4}, !- Handle
+  {57194372-7e4f-4fcf-8a70-9e953d1dc29b}, !- Handle
   Fan On Off Power Curve,                 !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 Constant
@@ -5898,7 +3557,7 @@ OS:Curve:Exponent,
   ;                                       !- Output Unit Type
 
 OS:Curve:Cubic,
-  {9a81da11-7d1a-47c0-b608-e2001474808b}, !- Handle
+  {5099b071-d0c1-4b81-9f0b-863aa608e530}, !- Handle
   Fan On Off Efficiency Curve,            !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 x
@@ -5907,10 +3566,26 @@ OS:Curve:Cubic,
   0,                                      !- Minimum Value of x
   1;                                      !- Maximum Value of x
 
+OS:Connection,
+  {ffa5fadb-842a-4c93-9550-bb33233aa2d8}, !- Handle
+  {b0a571f1-f569-4d1c-bffa-430374e18c04}, !- Name
+  ,                                       !- Source Object
+  3,                                      !- Outlet Port
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Target Object
+  4;                                      !- Inlet Port
+
+OS:Connection,
+  {7f3e9031-7128-49fc-8d3c-82464bc2d7ce}, !- Handle
+  {724d1333-8217-4a3c-9dae-3b1de52f7a6d}, !- Name
+  {fec772da-3099-43c0-90a3-09dc90ef244f}, !- Source Object
+  3,                                      !- Outlet Port
+  ,                                       !- Target Object
+  2;                                      !- Inlet Port
+
 OS:Coil:Cooling:DX:SingleSpeed,
-  {7ac1ed1a-40ba-4cb0-bb0d-6308c1b62040}, !- Handle
-  Coil Cooling DX Single Speed 11,        !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
+  {1cbcee3e-dde8-44b9-b113-184e3369c7f8}, !- Handle
+  Coil Cooling DX Single Speed 6,         !- Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
   autosize,                               !- Rated Total Cooling Capacity {W}
   autosize,                               !- Rated Sensible Heat Ratio
   3,                                      !- Rated COP {W/W}
@@ -5918,11 +3593,11 @@ OS:Coil:Cooling:DX:SingleSpeed,
   773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {b402ad97-4d30-4f4e-aa8d-a75a2188bd9e}, !- Total Cooling Capacity Function of Temperature Curve Name
-  {3b03fca9-a5ae-4916-81a4-65b824e157e9}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
-  {2f86d95d-ad84-49aa-b076-56b0912fac9d}, !- Energy Input Ratio Function of Temperature Curve Name
-  {4620c3c3-b678-428d-986d-061b849590c4}, !- Energy Input Ratio Function of Flow Fraction Curve Name
-  {8abed49f-b580-46f3-8d40-6b7490b399b1}, !- Part Load Fraction Correlation Curve Name
+  {8d5551e7-ff62-41f6-a53e-7b14cbb76cb1}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {02547747-82a0-4c2c-9ff8-a737284f3ff2}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {a65160fb-dea9-4392-9efc-8deb20673150}, !- Energy Input Ratio Function of Temperature Curve Name
+  {9646167d-efc1-45e4-a7a9-4efee184216b}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {4f9496b0-363f-42a6-b141-1e6cfea85449}, !- Part Load Fraction Correlation Curve Name
   ,                                       !- Nominal Time for Condensate Removal to Begin {s}
   ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
   ,                                       !- Maximum Cycling Rate {cycles/hr}
@@ -5941,8 +3616,8 @@ OS:Coil:Cooling:DX:SingleSpeed,
   ;                                       !- Basin Heater Operating Schedule Name
 
 OS:Curve:Biquadratic,
-  {b402ad97-4d30-4f4e-aa8d-a75a2188bd9e}, !- Handle
-  Curve Biquadratic 21,                   !- Name
+  {8d5551e7-ff62-41f6-a53e-7b14cbb76cb1}, !- Handle
+  Curve Biquadratic 11,                   !- Name
   0.942587793,                            !- Coefficient1 Constant
   0.009543347,                            !- Coefficient2 x
   0.00068377,                             !- Coefficient3 x**2
@@ -5955,8 +3630,8 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {3b03fca9-a5ae-4916-81a4-65b824e157e9}, !- Handle
-  Curve Quadratic 31,                     !- Name
+  {02547747-82a0-4c2c-9ff8-a737284f3ff2}, !- Handle
+  Curve Quadratic 16,                     !- Name
   0.8,                                    !- Coefficient1 Constant
   0.2,                                    !- Coefficient2 x
   0,                                      !- Coefficient3 x**2
@@ -5964,8 +3639,8 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Biquadratic,
-  {2f86d95d-ad84-49aa-b076-56b0912fac9d}, !- Handle
-  Curve Biquadratic 22,                   !- Name
+  {a65160fb-dea9-4392-9efc-8deb20673150}, !- Handle
+  Curve Biquadratic 12,                   !- Name
   0.342414409,                            !- Coefficient1 Constant
   0.034885008,                            !- Coefficient2 x
   -0.0006237,                             !- Coefficient3 x**2
@@ -5978,8 +3653,8 @@ OS:Curve:Biquadratic,
   46;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {4620c3c3-b678-428d-986d-061b849590c4}, !- Handle
-  Curve Quadratic 32,                     !- Name
+  {9646167d-efc1-45e4-a7a9-4efee184216b}, !- Handle
+  Curve Quadratic 17,                     !- Name
   1.1552,                                 !- Coefficient1 Constant
   -0.1808,                                !- Coefficient2 x
   0.0256,                                 !- Coefficient3 x**2
@@ -5987,8 +3662,8 @@ OS:Curve:Quadratic,
   1.5;                                    !- Maximum Value of x
 
 OS:Curve:Quadratic,
-  {8abed49f-b580-46f3-8d40-6b7490b399b1}, !- Handle
-  Curve Quadratic 33,                     !- Name
+  {4f9496b0-363f-42a6-b141-1e6cfea85449}, !- Handle
+  Curve Quadratic 18,                     !- Name
   0.85,                                   !- Coefficient1 Constant
   0.15,                                   !- Coefficient2 x
   0,                                      !- Coefficient3 x**2
@@ -5996,22 +3671,22 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:Fan:OnOff,
-  {223472e1-0586-4aa0-9926-8587d182f3d6}, !- Handle
+  {7f4227bb-212e-4b2b-93d2-24b9b552fc72}, !- Handle
   Fan On Off 2,                           !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  0.6,                                    !- Fan Efficiency
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  0.6,                                    !- Fan Total Efficiency
   300,                                    !- Pressure Rise {Pa}
   autosize,                               !- Maximum Flow Rate {m3/s}
   0.8,                                    !- Motor Efficiency
   1,                                      !- Motor In Airstream Fraction
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
-  {07acfa87-3ebb-43f3-b754-a686d792c8ea}, !- Fan Power Ratio Function of Speed Ratio Curve Name
-  {f078488d-0d81-415f-8212-5726951f6cb8}, !- Fan Efficiency Ratio Function of Speed Ratio Curve Name
+  {ae1c78b7-59d1-4571-8fc2-56af388d7a27}, !- Fan Power Ratio Function of Speed Ratio Curve Name
+  {6e82bbb4-a684-4950-a312-90fdf1ea3b03}, !- Fan Efficiency Ratio Function of Speed Ratio Curve Name
   ;                                       !- End-Use Subcategory
 
 OS:Curve:Exponent,
-  {07acfa87-3ebb-43f3-b754-a686d792c8ea}, !- Handle
+  {ae1c78b7-59d1-4571-8fc2-56af388d7a27}, !- Handle
   Fan On Off Power Curve 1,               !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 Constant
@@ -6024,7 +3699,7 @@ OS:Curve:Exponent,
   ;                                       !- Output Unit Type
 
 OS:Curve:Cubic,
-  {f078488d-0d81-415f-8212-5726951f6cb8}, !- Handle
+  {6e82bbb4-a684-4950-a312-90fdf1ea3b03}, !- Handle
   Fan On Off Efficiency Curve 1,          !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 x
@@ -6034,13 +3709,13 @@ OS:Curve:Cubic,
   1;                                      !- Maximum Value of x
 
 OS:Schedule:Constant,
-  {93b4ddde-f26b-4eea-913c-257ce666a792}, !- Handle
+  {592917b9-a547-4e22-b849-bc4b3e49ff27}, !- Handle
   Always Off Discrete,                    !- Name
-  {4fda2296-c460-4f50-986f-6e79fbf98c78}, !- Schedule Type Limits Name
+  {680b4056-f921-4e3f-9e02-7ff992678853}, !- Schedule Type Limits Name
   0;                                      !- Value
 
 OS:ScheduleTypeLimits,
-  {4fda2296-c460-4f50-986f-6e79fbf98c78}, !- Handle
+  {680b4056-f921-4e3f-9e02-7ff992678853}, !- Handle
   OnOff 1,                                !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
@@ -6048,20 +3723,20 @@ OS:ScheduleTypeLimits,
   Availability;                           !- Unit Type
 
 OS:Coil:Heating:Electric,
-  {a88fd663-60e6-446b-ae35-df80d21706b5}, !- Handle
+  {5be7d3bf-4842-4b95-8956-26b53691cdd1}, !- Handle
   Coil Heating Electric 1,                !- Name
-  {93b4ddde-f26b-4eea-913c-257ce666a792}, !- Availability Schedule Name
+  {592917b9-a547-4e22-b849-bc4b3e49ff27}, !- Availability Schedule Name
   ,                                       !- Efficiency
   ,                                       !- Nominal Capacity {W}
   ,                                       !- Air Inlet Node Name
   ;                                       !- Air Outlet Node Name
 
 OS:ZoneHVAC:PackagedTerminalAirConditioner,
-  {28ae44e7-45bd-4339-b64f-c39dac498bdd}, !- Handle
-  Zone HVAC Packaged Terminal Air Conditioner 11, !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {a24c47a1-ab78-42a7-9a18-c377bcfeb05f}, !- Air Inlet Node Name
-  {557e47c7-94f1-48f8-bb4c-26b0df5b231d}, !- Air Outlet Node Name
+  {302d72d9-06d1-496e-b14b-a697d235ff87}, !- Handle
+  Zone HVAC Packaged Terminal Air Conditioner 6, !- Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {5264a92a-f926-4bbf-9935-feafaa9db82e}, !- Air Inlet Node Name
+  {a2a6250e-f126-443a-8fb3-63965421ac31}, !- Air Outlet Node Name
   OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
   ,                                       !- Outdoor Air Mixer Name
   Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
@@ -6070,80 +3745,80 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
   Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
   Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
-  {223472e1-0586-4aa0-9926-8587d182f3d6}, !- Supply Air Fan Name
-  {a88fd663-60e6-446b-ae35-df80d21706b5}, !- Heating Coil Name
-  {7ac1ed1a-40ba-4cb0-bb0d-6308c1b62040}, !- Cooling Coil Name
+  {7f4227bb-212e-4b2b-93d2-24b9b552fc72}, !- Supply Air Fan Name
+  {5be7d3bf-4842-4b95-8956-26b53691cdd1}, !- Heating Coil Name
+  {1cbcee3e-dde8-44b9-b113-184e3369c7f8}, !- Cooling Coil Name
   DrawThrough,                            !- Fan Placement
   ;                                       !- Supply Air Fan Operating Mode Schedule Name
 
 OS:Node,
-  {e8da201b-2688-4fbe-88a1-ed8d1104c3a2}, !- Handle
-  Node 67,                                !- Name
-  {ed97e2cc-1a23-40e2-89d2-87ccf2073ee2}, !- Inlet Port
-  {a24c47a1-ab78-42a7-9a18-c377bcfeb05f}; !- Outlet Port
+  {c4b59057-d33f-4e0b-8a14-e63bc6502dbf}, !- Handle
+  Node 42,                                !- Name
+  {7eff04ad-1ac7-4d56-b488-bc20656d7de6}, !- Inlet Port
+  {5264a92a-f926-4bbf-9935-feafaa9db82e}; !- Outlet Port
 
 OS:Connection,
-  {ed97e2cc-1a23-40e2-89d2-87ccf2073ee2}, !- Handle
-  {af185954-7aa2-4ec9-bf8f-9019e51e8548}, !- Name
-  {1f1a3ce9-76ee-4084-8cc3-87b50190e583}, !- Source Object
+  {7eff04ad-1ac7-4d56-b488-bc20656d7de6}, !- Handle
+  {7afe6b57-479a-44e9-8ed7-0e9ff25f1941}, !- Name
+  {9695ed04-35b6-4772-83cd-5187282d3bc0}, !- Source Object
   4,                                      !- Outlet Port
-  {e8da201b-2688-4fbe-88a1-ed8d1104c3a2}, !- Target Object
+  {c4b59057-d33f-4e0b-8a14-e63bc6502dbf}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a24c47a1-ab78-42a7-9a18-c377bcfeb05f}, !- Handle
-  {009a58e3-34c6-44d6-ba6f-46d25ffbdda4}, !- Name
-  {e8da201b-2688-4fbe-88a1-ed8d1104c3a2}, !- Source Object
+  {5264a92a-f926-4bbf-9935-feafaa9db82e}, !- Handle
+  {76f6c708-8dfb-4d33-b561-88fee45532c8}, !- Name
+  {c4b59057-d33f-4e0b-8a14-e63bc6502dbf}, !- Source Object
   3,                                      !- Outlet Port
-  {28ae44e7-45bd-4339-b64f-c39dac498bdd}, !- Target Object
+  {302d72d9-06d1-496e-b14b-a697d235ff87}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {86ed3fd2-a263-4583-b247-8135b842bcd4}, !- Handle
-  Node 68,                                !- Name
-  {557e47c7-94f1-48f8-bb4c-26b0df5b231d}, !- Inlet Port
-  {3105466c-dba9-4791-bd25-3303ff263aca}; !- Outlet Port
+  {9388e52a-72fe-41c8-881f-1373d7b3ebdd}, !- Handle
+  Node 43,                                !- Name
+  {a2a6250e-f126-443a-8fb3-63965421ac31}, !- Inlet Port
+  {fbef4d93-883e-4194-8958-e500c9bda87b}; !- Outlet Port
 
 OS:Connection,
-  {3105466c-dba9-4791-bd25-3303ff263aca}, !- Handle
-  {de27d19f-e92b-4a25-8c12-3df2e13064d9}, !- Name
-  {86ed3fd2-a263-4583-b247-8135b842bcd4}, !- Source Object
+  {fbef4d93-883e-4194-8958-e500c9bda87b}, !- Handle
+  {e68e449f-a69e-43a8-a429-b1948ec18d05}, !- Name
+  {9388e52a-72fe-41c8-881f-1373d7b3ebdd}, !- Source Object
   3,                                      !- Outlet Port
-  {25c71059-c1f2-4c97-b453-b7205cfb1f2d}, !- Target Object
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {557e47c7-94f1-48f8-bb4c-26b0df5b231d}, !- Handle
-  {841cd080-0018-45e6-b260-d5b0bffd00bb}, !- Name
-  {28ae44e7-45bd-4339-b64f-c39dac498bdd}, !- Source Object
+  {a2a6250e-f126-443a-8fb3-63965421ac31}, !- Handle
+  {4f0e96cc-4248-4601-a737-4eb101d64147}, !- Name
+  {302d72d9-06d1-496e-b14b-a697d235ff87}, !- Source Object
   4,                                      !- Outlet Port
-  {86ed3fd2-a263-4583-b247-8135b842bcd4}, !- Target Object
+  {9388e52a-72fe-41c8-881f-1373d7b3ebdd}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:ZoneControl:Humidistat,
-  {4ecf77f1-57a1-456b-90c4-5b4b5a9b4e6a}, !- Handle
+  {30ec88c2-b1d0-4368-8c8c-24f6d64b151d}, !- Handle
   Zone Control Humidistat 1,              !- Name
   ;                                       !- Humidifying Relative Humidity Setpoint Schedule Name
 
 OS:ZoneHVAC:Dehumidifier:DX,
-  {c99ee959-6537-44d2-b73f-65baa58af9df}, !- Handle
+  {a870f83f-38a0-4d83-bfa9-ec927f3fea1f}, !- Handle
   Zone HVAC Dehumidifier DX 1,            !- Name
-  {f9896291-70f3-4377-ae88-d58ac54cc8d1}, !- Availability Schedule Name
-  {b71cf736-a07c-4b14-ba04-b0772a9fe7c4}, !- Air Inlet Node Name
-  {ba86b746-5a10-42c8-a90c-8b437c6b4b50}, !- Air Outlet Node Name
+  {37d39104-e28e-4e8d-ade1-b5231ffc6af4}, !- Availability Schedule Name
+  {1a520668-84a4-404a-90d5-b150c41f27df}, !- Air Inlet Node Name
+  {30f5f830-6d29-4041-a9ad-0edb20b791c9}, !- Air Outlet Node Name
   50.16,                                  !- Rated Water Removal {L/day}
   3.412,                                  !- Rated Energy Factor {L/kWh}
   0.12036,                                !- Rated Air Flow Rate {m3/s}
-  {23b33055-6727-4fd5-9a44-d99e7e1a829e}, !- Water Removal Curve Name
-  {c9798da7-b0de-4fd7-ba63-9343db57a356}, !- Energy Factor Curve Name
-  {70f689fd-79e6-4f48-8d18-baa10163b9ec}, !- Part Load Fraction Correlation Curve Name
+  {7ff1008a-7d62-443a-b320-643a0fa7fd70}, !- Water Removal Curve Name
+  {ab56e506-6159-4213-a46f-deb94c75a9e4}, !- Energy Factor Curve Name
+  {85886407-d391-4153-8d5c-37d2e9cc8fd8}, !- Part Load Fraction Correlation Curve Name
   10,                                     !- Minimum Dry-Bulb Temperature for Dehumidifier Operation {C}
   32,                                     !- Maximum Dry-Bulb Temperature for Dehumidifier Operation {C}
   0;                                      !- Off-Cycle Parasitic Electric Load {W}
 
 OS:Curve:Biquadratic,
-  {23b33055-6727-4fd5-9a44-d99e7e1a829e}, !- Handle
-  Curve Biquadratic 23,                   !- Name
+  {7ff1008a-7d62-443a-b320-643a0fa7fd70}, !- Handle
+  Curve Biquadratic 13,                   !- Name
   -2.72487866408,                         !- Coefficient1 Constant
   0.100711983591,                         !- Coefficient2 x
   -0.000990538285,                        !- Coefficient3 x**2
@@ -6156,8 +3831,8 @@ OS:Curve:Biquadratic,
   80;                                     !- Maximum Value of y
 
 OS:Curve:Biquadratic,
-  {c9798da7-b0de-4fd7-ba63-9343db57a356}, !- Handle
-  Curve Biquadratic 24,                   !- Name
+  {ab56e506-6159-4213-a46f-deb94c75a9e4}, !- Handle
+  Curve Biquadratic 14,                   !- Name
   -2.388319068955,                        !- Coefficient1 Constant
   0.093047739452,                         !- Coefficient2 x
   -0.001369700327,                        !- Coefficient3 x**2
@@ -6170,8 +3845,8 @@ OS:Curve:Biquadratic,
   80;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {70f689fd-79e6-4f48-8d18-baa10163b9ec}, !- Handle
-  Curve Quadratic 34,                     !- Name
+  {85886407-d391-4153-8d5c-37d2e9cc8fd8}, !- Handle
+  Curve Quadratic 19,                     !- Name
   0.95,                                   !- Coefficient1 Constant
   0.05,                                   !- Coefficient2 x
   0,                                      !- Coefficient3 x**2
@@ -6179,46 +3854,46 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:Node,
-  {30940a98-48b5-428a-9103-74b08012fd89}, !- Handle
-  Node 69,                                !- Name
-  {0799096d-d035-4984-a335-99762f9c6fd2}, !- Inlet Port
-  {b71cf736-a07c-4b14-ba04-b0772a9fe7c4}; !- Outlet Port
+  {14322b7e-4b21-4dbe-8579-0c3dd36a6121}, !- Handle
+  Node 44,                                !- Name
+  {80b14976-b463-4008-a7da-261ec3621998}, !- Inlet Port
+  {1a520668-84a4-404a-90d5-b150c41f27df}; !- Outlet Port
 
 OS:Connection,
-  {0799096d-d035-4984-a335-99762f9c6fd2}, !- Handle
-  {15b194c7-0d4a-4549-ad63-17a72900bc00}, !- Name
-  {1f1a3ce9-76ee-4084-8cc3-87b50190e583}, !- Source Object
+  {80b14976-b463-4008-a7da-261ec3621998}, !- Handle
+  {381bd638-58c1-44df-ad6e-1d6e1a937f94}, !- Name
+  {9695ed04-35b6-4772-83cd-5187282d3bc0}, !- Source Object
   5,                                      !- Outlet Port
-  {30940a98-48b5-428a-9103-74b08012fd89}, !- Target Object
+  {14322b7e-4b21-4dbe-8579-0c3dd36a6121}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b71cf736-a07c-4b14-ba04-b0772a9fe7c4}, !- Handle
-  {c5f22be1-ba28-4e7c-b8bf-296ee6957d72}, !- Name
-  {30940a98-48b5-428a-9103-74b08012fd89}, !- Source Object
+  {1a520668-84a4-404a-90d5-b150c41f27df}, !- Handle
+  {22ebabe5-874a-4c36-a4d0-96ea2735715e}, !- Name
+  {14322b7e-4b21-4dbe-8579-0c3dd36a6121}, !- Source Object
   3,                                      !- Outlet Port
-  {c99ee959-6537-44d2-b73f-65baa58af9df}, !- Target Object
+  {a870f83f-38a0-4d83-bfa9-ec927f3fea1f}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {cf00bac9-eca4-433c-ab84-e6c579ef4818}, !- Handle
-  Node 70,                                !- Name
-  {ba86b746-5a10-42c8-a90c-8b437c6b4b50}, !- Inlet Port
-  {a6416344-000c-4e9f-887d-dfec62b5e495}; !- Outlet Port
+  {f9fdbf81-2a14-4f27-a67a-be0b1e02d85d}, !- Handle
+  Node 45,                                !- Name
+  {30f5f830-6d29-4041-a9ad-0edb20b791c9}, !- Inlet Port
+  {955ba147-d594-43b1-93ec-a5de78741e14}; !- Outlet Port
 
 OS:Connection,
-  {a6416344-000c-4e9f-887d-dfec62b5e495}, !- Handle
-  {33430d85-02c7-444a-b2dd-f3de3eb2edec}, !- Name
-  {cf00bac9-eca4-433c-ab84-e6c579ef4818}, !- Source Object
+  {955ba147-d594-43b1-93ec-a5de78741e14}, !- Handle
+  {ecdfa8fc-491e-445b-807f-9dddd42d95e6}, !- Name
+  {f9fdbf81-2a14-4f27-a67a-be0b1e02d85d}, !- Source Object
   3,                                      !- Outlet Port
-  {25c71059-c1f2-4c97-b453-b7205cfb1f2d}, !- Target Object
+  {021fac08-2815-44a6-819a-5b6e062d59ca}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {ba86b746-5a10-42c8-a90c-8b437c6b4b50}, !- Handle
-  {7d7035ad-f7f0-4435-bafe-b34631c6d412}, !- Name
-  {c99ee959-6537-44d2-b73f-65baa58af9df}, !- Source Object
+  {30f5f830-6d29-4041-a9ad-0edb20b791c9}, !- Handle
+  {f63a5771-1c12-4e0f-8484-85749f08a3f7}, !- Name
+  {a870f83f-38a0-4d83-bfa9-ec927f3fea1f}, !- Source Object
   4,                                      !- Outlet Port
-  {cf00bac9-eca4-433c-ab84-e6c579ef4818}, !- Target Object
+  {f9fdbf81-2a14-4f27-a67a-be0b1e02d85d}, !- Target Object
   2;                                      !- Inlet Port
 

--- a/model/simulationtests/airloop_and_zonehvac.rb
+++ b/model/simulationtests/airloop_and_zonehvac.rb
@@ -68,6 +68,8 @@ zone.setZoneControlHumidistat(humidistat)
 zone_hvac = OpenStudio::Model::ZoneHVACDehumidifierDX.new(model)
 zone_hvac.addToThermalZone(zone)
 
+#set LoadDistributionScheme
+zone.setLoadDistributionScheme("UniformLoad")
 
 model.save('before.osm', true)
 

--- a/test/airloop_and_zonehvac.osm_2.6.2_out.osw
+++ b/test/airloop_and_zonehvac.osm_2.6.2_out.osw
@@ -1,0 +1,1030 @@
+{
+  "completed_status": "Success",
+  "current_step": 1,
+  "eplusout_err": [
+    "Program Version,EnergyPlus, Version 8.9.0-eba93e8e1b, ",
+    "   ************* Beginning Zone Sizing Calculations",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 2\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 3\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 4\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 5\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 6\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 7\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS ON CONTINUOUS\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** GetHTSurfaceData: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.",
+    "   **   ~~~   ** Found first in surface=SURFACE 25",
+    "   **   ~~~   ** Defaults, constant throughout the year of (18.0) will be used.",
+    "   ** Warning ** CheckUsedConstructions: There are 8 nominally unused constructions in input.",
+    "   **   ~~~   ** For explicit details on each unused construction, use Output:Diagnostics,DisplayExtraWarnings;",
+    "   ************* Beginning Plant Sizing Calculations",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTCOOLING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTHEATING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Electricity:Facility\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr",
+    "   ************* Testing Individual Branch Integrity",
+    "   ************* All Branches passed integrity testing",
+    "   ************* Testing Individual Supply Air Path Integrity",
+    "   ************* All Supply Air Paths passed integrity testing",
+    "   ************* Testing Individual Return Air Path Integrity",
+    "   ************* All Return Air Paths passed integrity testing",
+    "   ************* No node connection errors were found.",
+    "   ************* Beginning Simulation",
+    "   ** Warning ** Processing Monthly Tabular Reports: Variable names not valid for this simulation",
+    "   **   ~~~   ** ...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual variables.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 4\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -5.43",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/01 10:40 - 10:45",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 5\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -3.30",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 02/16 14:53 - 15:00",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 2\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -3.88",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 02/20 09:35 - 09:40",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-ELECTRICITY\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-DISTILLATE OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-RESIDUAL OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-NATURAL GAS\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-COAL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ************* Simulation Error Summary *************",
+    "   ************* There are 1 unused schedules in input.",
+    "   ************* There are 1 unused week schedules in input.",
+    "   ************* There are 7 unused day schedules in input.",
+    "   ************* Use Output:Diagnostics,DisplayUnusedSchedules; to see them.",
+    "   *************",
+    "   ************* ===== Recurring Error Summary =====",
+    "   ************* The following recurring error messages occurred.",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 4\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 559 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.15 [C]  Min=-16.55 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 5\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 13 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.55 [C]  Min=-4.4 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 2\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 7 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-2.500000E-002 [C]  Min=-3.875 [C]",
+    "   *************",
+    "   *************",
+    "   ************* ===== Final Error Summary =====",
+    "   ************* The following error categories occurred.  Consider correcting or noting.",
+    "   ************* Nominally Unused Constructions",
+    "   ************* ..The nominally unused constructions warning is provided to alert you to potential conditions that can cause",
+    "   ************* ..extra time during simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm",
+    "   ************* ..object. You may remove the constructions indicated (when you use the DisplayExtraWarnings option).",
+    "   *************",
+    "   ************* EnergyPlus Warmup Error Summary. During Warmup: 0 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Sizing Error Summary. During Sizing: 9 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Completed Successfully-- 597 Warning; 0 Severe Errors; "
+  ],
+  "seed_file": "in.osm",
+  "steps": [
+    {
+      "arguments": {
+      },
+      "measure_dir_name": "openstudio_results",
+      "result": {
+        "measure_class_name": "OpenStudioResults",
+        "measure_display_name": "OpenStudio Results",
+        "measure_name": "openstudio_results",
+        "measure_taxonomy": "Reporting.QAQC",
+        "measure_type": "ReportingMeasure",
+        "measure_uid": "a25386cd-60e4-46bc-8b11-c755f379d916",
+        "measure_version_id": "5b8e57e8-830a-43ae-90d4-a41d97698d95",
+        "measure_version_modified": "20171219T161835Z",
+        "measure_xml_checksum": "557BF06F",
+        "stderr": "",
+        "stdout": "",
+        "step_errors": [
+
+        ],
+        "step_final_condition": "Generated report with 21 sections to ./report.html.",
+        "step_info": [
+
+        ],
+        "step_initial_condition": "Gathering data from EnergyPlus SQL file and OSM model.",
+        "step_result": "Success",
+        "step_values": [
+          {
+            "name": "building_summary_section",
+            "value": true
+          },
+          {
+            "name": "annual_overview_section",
+            "value": true
+          },
+          {
+            "name": "monthly_overview_section",
+            "value": true
+          },
+          {
+            "name": "utility_bills_rates_section",
+            "value": true
+          },
+          {
+            "name": "envelope_section_section",
+            "value": true
+          },
+          {
+            "name": "space_type_breakdown_section",
+            "value": true
+          },
+          {
+            "name": "space_type_details_section",
+            "value": true
+          },
+          {
+            "name": "interior_lighting_section",
+            "value": true
+          },
+          {
+            "name": "plug_loads_section",
+            "value": true
+          },
+          {
+            "name": "exterior_light_section",
+            "value": true
+          },
+          {
+            "name": "water_use_section",
+            "value": true
+          },
+          {
+            "name": "hvac_load_profile",
+            "value": true
+          },
+          {
+            "name": "zone_condition_section",
+            "value": true
+          },
+          {
+            "name": "zone_summary_section",
+            "value": true
+          },
+          {
+            "name": "zone_equipment_detail_section",
+            "value": true
+          },
+          {
+            "name": "air_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "plant_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "outdoor_air_section",
+            "value": true
+          },
+          {
+            "name": "cost_summary_section",
+            "value": true
+          },
+          {
+            "name": "source_energy_section",
+            "value": true
+          },
+          {
+            "name": "schedules_overview_section",
+            "value": true
+          },
+          {
+            "display_name": "Building 1",
+            "name": "building_name",
+            "value": "building_name"
+          },
+          {
+            "name": "total_site_energy",
+            "units": "kBtu",
+            "value": 3777202.88
+          },
+          {
+            "name": "net_site_energy",
+            "units": "kBtu",
+            "value": 3777202.88
+          },
+          {
+            "name": "total_building_area",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "total_site_eui",
+            "units": "kBtu/ft^2",
+            "value": 70.18
+          },
+          {
+            "name": "eui",
+            "units": "kBtu/ft^2",
+            "value": 70.18
+          },
+          {
+            "name": "unmet_hours_during_heating",
+            "units": "hr",
+            "value": 66.25
+          },
+          {
+            "name": "unmet_hours_during_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_during_occupied_heating",
+            "units": "hr",
+            "value": 10.75
+          },
+          {
+            "name": "unmet_hours_during_occupied_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_tolerance_heating",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "unmet_hours_tolerance_cooling",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "end_use_heating",
+            "units": "kBtu",
+            "value": 2493119.2
+          },
+          {
+            "name": "end_use_cooling",
+            "units": "kBtu",
+            "value": 65664.77
+          },
+          {
+            "name": "end_use_interior_lighting",
+            "units": "kBtu",
+            "value": 522304.1
+          },
+          {
+            "name": "end_use_exterior_lighting",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_interior_equipment",
+            "units": "kBtu",
+            "value": 522304.1
+          },
+          {
+            "name": "end_use_exterior_equipment",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_fans",
+            "units": "kBtu",
+            "value": 118770.96
+          },
+          {
+            "name": "end_use_pumps",
+            "units": "kBtu",
+            "value": 55030.26
+          },
+          {
+            "name": "end_use_heat_rejection",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_humidification",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_heat_recovery",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_water_systems",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_refrigeration",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_generators",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_electricity",
+            "units": "kBtu",
+            "value": 1284083.68
+          },
+          {
+            "name": "fuel_natural_gas",
+            "units": "kBtu",
+            "value": 2493119.2
+          },
+          {
+            "name": "fuel_additional_fuel",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_cooling",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_heating",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heating",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_cooling",
+            "units": "kWh",
+            "value": 19244.44
+          },
+          {
+            "name": "end_use_electricity_interior_lighting",
+            "units": "kWh",
+            "value": 153072.22
+          },
+          {
+            "name": "end_use_electricity_exterior_lighting",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_interior_equipment",
+            "units": "kWh",
+            "value": 153072.22
+          },
+          {
+            "name": "end_use_electricity_exterior_equipment",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_fans",
+            "units": "kWh",
+            "value": 34808.33
+          },
+          {
+            "name": "end_use_electricity_pumps",
+            "units": "kWh",
+            "value": 16127.78
+          },
+          {
+            "name": "end_use_electricity_heat_rejection",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_humidification",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heat_recovery",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_water_systems",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_refrigeration",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_generators",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heating",
+            "units": "therms",
+            "value": 24936.0
+          },
+          {
+            "name": "end_use_natural_gas_cooling",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_fans",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_pumps",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_rejection",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_humidification",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_recovery",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_water_systems",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_refrigeration",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_generators",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "electricity_heating_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_cooling_ip",
+            "units": "kWh",
+            "value": 19245.22
+          },
+          {
+            "name": "electricity_interior_lighting_ip",
+            "units": "kWh",
+            "value": 153073.56
+          },
+          {
+            "name": "electricity_exterior_lighting_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_interior_equipment_ip",
+            "units": "kWh",
+            "value": 153073.56
+          },
+          {
+            "name": "electricity_exterior_equipment_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_fans_ip",
+            "units": "kWh",
+            "value": 34807.94
+          },
+          {
+            "name": "electricity_pumps_ip",
+            "units": "kWh",
+            "value": 16127.79
+          },
+          {
+            "name": "electricity_heat_rejection_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_humidification_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_heat_recovery_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_water_systems_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_refrigeration_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_generators_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_ip",
+            "units": "kWh",
+            "value": 376328.06
+          },
+          {
+            "name": "natural_gas_heating_ip",
+            "units": "MBtu",
+            "value": 2493.12
+          },
+          {
+            "name": "natural_gas_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_ip",
+            "units": "MBtu",
+            "value": 2493.12
+          },
+          {
+            "name": "additional_fuel_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_roof_iead_climate_zone_2_5",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_wall_steel_frame_climate_zone_4_8",
+            "units": "ft^2",
+            "value": 7750.02
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_window_climate_zone_4_5",
+            "units": "ft^2",
+            "value": 5166.68
+          },
+          {
+            "name": "gross_window_wall_ratio",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "gross_window_wall_ratio_conditioned",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "skylight_roof_ratio",
+            "units": "%",
+            "value": 0
+          },
+          {
+            "name": "space_type_baseline_model_space_type",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "exterior_lighting_total_power",
+            "units": "W",
+            "value": 0
+          },
+          {
+            "name": "exterior_lighting_total_consumption",
+            "units": "kWh",
+            "value": 1106988.89
+          },
+          {
+            "name": "inflation_approach",
+            "value": "Constant Dollar"
+          },
+          {
+            "name": "analysis_length",
+            "units": "yrs",
+            "value": 25
+          },
+          {
+            "name": "annual_peak_electric_demand",
+            "units": "kW",
+            "value": 162.97
+          },
+          {
+            "name": "first_year_capital_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "annual_utility_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "total_lifecycle_cost",
+            "units": "$",
+            "value": 0
+          }
+        ],
+        "step_warnings": [
+
+        ]
+      }
+    }
+  ],
+  "weather_file": "../../weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw"
+}

--- a/test/airloop_and_zonehvac.rb_2.6.2_out.osw
+++ b/test/airloop_and_zonehvac.rb_2.6.2_out.osw
@@ -1,0 +1,1030 @@
+{
+  "completed_status": "Success",
+  "current_step": 1,
+  "eplusout_err": [
+    "Program Version,EnergyPlus, Version 8.9.0-eba93e8e1b, ",
+    "   ************* Beginning Zone Sizing Calculations",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 2\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 3\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 4\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 5\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 6\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 7\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS ON CONTINUOUS\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** GetHTSurfaceData: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.",
+    "   **   ~~~   ** Found first in surface=SURFACE 25",
+    "   **   ~~~   ** Defaults, constant throughout the year of (18.0) will be used.",
+    "   ** Warning ** CheckUsedConstructions: There are 8 nominally unused constructions in input.",
+    "   **   ~~~   ** For explicit details on each unused construction, use Output:Diagnostics,DisplayExtraWarnings;",
+    "   ************* Beginning Plant Sizing Calculations",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTCOOLING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTHEATING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Electricity:Facility\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr",
+    "   ************* Testing Individual Branch Integrity",
+    "   ************* All Branches passed integrity testing",
+    "   ************* Testing Individual Supply Air Path Integrity",
+    "   ************* All Supply Air Paths passed integrity testing",
+    "   ************* Testing Individual Return Air Path Integrity",
+    "   ************* All Return Air Paths passed integrity testing",
+    "   ************* No node connection errors were found.",
+    "   ************* Beginning Simulation",
+    "   ** Warning ** Processing Monthly Tabular Reports: Variable names not valid for this simulation",
+    "   **   ~~~   ** ...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual variables.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 4\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -5.43",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/01 10:40 - 10:45",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 5\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -3.30",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 02/16 14:53 - 15:00",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 2\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -3.88",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 02/20 09:35 - 09:40",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-ELECTRICITY\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-DISTILLATE OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-RESIDUAL OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-NATURAL GAS\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-COAL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ************* Simulation Error Summary *************",
+    "   ************* There are 1 unused schedules in input.",
+    "   ************* There are 1 unused week schedules in input.",
+    "   ************* There are 7 unused day schedules in input.",
+    "   ************* Use Output:Diagnostics,DisplayUnusedSchedules; to see them.",
+    "   *************",
+    "   ************* ===== Recurring Error Summary =====",
+    "   ************* The following recurring error messages occurred.",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 4\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 559 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.15 [C]  Min=-16.55 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 5\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 13 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.55 [C]  Min=-4.4 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 2\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 7 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-2.500000E-002 [C]  Min=-3.875 [C]",
+    "   *************",
+    "   *************",
+    "   ************* ===== Final Error Summary =====",
+    "   ************* The following error categories occurred.  Consider correcting or noting.",
+    "   ************* Nominally Unused Constructions",
+    "   ************* ..The nominally unused constructions warning is provided to alert you to potential conditions that can cause",
+    "   ************* ..extra time during simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm",
+    "   ************* ..object. You may remove the constructions indicated (when you use the DisplayExtraWarnings option).",
+    "   *************",
+    "   ************* EnergyPlus Warmup Error Summary. During Warmup: 0 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Sizing Error Summary. During Sizing: 9 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Completed Successfully-- 597 Warning; 0 Severe Errors; "
+  ],
+  "seed_file": "in.osm",
+  "steps": [
+    {
+      "arguments": {
+      },
+      "measure_dir_name": "openstudio_results",
+      "result": {
+        "measure_class_name": "OpenStudioResults",
+        "measure_display_name": "OpenStudio Results",
+        "measure_name": "openstudio_results",
+        "measure_taxonomy": "Reporting.QAQC",
+        "measure_type": "ReportingMeasure",
+        "measure_uid": "a25386cd-60e4-46bc-8b11-c755f379d916",
+        "measure_version_id": "5b8e57e8-830a-43ae-90d4-a41d97698d95",
+        "measure_version_modified": "20171219T161835Z",
+        "measure_xml_checksum": "557BF06F",
+        "stderr": "",
+        "stdout": "",
+        "step_errors": [
+
+        ],
+        "step_final_condition": "Generated report with 21 sections to ./report.html.",
+        "step_info": [
+
+        ],
+        "step_initial_condition": "Gathering data from EnergyPlus SQL file and OSM model.",
+        "step_result": "Success",
+        "step_values": [
+          {
+            "name": "building_summary_section",
+            "value": true
+          },
+          {
+            "name": "annual_overview_section",
+            "value": true
+          },
+          {
+            "name": "monthly_overview_section",
+            "value": true
+          },
+          {
+            "name": "utility_bills_rates_section",
+            "value": true
+          },
+          {
+            "name": "envelope_section_section",
+            "value": true
+          },
+          {
+            "name": "space_type_breakdown_section",
+            "value": true
+          },
+          {
+            "name": "space_type_details_section",
+            "value": true
+          },
+          {
+            "name": "interior_lighting_section",
+            "value": true
+          },
+          {
+            "name": "plug_loads_section",
+            "value": true
+          },
+          {
+            "name": "exterior_light_section",
+            "value": true
+          },
+          {
+            "name": "water_use_section",
+            "value": true
+          },
+          {
+            "name": "hvac_load_profile",
+            "value": true
+          },
+          {
+            "name": "zone_condition_section",
+            "value": true
+          },
+          {
+            "name": "zone_summary_section",
+            "value": true
+          },
+          {
+            "name": "zone_equipment_detail_section",
+            "value": true
+          },
+          {
+            "name": "air_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "plant_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "outdoor_air_section",
+            "value": true
+          },
+          {
+            "name": "cost_summary_section",
+            "value": true
+          },
+          {
+            "name": "source_energy_section",
+            "value": true
+          },
+          {
+            "name": "schedules_overview_section",
+            "value": true
+          },
+          {
+            "display_name": "Building 1",
+            "name": "building_name",
+            "value": "building_name"
+          },
+          {
+            "name": "total_site_energy",
+            "units": "kBtu",
+            "value": 3769876.25
+          },
+          {
+            "name": "net_site_energy",
+            "units": "kBtu",
+            "value": 3769876.25
+          },
+          {
+            "name": "total_building_area",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "total_site_eui",
+            "units": "kBtu/ft^2",
+            "value": 70.05
+          },
+          {
+            "name": "eui",
+            "units": "kBtu/ft^2",
+            "value": 70.05
+          },
+          {
+            "name": "unmet_hours_during_heating",
+            "units": "hr",
+            "value": 66.25
+          },
+          {
+            "name": "unmet_hours_during_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_during_occupied_heating",
+            "units": "hr",
+            "value": 10.75
+          },
+          {
+            "name": "unmet_hours_during_occupied_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_tolerance_heating",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "unmet_hours_tolerance_cooling",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "end_use_heating",
+            "units": "kBtu",
+            "value": 2492313.55
+          },
+          {
+            "name": "end_use_cooling",
+            "units": "kBtu",
+            "value": 65295.12
+          },
+          {
+            "name": "end_use_interior_lighting",
+            "units": "kBtu",
+            "value": 522304.1
+          },
+          {
+            "name": "end_use_exterior_lighting",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_interior_equipment",
+            "units": "kBtu",
+            "value": 522304.1
+          },
+          {
+            "name": "end_use_exterior_equipment",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_fans",
+            "units": "kBtu",
+            "value": 112638.59
+          },
+          {
+            "name": "end_use_pumps",
+            "units": "kBtu",
+            "value": 55011.31
+          },
+          {
+            "name": "end_use_heat_rejection",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_humidification",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_heat_recovery",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_water_systems",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_refrigeration",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_generators",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_electricity",
+            "units": "kBtu",
+            "value": 1277562.7
+          },
+          {
+            "name": "fuel_natural_gas",
+            "units": "kBtu",
+            "value": 2492313.55
+          },
+          {
+            "name": "fuel_additional_fuel",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_cooling",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_heating",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heating",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_cooling",
+            "units": "kWh",
+            "value": 19136.11
+          },
+          {
+            "name": "end_use_electricity_interior_lighting",
+            "units": "kWh",
+            "value": 153072.22
+          },
+          {
+            "name": "end_use_electricity_exterior_lighting",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_interior_equipment",
+            "units": "kWh",
+            "value": 153072.22
+          },
+          {
+            "name": "end_use_electricity_exterior_equipment",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_fans",
+            "units": "kWh",
+            "value": 33011.11
+          },
+          {
+            "name": "end_use_electricity_pumps",
+            "units": "kWh",
+            "value": 16122.22
+          },
+          {
+            "name": "end_use_electricity_heat_rejection",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_humidification",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heat_recovery",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_water_systems",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_refrigeration",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_generators",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heating",
+            "units": "therms",
+            "value": 24927.94
+          },
+          {
+            "name": "end_use_natural_gas_cooling",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_fans",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_pumps",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_rejection",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_humidification",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_recovery",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_water_systems",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_refrigeration",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_generators",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "electricity_heating_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_cooling_ip",
+            "units": "kWh",
+            "value": 19134.95
+          },
+          {
+            "name": "electricity_interior_lighting_ip",
+            "units": "kWh",
+            "value": 153073.56
+          },
+          {
+            "name": "electricity_exterior_lighting_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_interior_equipment_ip",
+            "units": "kWh",
+            "value": 153073.56
+          },
+          {
+            "name": "electricity_exterior_equipment_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_fans_ip",
+            "units": "kWh",
+            "value": 33011.23
+          },
+          {
+            "name": "electricity_pumps_ip",
+            "units": "kWh",
+            "value": 16123.51
+          },
+          {
+            "name": "electricity_heat_rejection_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_humidification_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_heat_recovery_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_water_systems_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_refrigeration_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_generators_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_ip",
+            "units": "kWh",
+            "value": 374416.8
+          },
+          {
+            "name": "natural_gas_heating_ip",
+            "units": "MBtu",
+            "value": 2492.31
+          },
+          {
+            "name": "natural_gas_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_ip",
+            "units": "MBtu",
+            "value": 2492.31
+          },
+          {
+            "name": "additional_fuel_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_roof_iead_climate_zone_2_5",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_wall_steel_frame_climate_zone_4_8",
+            "units": "ft^2",
+            "value": 7750.02
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_window_climate_zone_4_5",
+            "units": "ft^2",
+            "value": 5166.68
+          },
+          {
+            "name": "gross_window_wall_ratio",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "gross_window_wall_ratio_conditioned",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "skylight_roof_ratio",
+            "units": "%",
+            "value": 0
+          },
+          {
+            "name": "space_type_baseline_model_space_type",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "exterior_lighting_total_power",
+            "units": "W",
+            "value": 0
+          },
+          {
+            "name": "exterior_lighting_total_consumption",
+            "units": "kWh",
+            "value": 1104841.67
+          },
+          {
+            "name": "inflation_approach",
+            "value": "Constant Dollar"
+          },
+          {
+            "name": "analysis_length",
+            "units": "yrs",
+            "value": 25
+          },
+          {
+            "name": "annual_peak_electric_demand",
+            "units": "kW",
+            "value": 157.31
+          },
+          {
+            "name": "first_year_capital_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "annual_utility_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "total_lifecycle_cost",
+            "units": "$",
+            "value": 0
+          }
+        ],
+        "step_warnings": [
+
+        ]
+      }
+    }
+  ],
+  "weather_file": "../../weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw"
+}


### PR DESCRIPTION
Pull request overview
---------------------

**Addresses NREL/OpenStudio#3257.**

Link to relevant GitHub Issue(s) if appropriate:

This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

> This pull request adds missing tests for the following classes:
> *  [ThermalZone](https://github.com/NREL/OpenStudio/blob/equiplist_fix/openstudiocore/src/model/ThermalZone.hpp#L391-L393)
> *  [ZoneHVACEquipmentList](https://github.com/NREL/OpenStudio/blob/equiplist_fix/openstudiocore/src/model/ZoneHVACEquipmentList.hpp#L57-L59)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [x] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [x] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

