### PR TITLE
Update271

### DIFF
--- a/model/simulationtests/multiple_loops_w_plenums.osm
+++ b/model/simulationtests/multiple_loops_w_plenums.osm
@@ -1,10 +1,10 @@
 
 OS:Version,
-  {88f76c2e-fb3d-4e2e-875b-ea88517c3fcf}, !- Handle
-  2.6.2;                                  !- Version Identifier
+  {02b053da-77da-443b-8b76-eda1a0788d11}, !- Handle
+  2.7.0;                                  !- Version Identifier
 
 OS:BuildingStory,
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Handle
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Handle
   Story 1,                                !- Name
   0,                                      !- Nominal Z Coordinate {m}
   4,                                      !- Nominal Floor to Floor Height {m}
@@ -13,7 +13,7 @@ OS:BuildingStory,
   ;                                       !- Group Rendering Name
 
 OS:Space,
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Handle
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Handle
   Story 1 West Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -22,15 +22,15 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Building Story Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}; !- Thermal Zone Name
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Building Story Name
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}; !- Thermal Zone Name
 
 OS:Surface,
-  {ba347dc4-3e9e-4a9e-b293-fdc1bea9111d}, !- Handle
+  {a0dbdeea-9c32-4371-98b9-d1cd37d67707}, !- Handle
   Surface 1,                              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -43,11 +43,11 @@ OS:Surface,
   3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {b91f8b86-e731-44ae-9f7a-3925940443a2}, !- Handle
+  {3ba6f26a-e1c9-4fa3-92bd-5b2a99cdba71}, !- Handle
   Surface 2,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -60,13 +60,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {f475667a-6fdd-49e4-95d0-93dacaa717e0}, !- Handle
+  {8b20d013-b84b-49af-8b1f-b6adefdb6954}, !- Handle
   Surface 3,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {7f2d3158-6a3a-4875-b3bb-f46a29df471d}, !- Outside Boundary Condition Object
+  {1f02f916-6928-4071-bd94-e638208b6b8c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -77,13 +77,13 @@ OS:Surface,
   0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {87eb0d1f-bedf-4316-aabf-f0203a508eaf}, !- Handle
+  {08f913ff-fa8c-4524-8645-76b616aa149a}, !- Handle
   Surface 4,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {17353fd5-1e6a-4d5e-a939-1869925e0293}, !- Outside Boundary Condition Object
+  {506907ff-fe62-46e6-8509-2fb954f9c44c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -94,13 +94,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {127ea941-4402-41d0-bc06-681a188a823d}, !- Handle
+  {9c3d90a8-31e6-40ed-80bc-5945dbceb112}, !- Handle
   Surface 5,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {98f3179c-6212-4399-ae64-805b79b6a8cb}, !- Outside Boundary Condition Object
+  {339e2022-11ab-4db7-b606-f7533b6d73e9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -111,13 +111,13 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {abc67ae1-f361-4e12-bbaa-5ece7ded057b}, !- Handle
+  {d27a282f-5954-49f5-a5cc-026005455215}, !- Handle
   Surface 6,                              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {0a607d01-0659-4a2b-9ce7-336b33524a7d}, !- Space Name
+  {808270f4-ae2d-49f2-9706-d4199506c23c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {01d75303-70ee-4c64-97ed-7e25fb06366a}, !- Outside Boundary Condition Object
+  {86383e8e-329b-4437-abb3-6368d4f50928}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -128,7 +128,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Handle
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Handle
   Story 1 North Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -137,15 +137,15 @@ OS:Space,
   3,                                      !- X Origin {m}
   47,                                     !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Building Story Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}; !- Thermal Zone Name
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Building Story Name
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}; !- Thermal Zone Name
 
 OS:Surface,
-  {9d3b55c1-49a8-446b-aa57-13d7d4cadac7}, !- Handle
+  {de386ecd-73f4-4a69-9a95-030f5ce6bb9b}, !- Handle
   Surface 7,                              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -158,11 +158,11 @@ OS:Surface,
   0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {315d0d86-2dfe-4a7f-bbe8-422498bcbaa2}, !- Handle
+  {d3fd35bc-00ac-4f36-9c5d-fab439107f10}, !- Handle
   Surface 8,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -175,13 +175,13 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {41811bc3-bd3c-4336-8ac9-bc1e6c1c06c4}, !- Handle
+  {9923d8b7-ee58-4e4e-bc15-7107b226b961}, !- Handle
   Surface 9,                              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {80708b2d-cdc1-499e-8acc-4c58ad59ffdd}, !- Outside Boundary Condition Object
+  {b6e092af-9582-4b33-bd1a-0149404c0ee5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -192,13 +192,13 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {35ad2bac-81f9-4452-a710-0553c10e87a2}, !- Handle
+  {02982168-bd4b-43c0-8853-d08e0ba87eb3}, !- Handle
   Surface 10,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {4b1f173c-41a7-47c5-af6e-30a8f0579085}, !- Outside Boundary Condition Object
+  {d3947916-9394-4536-9d40-9376c1554847}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -209,13 +209,13 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {7f2d3158-6a3a-4875-b3bb-f46a29df471d}, !- Handle
+  {1f02f916-6928-4071-bd94-e638208b6b8c}, !- Handle
   Surface 11,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {f475667a-6fdd-49e4-95d0-93dacaa717e0}, !- Outside Boundary Condition Object
+  {8b20d013-b84b-49af-8b1f-b6adefdb6954}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -226,13 +226,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {b3733de5-3e4c-4a55-b217-199dbba52cba}, !- Handle
+  {ac8f45e5-4b32-401c-aa57-42d7e6616b1e}, !- Handle
   Surface 12,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {7594c168-369a-4227-a7b7-4708b347df2a}, !- Space Name
+  {a862081c-3e59-4e04-94fa-417ebe4eb08c}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {1f70e12d-a434-46dd-ba8e-550cd629b584}, !- Outside Boundary Condition Object
+  {e5e064e9-058b-49d3-80ca-f7f69dd2871f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -243,7 +243,7 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Handle
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Handle
   Story 1 East Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -252,15 +252,15 @@ OS:Space,
   97,                                     !- X Origin {m}
   3,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Building Story Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}; !- Thermal Zone Name
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Building Story Name
+  {04447c30-2fe3-475a-a960-2e2072326865}; !- Thermal Zone Name
 
 OS:Surface,
-  {2fe6117c-d463-44ba-9c29-2cefe15420ce}, !- Handle
+  {c1c78139-32e6-47db-a814-2a6eaa075e4d}, !- Handle
   Surface 13,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -273,11 +273,11 @@ OS:Surface,
   0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {ad5ffc9f-5844-43e6-a379-91e5dedc8387}, !- Handle
+  {ea907d1f-13ca-4181-a73f-9db08a8b1242}, !- Handle
   Surface 14,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -290,13 +290,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {e8a29726-bab4-477d-a454-eafbd6e74aba}, !- Handle
+  {e56dfcc5-8f9c-4a85-a8ae-710e95bdaaf5}, !- Handle
   Surface 15,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {527a756d-67e5-4c86-b40c-4dd96d8850b9}, !- Outside Boundary Condition Object
+  {e4065538-f83a-40f9-a72e-f3cbd834d2e2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -307,13 +307,13 @@ OS:Surface,
   3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {f5122950-86de-4f50-9fbc-9fe980b47dfa}, !- Handle
+  {576ea8e4-8c86-4197-acb5-0e56187a9578}, !- Handle
   Surface 16,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {4cc5ee26-97a8-4e82-b24b-65820dd91d0e}, !- Outside Boundary Condition Object
+  {e5e77a5e-8e4e-4c6f-9bd0-6a5db96a6cc1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -324,13 +324,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {80708b2d-cdc1-499e-8acc-4c58ad59ffdd}, !- Handle
+  {b6e092af-9582-4b33-bd1a-0149404c0ee5}, !- Handle
   Surface 17,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {41811bc3-bd3c-4336-8ac9-bc1e6c1c06c4}, !- Outside Boundary Condition Object
+  {9923d8b7-ee58-4e4e-bc15-7107b226b961}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -341,13 +341,13 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {1e7f235d-7369-4d73-b5fb-40aacea95c2e}, !- Handle
+  {73456bcd-1ad4-458c-b6f9-692a6872b525}, !- Handle
   Surface 18,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {76fe93f4-5ed6-4c0c-aa32-024259c12c66}, !- Space Name
+  {9171bb78-90aa-4f73-9ba6-349fe6bf6eee}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {a39b0e23-9c22-4499-b2a1-921735f4b0b9}, !- Outside Boundary Condition Object
+  {0c610164-9cfd-447a-aa03-4fd1fc288fae}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -358,7 +358,7 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Handle
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Handle
   Story 1 South Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -367,15 +367,15 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Building Story Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}; !- Thermal Zone Name
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Building Story Name
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}; !- Thermal Zone Name
 
 OS:Surface,
-  {fb410827-7d65-4ba6-adab-07358de79dd1}, !- Handle
+  {086d0c1e-1d84-4f2f-939b-f0d98a52a69f}, !- Handle
   Surface 19,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -388,11 +388,11 @@ OS:Surface,
   97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {97b88924-851b-46ed-b9b4-9b30ae148d5a}, !- Handle
+  {cb929871-4f38-4e67-9361-1f6dba09d026}, !- Handle
   Surface 20,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -405,13 +405,13 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {98f3179c-6212-4399-ae64-805b79b6a8cb}, !- Handle
+  {339e2022-11ab-4db7-b606-f7533b6d73e9}, !- Handle
   Surface 21,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {127ea941-4402-41d0-bc06-681a188a823d}, !- Outside Boundary Condition Object
+  {9c3d90a8-31e6-40ed-80bc-5945dbceb112}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -422,13 +422,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {3dbe9930-9db6-4537-be17-4ccf050d0a1c}, !- Handle
+  {9e32160b-0d47-43c3-9e90-6d9921044721}, !- Handle
   Surface 22,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {e41f26c1-d583-4eeb-b50f-086ff8bfea86}, !- Outside Boundary Condition Object
+  {e67ba867-f1e4-4bf4-ac2d-62d5a8ab2490}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -439,13 +439,13 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {527a756d-67e5-4c86-b40c-4dd96d8850b9}, !- Handle
+  {e4065538-f83a-40f9-a72e-f3cbd834d2e2}, !- Handle
   Surface 23,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {e8a29726-bab4-477d-a454-eafbd6e74aba}, !- Outside Boundary Condition Object
+  {e56dfcc5-8f9c-4a85-a8ae-710e95bdaaf5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -456,13 +456,13 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {786a5753-d6cd-4289-8a60-ab87d4a0c1c8}, !- Handle
+  {d60ce322-1b3a-4e0f-b49f-c6576c436153}, !- Handle
   Surface 24,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {c10d31bc-7259-43f6-9192-38c2a874affb}, !- Space Name
+  {21b7add5-f67c-4dbc-86e6-1f953e0223cc}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {3e2f0d9f-4166-4841-bd47-34a749090250}, !- Outside Boundary Condition Object
+  {328e5ddc-d482-498e-bd47-9697817cc1f7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -473,7 +473,7 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Handle
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Handle
   Story 1 Core Space,                     !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -482,15 +482,15 @@ OS:Space,
   3,                                      !- X Origin {m}
   3,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
-  {cd02f0a4-5a1e-4c37-a617-2bf4d7c41c23}, !- Building Story Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}; !- Thermal Zone Name
+  {c5552f0b-3f52-47d8-b7d0-d82fe7dfeee4}, !- Building Story Name
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}; !- Thermal Zone Name
 
 OS:Surface,
-  {9a7b8e55-8201-4c20-b8a3-f6d4f1068fde}, !- Handle
+  {d6a42dca-c6d1-4384-9b89-c878cccf5d2a}, !- Handle
   Surface 25,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Ground,                                 !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
@@ -503,13 +503,13 @@ OS:Surface,
   94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {17353fd5-1e6a-4d5e-a939-1869925e0293}, !- Handle
+  {506907ff-fe62-46e6-8509-2fb954f9c44c}, !- Handle
   Surface 26,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {87eb0d1f-bedf-4316-aabf-f0203a508eaf}, !- Outside Boundary Condition Object
+  {08f913ff-fa8c-4524-8645-76b616aa149a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -520,13 +520,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {4b1f173c-41a7-47c5-af6e-30a8f0579085}, !- Handle
+  {d3947916-9394-4536-9d40-9376c1554847}, !- Handle
   Surface 27,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {35ad2bac-81f9-4452-a710-0553c10e87a2}, !- Outside Boundary Condition Object
+  {02982168-bd4b-43c0-8853-d08e0ba87eb3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -537,13 +537,13 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {4cc5ee26-97a8-4e82-b24b-65820dd91d0e}, !- Handle
+  {e5e77a5e-8e4e-4c6f-9bd0-6a5db96a6cc1}, !- Handle
   Surface 28,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {f5122950-86de-4f50-9fbc-9fe980b47dfa}, !- Outside Boundary Condition Object
+  {576ea8e4-8c86-4197-acb5-0e56187a9578}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -554,13 +554,13 @@ OS:Surface,
   94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {e41f26c1-d583-4eeb-b50f-086ff8bfea86}, !- Handle
+  {e67ba867-f1e4-4bf4-ac2d-62d5a8ab2490}, !- Handle
   Surface 29,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {3dbe9930-9db6-4537-be17-4ccf050d0a1c}, !- Outside Boundary Condition Object
+  {9e32160b-0d47-43c3-9e90-6d9921044721}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -571,13 +571,13 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {828fa5bb-7376-4003-bbff-c55bc4cd7622}, !- Handle
+  {26573cb7-c9dd-4a74-9ff1-222e21ab6e4d}, !- Handle
   Surface 30,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {90921258-d8c1-4ed7-9deb-efb8821125aa}, !- Space Name
+  {3394d632-70be-429d-92af-c0a8334150ba}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {c1c1d7f9-a8d2-4697-a385-07038c519a83}, !- Outside Boundary Condition Object
+  {d9d57797-0e52-47d1-86fd-9c5bec0ed0a2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -588,7 +588,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:BuildingStory,
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Handle
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Handle
   Story 2,                                !- Name
   4,                                      !- Nominal Z Coordinate {m}
   4,                                      !- Nominal Floor to Floor Height {m}
@@ -597,7 +597,7 @@ OS:BuildingStory,
   ;                                       !- Group Rendering Name
 
 OS:Space,
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Handle
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Handle
   Story 2 West Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -606,17 +606,17 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   4,                                      !- Z Origin {m}
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Building Story Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}; !- Thermal Zone Name
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Building Story Name
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}; !- Thermal Zone Name
 
 OS:Surface,
-  {01d75303-70ee-4c64-97ed-7e25fb06366a}, !- Handle
+  {86383e8e-329b-4437-abb3-6368d4f50928}, !- Handle
   Surface 31,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {abc67ae1-f361-4e12-bbaa-5ece7ded057b}, !- Outside Boundary Condition Object
+  {d27a282f-5954-49f5-a5cc-026005455215}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -627,11 +627,11 @@ OS:Surface,
   3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {a7855523-bea6-4fe5-888b-4ed43e889fd0}, !- Handle
+  {b82511d2-eaad-4da3-894c-f3b20fda9da6}, !- Handle
   Surface 32,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -644,13 +644,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {35872c3e-5415-4706-b72d-ff794e7fd5f1}, !- Handle
+  {4e22a9e2-caf6-4104-83d5-08853efce2d1}, !- Handle
   Surface 33,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {e881ba00-48bc-4f36-8f5e-1ac427e8465a}, !- Outside Boundary Condition Object
+  {060db570-1a97-4cd5-b214-80d53a430e13}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -661,13 +661,13 @@ OS:Surface,
   0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {240ad58c-4f1b-4743-b7f9-77112bbad16e}, !- Handle
+  {40acec73-430b-439e-be42-b15e07c1a277}, !- Handle
   Surface 34,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {acdf42fd-906f-4357-bc15-ea75746db4ed}, !- Outside Boundary Condition Object
+  {35999ac4-f7c2-46b6-b956-fe2e00177583}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -678,13 +678,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {c0735d54-017c-4dc8-8372-6fc04a2fa261}, !- Handle
+  {bf1ed29a-2588-4c2b-89d4-847e0092e300}, !- Handle
   Surface 35,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {3536837a-48a2-456a-88ac-42eba38a32ee}, !- Outside Boundary Condition Object
+  {8c71c0a7-1bdc-448d-a747-34939c9c559e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -695,11 +695,11 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {a027d5af-fec4-4738-b4a4-5a4ad5eace37}, !- Handle
+  {bd1242f2-83b6-4814-9c3d-9ec5f2558197}, !- Handle
   Surface 36,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {507a0bc9-0de9-487a-9f21-7117acef6241}, !- Space Name
+  {b7368e9f-2004-4c1e-81ae-07b12d6bbae7}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -712,7 +712,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Handle
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Handle
   Story 2 North Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -721,17 +721,17 @@ OS:Space,
   3,                                      !- X Origin {m}
   47,                                     !- Y Origin {m}
   4,                                      !- Z Origin {m}
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Building Story Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}; !- Thermal Zone Name
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Building Story Name
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}; !- Thermal Zone Name
 
 OS:Surface,
-  {1f70e12d-a434-46dd-ba8e-550cd629b584}, !- Handle
+  {e5e064e9-058b-49d3-80ca-f7f69dd2871f}, !- Handle
   Surface 37,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {b3733de5-3e4c-4a55-b217-199dbba52cba}, !- Outside Boundary Condition Object
+  {ac8f45e5-4b32-401c-aa57-42d7e6616b1e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -742,11 +742,11 @@ OS:Surface,
   0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {d94038b6-78bb-4dbb-b954-7891a6160ad6}, !- Handle
+  {f10f1523-397d-4b5f-a410-0097411bffe4}, !- Handle
   Surface 38,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -759,13 +759,13 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {4b00856b-65bb-4269-9505-2eab05bd2bc9}, !- Handle
+  {583a9311-23c2-45b9-8317-9bc715ec8191}, !- Handle
   Surface 39,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {55d640ba-38f0-49d6-9aa0-44149b768b38}, !- Outside Boundary Condition Object
+  {0c32ea9c-bca2-4670-9624-a14721088afe}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -776,13 +776,13 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {7f9dad33-30ad-41c3-beb6-3ef13a6cf397}, !- Handle
+  {e450b1d1-256f-45cf-8754-b4b30ad648d1}, !- Handle
   Surface 40,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {8e9a0217-b3d6-4a0a-b202-38060c1bd878}, !- Outside Boundary Condition Object
+  {cc8ff1f9-1176-45cb-941a-57a539665a93}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -793,13 +793,13 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {e881ba00-48bc-4f36-8f5e-1ac427e8465a}, !- Handle
+  {060db570-1a97-4cd5-b214-80d53a430e13}, !- Handle
   Surface 41,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {35872c3e-5415-4706-b72d-ff794e7fd5f1}, !- Outside Boundary Condition Object
+  {4e22a9e2-caf6-4104-83d5-08853efce2d1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -810,11 +810,11 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {e346e424-6227-4d3c-a617-22f5f9dc4ef9}, !- Handle
+  {85a0842c-f4e7-4b49-94f1-d949d5ffaf54}, !- Handle
   Surface 42,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {343514b7-068c-4305-a4e2-85be0ae578d0}, !- Space Name
+  {d76c561c-61d2-4619-a887-68fb7bb7e411}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -827,7 +827,7 @@ OS:Surface,
   -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Handle
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Handle
   Story 2 East Perimeter Space,           !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -836,17 +836,17 @@ OS:Space,
   97,                                     !- X Origin {m}
   3,                                      !- Y Origin {m}
   4,                                      !- Z Origin {m}
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Building Story Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}; !- Thermal Zone Name
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Building Story Name
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}; !- Thermal Zone Name
 
 OS:Surface,
-  {a39b0e23-9c22-4499-b2a1-921735f4b0b9}, !- Handle
+  {0c610164-9cfd-447a-aa03-4fd1fc288fae}, !- Handle
   Surface 43,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {1e7f235d-7369-4d73-b5fb-40aacea95c2e}, !- Outside Boundary Condition Object
+  {73456bcd-1ad4-458c-b6f9-692a6872b525}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -857,11 +857,11 @@ OS:Surface,
   0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {d381700d-768f-4688-a350-26cecdc76e5c}, !- Handle
+  {b53dc4a9-987d-4259-a814-f98e9ed2a739}, !- Handle
   Surface 44,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -874,13 +874,13 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {814498d1-7e13-49b0-8273-e204942d4a5f}, !- Handle
+  {5ced30f6-4a42-4d92-a2e9-14a09774f9be}, !- Handle
   Surface 45,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {686f3cd8-cace-4b8d-9f5b-139783f07be7}, !- Outside Boundary Condition Object
+  {282d6e5d-5e1c-4798-98e0-22d7d641d281}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -891,13 +891,13 @@ OS:Surface,
   3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {26b9141e-f419-4915-8a85-2f981f80d11d}, !- Handle
+  {d131c759-2a6e-4420-9704-b885eed470c3}, !- Handle
   Surface 46,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {fedcbef7-1c40-4fbb-9770-bd73dcb41b51}, !- Outside Boundary Condition Object
+  {0412dbbb-e9f7-409c-9a3a-1b0741f579fa}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -908,13 +908,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {55d640ba-38f0-49d6-9aa0-44149b768b38}, !- Handle
+  {0c32ea9c-bca2-4670-9624-a14721088afe}, !- Handle
   Surface 47,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {4b00856b-65bb-4269-9505-2eab05bd2bc9}, !- Outside Boundary Condition Object
+  {583a9311-23c2-45b9-8317-9bc715ec8191}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -925,11 +925,11 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {077ccd3c-39fd-4e0d-bf9d-f3479137b9e6}, !- Handle
+  {b3b7f10c-e10e-46dc-83af-d30ed592ddc7}, !- Handle
   Surface 48,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {e840785e-1b3e-460f-8276-4fb4fcf640ce}, !- Space Name
+  {93abec31-97a5-4013-ae69-109890f941e2}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -942,7 +942,7 @@ OS:Surface,
   3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Handle
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Handle
   Story 2 South Perimeter Space,          !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -951,17 +951,17 @@ OS:Space,
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   4,                                      !- Z Origin {m}
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Building Story Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}; !- Thermal Zone Name
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Building Story Name
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}; !- Thermal Zone Name
 
 OS:Surface,
-  {3e2f0d9f-4166-4841-bd47-34a749090250}, !- Handle
+  {328e5ddc-d482-498e-bd47-9697817cc1f7}, !- Handle
   Surface 49,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {786a5753-d6cd-4289-8a60-ab87d4a0c1c8}, !- Outside Boundary Condition Object
+  {d60ce322-1b3a-4e0f-b49f-c6576c436153}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -972,11 +972,11 @@ OS:Surface,
   97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {d0cb7038-3f65-4c57-874c-15c5ff64f5e8}, !- Handle
+  {efa0488f-32fe-4cb6-8159-ad7b196b7df2}, !- Handle
   Surface 50,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -989,13 +989,13 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {3536837a-48a2-456a-88ac-42eba38a32ee}, !- Handle
+  {8c71c0a7-1bdc-448d-a747-34939c9c559e}, !- Handle
   Surface 51,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {c0735d54-017c-4dc8-8372-6fc04a2fa261}, !- Outside Boundary Condition Object
+  {bf1ed29a-2588-4c2b-89d4-847e0092e300}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1006,13 +1006,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {f2c970b3-b693-4930-a71b-c0b41b03debf}, !- Handle
+  {26683aa9-7541-4af0-bcaf-d8a9dd2f0f0f}, !- Handle
   Surface 52,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {1bb2eddf-3950-4e97-ac23-924d3638ac0b}, !- Outside Boundary Condition Object
+  {fe761542-a7f0-4c7d-be37-bb1cb410225f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1023,13 +1023,13 @@ OS:Surface,
   3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {686f3cd8-cace-4b8d-9f5b-139783f07be7}, !- Handle
+  {282d6e5d-5e1c-4798-98e0-22d7d641d281}, !- Handle
   Surface 53,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {814498d1-7e13-49b0-8273-e204942d4a5f}, !- Outside Boundary Condition Object
+  {5ced30f6-4a42-4d92-a2e9-14a09774f9be}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1040,11 +1040,11 @@ OS:Surface,
   97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {6db25380-1716-4be5-8ff3-3ec41114aeba}, !- Handle
+  {ad037ea7-8efb-4bc3-a965-17866c340c87}, !- Handle
   Surface 54,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {856cc75c-bac9-43b1-b047-f08f8495b698}, !- Space Name
+  {8669ead9-38a8-41fc-87ed-dffec62076ef}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -1057,7 +1057,7 @@ OS:Surface,
   100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Handle
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Handle
   Story 2 Core Space,                     !- Name
   ,                                       !- Space Type Name
   ,                                       !- Default Construction Set Name
@@ -1066,17 +1066,17 @@ OS:Space,
   3,                                      !- X Origin {m}
   3,                                      !- Y Origin {m}
   4,                                      !- Z Origin {m}
-  {f5a1ee29-5bc0-4fca-8864-5c81b98026b9}, !- Building Story Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}; !- Thermal Zone Name
+  {140e7cd0-90bd-4017-bccf-5bdc8f2e9e9e}, !- Building Story Name
+  {54861a32-007b-42ff-8229-2ea64b538c06}; !- Thermal Zone Name
 
 OS:Surface,
-  {c1c1d7f9-a8d2-4697-a385-07038c519a83}, !- Handle
+  {d9d57797-0e52-47d1-86fd-9c5bec0ed0a2}, !- Handle
   Surface 55,                             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {828fa5bb-7376-4003-bbff-c55bc4cd7622}, !- Outside Boundary Condition Object
+  {26573cb7-c9dd-4a74-9ff1-222e21ab6e4d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1087,13 +1087,13 @@ OS:Surface,
   94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {acdf42fd-906f-4357-bc15-ea75746db4ed}, !- Handle
+  {35999ac4-f7c2-46b6-b956-fe2e00177583}, !- Handle
   Surface 56,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {240ad58c-4f1b-4743-b7f9-77112bbad16e}, !- Outside Boundary Condition Object
+  {40acec73-430b-439e-be42-b15e07c1a277}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1104,13 +1104,13 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {8e9a0217-b3d6-4a0a-b202-38060c1bd878}, !- Handle
+  {cc8ff1f9-1176-45cb-941a-57a539665a93}, !- Handle
   Surface 57,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {7f9dad33-30ad-41c3-beb6-3ef13a6cf397}, !- Outside Boundary Condition Object
+  {e450b1d1-256f-45cf-8754-b4b30ad648d1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1121,13 +1121,13 @@ OS:Surface,
   0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {fedcbef7-1c40-4fbb-9770-bd73dcb41b51}, !- Handle
+  {0412dbbb-e9f7-409c-9a3a-1b0741f579fa}, !- Handle
   Surface 58,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {26b9141e-f419-4915-8a85-2f981f80d11d}, !- Outside Boundary Condition Object
+  {d131c759-2a6e-4420-9704-b885eed470c3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1138,13 +1138,13 @@ OS:Surface,
   94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {1bb2eddf-3950-4e97-ac23-924d3638ac0b}, !- Handle
+  {fe761542-a7f0-4c7d-be37-bb1cb410225f}, !- Handle
   Surface 59,                             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {f2c970b3-b693-4930-a71b-c0b41b03debf}, !- Outside Boundary Condition Object
+  {26683aa9-7541-4af0-bcaf-d8a9dd2f0f0f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1155,11 +1155,11 @@ OS:Surface,
   94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {61ee0c69-c761-41a9-96b6-8043fac0e0d6}, !- Handle
+  {e356158d-0b0c-4fc6-a1a4-e01111e73dbe}, !- Handle
   Surface 60,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
-  {22af24f7-fa22-45f9-aa65-7565bad6448f}, !- Space Name
+  {31839d06-1c1b-4085-9518-aac6ffea669f}, !- Space Name
   Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   SunExposed,                             !- Sun Exposure
@@ -1172,7 +1172,7 @@ OS:Surface,
   0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
 
 OS:ThermalZone,
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}, !- Handle
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}, !- Handle
   Story 1 Core Thermal Zone,              !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1181,51 +1181,51 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {0a7ef0dc-0a76-4613-b575-19ae39630b7b}, !- Zone Air Inlet Port List
-  {a9f3d0c8-74a5-4d76-8718-433c778aaa47}, !- Zone Air Exhaust Port List
-  {e47a5d1e-08e3-4176-ab0d-65e23d651388}, !- Zone Air Node Name
-  {67c6b59a-005f-46b6-8ef7-9f4dbda71fad}, !- Zone Return Air Port List
+  {2dc5f109-ea4d-4bf4-a383-37e25facd7f5}, !- Zone Air Inlet Port List
+  {db854711-42de-4af5-bdb4-fbb4f7abefab}, !- Zone Air Exhaust Port List
+  {86430d24-6f98-40d7-bed7-ac2101a99f79}, !- Zone Air Node Name
+  {c7c00db1-6f4b-4319-94d1-531532185141}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {c32c9e89-a66a-4a92-b035-51881c6ad791}, !- Thermostat Name
+  {5796930f-d244-4993-96af-8a7010732ffd}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {093132ec-e095-4075-9e75-fb495b2a2b99}, !- Handle
+  {c8d13dd1-a669-4aa8-9656-115fb815b60a}, !- Handle
   Node 1,                                 !- Name
-  {e47a5d1e-08e3-4176-ab0d-65e23d651388}, !- Inlet Port
+  {86430d24-6f98-40d7-bed7-ac2101a99f79}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {e47a5d1e-08e3-4176-ab0d-65e23d651388}, !- Handle
-  {7cbb41d6-97b2-44e9-a586-46395b91dbf3}, !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}, !- Source Object
+  {86430d24-6f98-40d7-bed7-ac2101a99f79}, !- Handle
+  {46d528c8-2374-41e8-87c6-2b2e78ebc820}, !- Name
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}, !- Source Object
   11,                                     !- Outlet Port
-  {093132ec-e095-4075-9e75-fb495b2a2b99}, !- Target Object
+  {c8d13dd1-a669-4aa8-9656-115fb815b60a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {0a7ef0dc-0a76-4613-b575-19ae39630b7b}, !- Handle
-  {a3a09ecf-e646-4ce0-9768-86512f57a196}, !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}; !- HVAC Component
+  {2dc5f109-ea4d-4bf4-a383-37e25facd7f5}, !- Handle
+  {d46f2bfb-04bf-4fd5-806a-6caf6dff7711}, !- Name
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}; !- HVAC Component
 
 OS:PortList,
-  {a9f3d0c8-74a5-4d76-8718-433c778aaa47}, !- Handle
-  {8a099999-60b0-402a-a6b8-f04fdc899931}, !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}; !- HVAC Component
+  {db854711-42de-4af5-bdb4-fbb4f7abefab}, !- Handle
+  {11336d7a-8109-46cb-84a3-8c4d86a22023}, !- Name
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}; !- HVAC Component
 
 OS:PortList,
-  {67c6b59a-005f-46b6-8ef7-9f4dbda71fad}, !- Handle
-  {59731bd8-a315-465b-acd5-485d6e437c29}, !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}; !- HVAC Component
+  {c7c00db1-6f4b-4319-94d1-531532185141}, !- Handle
+  {a3cedbbc-2efc-41ca-8ea3-05f8419a1d4d}, !- Name
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {0ca9dbc5-f5d7-4d6b-b02f-4279348554ff}, !- Handle
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}, !- Zone or ZoneList Name
+  {190ff58c-4d36-4065-9923-4c5898eab40d}, !- Handle
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1254,12 +1254,12 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {3a44358d-0b37-4a34-addf-570464bf1584}, !- Handle
+  {f26a3785-1086-4a48-815f-12934786a207}, !- Handle
   Zone HVAC Equipment List 1,             !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}; !- Thermal Zone
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}; !- Thermal Zone
 
 OS:ThermalZone,
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- Handle
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- Handle
   Story 1 East Perimeter Thermal Zone,    !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1268,55 +1268,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {a3ae2cfe-592b-4de8-a162-12d5d60726a6}, !- Zone Air Inlet Port List
-  {4399e9ee-6243-455e-b961-c3aec3a4f757}, !- Zone Air Exhaust Port List
-  {d9d75cdb-2d27-42e9-87cb-c022d770fb75}, !- Zone Air Node Name
-  {6cde623f-f7ab-4c23-95d7-ec8881d9f865}, !- Zone Return Air Port List
+  {f9cf39c5-f2b9-433a-8441-a27787b1837a}, !- Zone Air Inlet Port List
+  {5ff3a6b0-da85-467e-9039-dbec0f8610fb}, !- Zone Air Exhaust Port List
+  {42ab6155-1e17-43e2-8885-0c9d37340df0}, !- Zone Air Node Name
+  {34e1d912-530c-4fbf-af8d-90ce615cb03d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {3c255959-cbc8-44f9-b9d4-62195cf87fe7}, !- Thermostat Name
+  {b72f7b35-1fff-4314-87f3-ddc70172ec54}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {db868b11-ce79-4b4d-9a23-cb27f5c5bf2b}, !- Handle
+  {a03131ec-01e8-4296-8c18-7d953810d40f}, !- Handle
   Node 2,                                 !- Name
-  {d9d75cdb-2d27-42e9-87cb-c022d770fb75}, !- Inlet Port
+  {42ab6155-1e17-43e2-8885-0c9d37340df0}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {d9d75cdb-2d27-42e9-87cb-c022d770fb75}, !- Handle
-  {5faacb87-2b61-4dc9-9ff3-974b03cb48be}, !- Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- Source Object
+  {42ab6155-1e17-43e2-8885-0c9d37340df0}, !- Handle
+  {934d2fa8-9dce-415b-93cb-4318620db7dc}, !- Name
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- Source Object
   11,                                     !- Outlet Port
-  {db868b11-ce79-4b4d-9a23-cb27f5c5bf2b}, !- Target Object
+  {a03131ec-01e8-4296-8c18-7d953810d40f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {a3ae2cfe-592b-4de8-a162-12d5d60726a6}, !- Handle
-  {daa1db79-1374-4563-b128-05cb77e512a4}, !- Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- HVAC Component
-  {2de80d95-bcc9-4192-bdec-740f75efb5f8}, !- Port 1
-  {b6b81218-3ac0-4b12-90e9-fc382c71827d}; !- Port 2
+  {f9cf39c5-f2b9-433a-8441-a27787b1837a}, !- Handle
+  {e195b4c6-8d7d-4f72-96b8-cef479a103c8}, !- Name
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- HVAC Component
+  {71510ca9-685c-460b-84f9-05cd7042ee52}, !- Port 1
+  {ec11edbf-e901-4b0e-b796-431ad7183b79}; !- Port 2
 
 OS:PortList,
-  {4399e9ee-6243-455e-b961-c3aec3a4f757}, !- Handle
-  {63501196-f7a0-46bb-b668-99e4031b43ab}, !- Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}; !- HVAC Component
+  {5ff3a6b0-da85-467e-9039-dbec0f8610fb}, !- Handle
+  {a0cb5f12-a552-4cb2-8e3d-0bf12981f35a}, !- Name
+  {04447c30-2fe3-475a-a960-2e2072326865}; !- HVAC Component
 
 OS:PortList,
-  {6cde623f-f7ab-4c23-95d7-ec8881d9f865}, !- Handle
-  {3e72bcee-c401-4fa2-ab46-e4bcd9750b01}, !- Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- HVAC Component
-  {c5469a77-2337-44a5-be7e-3f6f76e91a13}, !- Port 1
-  {e5d4a0f2-13bc-4f04-9896-4b0932728b9e}; !- Port 2
+  {34e1d912-530c-4fbf-af8d-90ce615cb03d}, !- Handle
+  {6724d2bb-ccc3-43d1-8aa0-36f5154b8329}, !- Name
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- HVAC Component
+  {4914116b-30d4-4458-a502-9e7496e6d032}, !- Port 1
+  {bd097d78-bed2-461e-9ebe-5228921b459f}; !- Port 2
 
 OS:Sizing:Zone,
-  {d07ed113-f3b2-40a0-806f-58e30bbfcfaf}, !- Handle
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- Zone or ZoneList Name
+  {574e6d3c-d71f-4b06-a072-05cddb5afe9d}, !- Handle
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1345,18 +1345,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {483ab546-7c94-4aac-8a0d-dc491add9757}, !- Handle
+  {d0c050f7-41e0-4b2f-9458-da56f9bcc267}, !- Handle
   Zone HVAC Equipment List 2,             !- Name
-  {2e7b327c-b4bd-42b1-b926-10c6312df3b4}, !- Thermal Zone
-  {76fa19cc-5ecb-424d-a368-9f1899b08695}, !- Zone Equipment 1
+  {04447c30-2fe3-475a-a960-2e2072326865}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {5189153b-e701-4fa0-97de-72c39b9e5310}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {f0fc1da6-2680-4a2d-ac0e-7778af7590a1}, !- Zone Equipment 2
+  {a489e831-427b-455d-b53f-a279b504c703}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- Handle
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- Handle
   Story 1 North Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1365,55 +1366,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {c5243fcc-3139-4d7b-a5b0-3b7b711e0e28}, !- Zone Air Inlet Port List
-  {536d6dba-5039-44e1-8ff3-f1d6853f0905}, !- Zone Air Exhaust Port List
-  {0a5d0af7-2053-4cfe-b74b-463f8a83258f}, !- Zone Air Node Name
-  {f6888b8b-7a06-4454-b283-9947d282069d}, !- Zone Return Air Port List
+  {b013d9bb-6e7b-43b5-b933-8a3197525aac}, !- Zone Air Inlet Port List
+  {137f46c3-f1f8-4927-b769-dc72a006b9ca}, !- Zone Air Exhaust Port List
+  {f16ec360-4384-4f1d-ac46-85a91b7b5d90}, !- Zone Air Node Name
+  {b8f5d8e3-c832-4f97-9096-15658f3433a9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {3266a68f-7518-4315-bc1c-57d216934f63}, !- Thermostat Name
+  {666e6b34-167c-441e-8b2f-3e86cb0aad48}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {11c0d3d7-9237-4c2d-9ebd-c52ed61a9803}, !- Handle
+  {24ed8f7d-952e-4cd9-8f95-f04cf7303303}, !- Handle
   Node 3,                                 !- Name
-  {0a5d0af7-2053-4cfe-b74b-463f8a83258f}, !- Inlet Port
+  {f16ec360-4384-4f1d-ac46-85a91b7b5d90}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {0a5d0af7-2053-4cfe-b74b-463f8a83258f}, !- Handle
-  {34797961-e489-4815-bf07-ac54b9e2994b}, !- Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- Source Object
+  {f16ec360-4384-4f1d-ac46-85a91b7b5d90}, !- Handle
+  {33b1a170-05f2-4d65-9069-82ff14d1d678}, !- Name
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- Source Object
   11,                                     !- Outlet Port
-  {11c0d3d7-9237-4c2d-9ebd-c52ed61a9803}, !- Target Object
+  {24ed8f7d-952e-4cd9-8f95-f04cf7303303}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {c5243fcc-3139-4d7b-a5b0-3b7b711e0e28}, !- Handle
-  {f8486996-59bd-4d8c-b4fd-c44e2c341d50}, !- Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- HVAC Component
-  {68cd1584-e440-40f6-8a3d-78161a6a85e3}, !- Port 1
-  {e49afaea-6321-4fb6-8e07-a6f176fae502}; !- Port 2
+  {b013d9bb-6e7b-43b5-b933-8a3197525aac}, !- Handle
+  {5b0ea416-a0dc-4448-9de2-7d877c9f996e}, !- Name
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- HVAC Component
+  {5d52656a-c140-436d-bb13-41035ba30175}, !- Port 1
+  {3d864097-09b9-4449-8c9a-f66f619f2c85}; !- Port 2
 
 OS:PortList,
-  {536d6dba-5039-44e1-8ff3-f1d6853f0905}, !- Handle
-  {284fdd9c-eebd-435d-93f4-f5292dac2ae4}, !- Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}; !- HVAC Component
+  {137f46c3-f1f8-4927-b769-dc72a006b9ca}, !- Handle
+  {9728ad8a-a5fe-455d-b9d3-4026c64e42a7}, !- Name
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}; !- HVAC Component
 
 OS:PortList,
-  {f6888b8b-7a06-4454-b283-9947d282069d}, !- Handle
-  {d7bc29af-ed20-4bcb-8896-156f24126f22}, !- Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- HVAC Component
-  {0e4f48c5-4636-43ba-9cae-2b5b1b22b781}, !- Port 1
-  {469f2973-e376-4115-aca5-e50bd6653d24}; !- Port 2
+  {b8f5d8e3-c832-4f97-9096-15658f3433a9}, !- Handle
+  {373b5618-4b09-4398-bd8b-3c1a5e3200b0}, !- Name
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- HVAC Component
+  {dcf5e50d-d2ff-4c97-ae32-3a3c9967e2e0}, !- Port 1
+  {0cb5743b-9e14-4aff-aab0-5e2dbc8a62d3}; !- Port 2
 
 OS:Sizing:Zone,
-  {3af393fa-992e-48a0-914b-787ad35365f6}, !- Handle
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- Zone or ZoneList Name
+  {1a7d5fad-343d-4893-bd2c-6c85545672d4}, !- Handle
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1442,18 +1443,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {8e69eeba-002a-44ce-a8c4-1fa6bcb9d527}, !- Handle
+  {6b884816-dac5-4e4c-820b-3a43d81c5d42}, !- Handle
   Zone HVAC Equipment List 3,             !- Name
-  {b62b90dc-3dd0-4f64-a426-26f55e7112d1}, !- Thermal Zone
-  {0caa970c-b2ce-4104-b41e-11a5536d44b7}, !- Zone Equipment 1
+  {d8893968-55ed-4ca6-b65d-9d0fbbaa855d}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {5931adcd-1fd7-417b-8755-69fb9991e32d}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {53e94f22-5fdf-4a8c-b627-50291494ce10}, !- Zone Equipment 2
+  {ad473cc8-4b29-4ba9-9a73-4360c7bd3e12}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- Handle
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- Handle
   Story 1 South Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1462,55 +1464,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {aeac121c-c6ed-464b-9940-dbaf54f5bfde}, !- Zone Air Inlet Port List
-  {117bd56b-2de5-4f06-bcfd-9dadb2d8c40b}, !- Zone Air Exhaust Port List
-  {c8c53d41-aac0-4f84-91c8-b59f330d549e}, !- Zone Air Node Name
-  {e2d252d0-fabd-4afb-b386-bc11c7618a04}, !- Zone Return Air Port List
+  {cf402869-4714-4cf1-885a-7a74464049fd}, !- Zone Air Inlet Port List
+  {a99904b0-fe19-4564-9175-c8791f232b40}, !- Zone Air Exhaust Port List
+  {ff986f8a-1453-4320-8d1a-e859a3404e5e}, !- Zone Air Node Name
+  {ad7c48a9-7942-4555-ac3a-44c7a61df8a7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {09efc2f1-fe33-4a4b-88f1-9e9764c0a3d1}, !- Thermostat Name
+  {86eecd91-4331-4a62-ada4-b5b659b7d0bb}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {4b680831-c839-44d0-923f-8bf9ab3a4c5b}, !- Handle
+  {7347ff40-53bf-48f0-ac4d-e7a1e97ea9ad}, !- Handle
   Node 4,                                 !- Name
-  {c8c53d41-aac0-4f84-91c8-b59f330d549e}, !- Inlet Port
+  {ff986f8a-1453-4320-8d1a-e859a3404e5e}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {c8c53d41-aac0-4f84-91c8-b59f330d549e}, !- Handle
-  {4d1a27e1-ee6d-49aa-9960-77db389150c8}, !- Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- Source Object
+  {ff986f8a-1453-4320-8d1a-e859a3404e5e}, !- Handle
+  {c1a6447d-2384-4bfe-9c66-521d21b247e0}, !- Name
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- Source Object
   11,                                     !- Outlet Port
-  {4b680831-c839-44d0-923f-8bf9ab3a4c5b}, !- Target Object
+  {7347ff40-53bf-48f0-ac4d-e7a1e97ea9ad}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {aeac121c-c6ed-464b-9940-dbaf54f5bfde}, !- Handle
-  {bfed12b9-0561-4e7e-bb2f-6c4bb959c8b8}, !- Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- HVAC Component
-  {d7ccddf8-fd24-47b1-b120-71f7346eaa6a}, !- Port 1
-  {b56f6545-26db-4bd5-a801-c09c4685edfb}; !- Port 2
+  {cf402869-4714-4cf1-885a-7a74464049fd}, !- Handle
+  {f00199d9-4042-4cdd-8612-c85b2ee668a5}, !- Name
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- HVAC Component
+  {bfa2db62-9c93-4ca6-9c4a-a35d738f984e}, !- Port 1
+  {58b739f0-4622-4256-a5c5-d7b1ef5153eb}; !- Port 2
 
 OS:PortList,
-  {117bd56b-2de5-4f06-bcfd-9dadb2d8c40b}, !- Handle
-  {58a5d392-52b8-4952-bb80-3cd362448a8e}, !- Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}; !- HVAC Component
+  {a99904b0-fe19-4564-9175-c8791f232b40}, !- Handle
+  {113d3999-337b-42e4-86dc-4eaf0596576f}, !- Name
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}; !- HVAC Component
 
 OS:PortList,
-  {e2d252d0-fabd-4afb-b386-bc11c7618a04}, !- Handle
-  {9ee2f194-4be6-443c-ad74-d05220d10e32}, !- Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- HVAC Component
-  {64e0b73f-8b69-4661-b689-f15e03c38d45}, !- Port 1
-  {6ed4712b-d350-4b3e-8a5f-4889c01a0e8b}; !- Port 2
+  {ad7c48a9-7942-4555-ac3a-44c7a61df8a7}, !- Handle
+  {ca7eded0-f428-465b-9430-acc8f354c332}, !- Name
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- HVAC Component
+  {7c6e54e9-68fc-4eb2-9694-3cf0e5331912}, !- Port 1
+  {3a7a574c-d4b1-4ea6-9a7e-8b2b812373e6}; !- Port 2
 
 OS:Sizing:Zone,
-  {9facc3bf-71e2-4956-9cc5-340cec611c52}, !- Handle
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- Zone or ZoneList Name
+  {b5f24397-e066-4ee7-867a-0be8ea77cac1}, !- Handle
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1539,18 +1541,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {5e267b87-d2a7-44a1-8472-cf7fecb8af9f}, !- Handle
+  {c5f6b15e-5cb7-4715-bd69-d9bba72c5334}, !- Handle
   Zone HVAC Equipment List 4,             !- Name
-  {0099e15a-f685-47c5-996c-a15576b57a35}, !- Thermal Zone
-  {3cafb1a1-021e-43cb-a7dc-cea372fb991f}, !- Zone Equipment 1
+  {40f0a882-a25d-46da-bbab-fcd02d3ea4f2}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {2e295cb8-5e31-4c59-9c57-dd649e6430ca}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {dcbb997a-8e9b-4fd1-923d-2af7228fc00c}, !- Zone Equipment 2
+  {1a6c952c-ace3-44b9-83cb-baf543185497}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- Handle
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- Handle
   Story 1 West Perimeter Thermal Zone,    !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1559,55 +1562,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {ed966860-1232-4cea-a353-bc9278caa407}, !- Zone Air Inlet Port List
-  {41890662-aff0-4810-906c-5dc3ce8ef07d}, !- Zone Air Exhaust Port List
-  {54e81981-234c-4099-9238-bc114af2b30e}, !- Zone Air Node Name
-  {2dc6338d-d0c4-4b49-a80f-60ac3fa78931}, !- Zone Return Air Port List
+  {3f08aa56-9494-4c79-b410-53887ea5b9e6}, !- Zone Air Inlet Port List
+  {3758d333-2477-49fb-8dc2-a37c3d833221}, !- Zone Air Exhaust Port List
+  {ad6db179-f4e5-4a10-978a-88437e10a027}, !- Zone Air Node Name
+  {ba7d211e-dc53-45ab-b570-f7e48508ea4f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {6b18e723-d965-489d-9e1a-930789957c11}, !- Thermostat Name
+  {c2a75eb6-7265-43a8-90b2-cab24787e3e5}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {c90b16a4-c45c-48ee-9e49-6cca4a44815f}, !- Handle
+  {ce5b7613-5c20-45bd-9e49-5c07cdafa8f0}, !- Handle
   Node 5,                                 !- Name
-  {54e81981-234c-4099-9238-bc114af2b30e}, !- Inlet Port
+  {ad6db179-f4e5-4a10-978a-88437e10a027}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {54e81981-234c-4099-9238-bc114af2b30e}, !- Handle
-  {de89eb95-24f1-4965-8e9d-17e8bf77808f}, !- Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- Source Object
+  {ad6db179-f4e5-4a10-978a-88437e10a027}, !- Handle
+  {8d169dee-96aa-4eba-b01c-515809df24c2}, !- Name
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- Source Object
   11,                                     !- Outlet Port
-  {c90b16a4-c45c-48ee-9e49-6cca4a44815f}, !- Target Object
+  {ce5b7613-5c20-45bd-9e49-5c07cdafa8f0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {ed966860-1232-4cea-a353-bc9278caa407}, !- Handle
-  {6e496d14-5f4e-467b-b99e-72ed48d24a6d}, !- Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- HVAC Component
-  {6c09741b-d952-4e5c-aa80-c52742d35784}, !- Port 1
-  {e375068c-c518-4085-89f5-602a0d5b44b0}; !- Port 2
+  {3f08aa56-9494-4c79-b410-53887ea5b9e6}, !- Handle
+  {b723ce39-21c6-4346-981f-8abb38872bd6}, !- Name
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- HVAC Component
+  {1a3ca6f8-187b-44b5-958b-1d75b6ad9905}, !- Port 1
+  {4fa7d102-f1d8-426b-be27-8794a810685f}; !- Port 2
 
 OS:PortList,
-  {41890662-aff0-4810-906c-5dc3ce8ef07d}, !- Handle
-  {bba9fb79-3eda-4277-a987-fa22c19ee3f5}, !- Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}; !- HVAC Component
+  {3758d333-2477-49fb-8dc2-a37c3d833221}, !- Handle
+  {746db1f0-8f0b-4a6c-be0e-5a2e0c71dc1a}, !- Name
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}; !- HVAC Component
 
 OS:PortList,
-  {2dc6338d-d0c4-4b49-a80f-60ac3fa78931}, !- Handle
-  {447a202c-8dd6-4be2-adb6-6923450705f9}, !- Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- HVAC Component
-  {f5de5e5e-4f7d-4a6c-b7b0-4d18d2018500}, !- Port 1
-  {29566d72-e7b7-4815-862c-a5c5b5867846}; !- Port 2
+  {ba7d211e-dc53-45ab-b570-f7e48508ea4f}, !- Handle
+  {a0902010-f641-44b3-ba27-c2a0e93b3c71}, !- Name
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- HVAC Component
+  {81044b0b-9c59-40d6-be5c-b3656c2bf481}, !- Port 1
+  {8d000667-2431-4993-b258-3b2d4b7eb697}; !- Port 2
 
 OS:Sizing:Zone,
-  {b9a07474-54c5-479d-8707-1d79fda8dfde}, !- Handle
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- Zone or ZoneList Name
+  {ee6f8ca2-73d8-4782-b5dc-491b11ef531c}, !- Handle
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1636,18 +1639,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {389cb2b1-c244-475d-8137-8ae5c0348222}, !- Handle
+  {90a014f4-e527-4231-bb55-dade56b8a197}, !- Handle
   Zone HVAC Equipment List 5,             !- Name
-  {7b53396c-d413-4c27-8c37-3004e9655e20}, !- Thermal Zone
-  {f26318e7-88a8-4820-b495-0417a5a8b97d}, !- Zone Equipment 1
+  {b9caba1b-3348-4b10-85b5-18895dcfc756}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {d389a078-5041-4852-9722-e526425acfd5}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {fc8b6947-d84e-4ab4-be7b-3a17ba881b42}, !- Zone Equipment 2
+  {bd463d8b-30b8-4705-9440-f8ac8c4ba19f}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}, !- Handle
+  {54861a32-007b-42ff-8229-2ea64b538c06}, !- Handle
   Story 2 Core Thermal Zone,              !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1656,51 +1660,51 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {e06fc115-ff6a-47c2-8e3d-8c0d4e00b852}, !- Zone Air Inlet Port List
-  {c9b25384-e43a-4d81-9fc7-a80d30986526}, !- Zone Air Exhaust Port List
-  {fe0cb63b-5609-41d0-9575-c67370053117}, !- Zone Air Node Name
-  {a295a81c-d28c-4902-ae7e-fccfd33cc49e}, !- Zone Return Air Port List
+  {068ed2e0-4c95-4344-8482-be1917e48b89}, !- Zone Air Inlet Port List
+  {bfbc2f98-0c11-422b-bf45-0a748a65b2f9}, !- Zone Air Exhaust Port List
+  {3d1b2ed5-d4c4-4e74-971d-d8c262264858}, !- Zone Air Node Name
+  {90fee810-5aae-40d9-90cd-7fd89202a8d9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {b01772e4-95e5-45eb-a03c-46afab05b355}, !- Thermostat Name
+  {60d5d0a2-91ed-48d1-b865-5d8722e7bc9e}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {77cd8484-1ace-4f56-94e6-8e2e9467f632}, !- Handle
+  {5034acd5-8709-445a-bac1-23a5651a0550}, !- Handle
   Node 6,                                 !- Name
-  {fe0cb63b-5609-41d0-9575-c67370053117}, !- Inlet Port
+  {3d1b2ed5-d4c4-4e74-971d-d8c262264858}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {fe0cb63b-5609-41d0-9575-c67370053117}, !- Handle
-  {59ea3589-58cc-49cc-9f5c-999347e76125}, !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}, !- Source Object
+  {3d1b2ed5-d4c4-4e74-971d-d8c262264858}, !- Handle
+  {ada5695b-ad54-4386-83f0-bcb411c7fd17}, !- Name
+  {54861a32-007b-42ff-8229-2ea64b538c06}, !- Source Object
   11,                                     !- Outlet Port
-  {77cd8484-1ace-4f56-94e6-8e2e9467f632}, !- Target Object
+  {5034acd5-8709-445a-bac1-23a5651a0550}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {e06fc115-ff6a-47c2-8e3d-8c0d4e00b852}, !- Handle
-  {c36f7c50-d173-42f9-a104-d2f9c520396e}, !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}; !- HVAC Component
+  {068ed2e0-4c95-4344-8482-be1917e48b89}, !- Handle
+  {319603f6-6a43-42ec-b4ac-aac3c72f219c}, !- Name
+  {54861a32-007b-42ff-8229-2ea64b538c06}; !- HVAC Component
 
 OS:PortList,
-  {c9b25384-e43a-4d81-9fc7-a80d30986526}, !- Handle
-  {bbbbb4a6-af1a-4d95-a8b6-14af70fed850}, !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}; !- HVAC Component
+  {bfbc2f98-0c11-422b-bf45-0a748a65b2f9}, !- Handle
+  {ca5ffc63-9703-47fc-ac65-3b13bb05c276}, !- Name
+  {54861a32-007b-42ff-8229-2ea64b538c06}; !- HVAC Component
 
 OS:PortList,
-  {a295a81c-d28c-4902-ae7e-fccfd33cc49e}, !- Handle
-  {ea7ea5da-aac4-4b6c-b65b-770ccd47160b}, !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}; !- HVAC Component
+  {90fee810-5aae-40d9-90cd-7fd89202a8d9}, !- Handle
+  {428fca43-4bd0-4959-99ee-6097f4e5ae78}, !- Name
+  {54861a32-007b-42ff-8229-2ea64b538c06}; !- HVAC Component
 
 OS:Sizing:Zone,
-  {e88c8c21-b56c-4ab5-922a-8d696ee49d00}, !- Handle
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}, !- Zone or ZoneList Name
+  {de84fa63-bec6-4a1f-baf6-88720f01b88c}, !- Handle
+  {54861a32-007b-42ff-8229-2ea64b538c06}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1729,12 +1733,12 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {10bf34f6-2ae1-4497-98e7-39a17f8e0164}, !- Handle
+  {af5a231f-1723-4282-9a29-c20a373e8a45}, !- Handle
   Zone HVAC Equipment List 6,             !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}; !- Thermal Zone
+  {54861a32-007b-42ff-8229-2ea64b538c06}; !- Thermal Zone
 
 OS:ThermalZone,
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- Handle
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- Handle
   Story 2 East Perimeter Thermal Zone,    !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1743,55 +1747,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {805427ed-6ecb-4c7b-92f5-17fb93368acb}, !- Zone Air Inlet Port List
-  {7a2ecb1b-0512-4a98-a440-36d151a67a19}, !- Zone Air Exhaust Port List
-  {fcdfe532-a445-442a-bc9e-ffdde598869a}, !- Zone Air Node Name
-  {1ac43259-f634-413f-9a94-9ef7e9e49097}, !- Zone Return Air Port List
+  {c65ba217-31bb-4b57-a5a1-d1b8712ec70c}, !- Zone Air Inlet Port List
+  {f545f63c-2f3a-4d5c-991d-7b5a20a5ae7f}, !- Zone Air Exhaust Port List
+  {0019fd06-2875-490e-a02c-bcd8b84c7410}, !- Zone Air Node Name
+  {97803d60-67ed-48b0-ad67-9d49cca6e51f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {3cc4c6f2-d1bf-47fe-a7ab-b48de16e66f3}, !- Thermostat Name
+  {e45fa8a2-bdbc-4b32-a825-540271662638}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {0d6d5c9d-d4bb-45c2-a28b-c46b9330cc1c}, !- Handle
+  {3fa957d6-ed6b-48e4-a7df-1d8d705212fa}, !- Handle
   Node 7,                                 !- Name
-  {fcdfe532-a445-442a-bc9e-ffdde598869a}, !- Inlet Port
+  {0019fd06-2875-490e-a02c-bcd8b84c7410}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {fcdfe532-a445-442a-bc9e-ffdde598869a}, !- Handle
-  {c9fcca20-c8ff-4117-b737-a496e65c14d1}, !- Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- Source Object
+  {0019fd06-2875-490e-a02c-bcd8b84c7410}, !- Handle
+  {13e30641-5ce5-4d9b-848c-c562641cd117}, !- Name
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- Source Object
   11,                                     !- Outlet Port
-  {0d6d5c9d-d4bb-45c2-a28b-c46b9330cc1c}, !- Target Object
+  {3fa957d6-ed6b-48e4-a7df-1d8d705212fa}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {805427ed-6ecb-4c7b-92f5-17fb93368acb}, !- Handle
-  {9b58cf40-169f-4701-920e-046016448681}, !- Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- HVAC Component
-  {3d89aabe-a1d7-477d-a87b-d89d399b04d8}, !- Port 1
-  {4be526ea-b730-4b96-875d-eec3194c8ff2}; !- Port 2
+  {c65ba217-31bb-4b57-a5a1-d1b8712ec70c}, !- Handle
+  {ba354315-ee7b-4585-a04c-ad6aaf15c19e}, !- Name
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- HVAC Component
+  {016d6a89-1f9d-4ea3-bbc9-0ca1de2ce2a6}, !- Port 1
+  {1edf3c07-f9d5-465e-8b32-cd0f18c932c4}; !- Port 2
 
 OS:PortList,
-  {7a2ecb1b-0512-4a98-a440-36d151a67a19}, !- Handle
-  {5539ef7a-1a69-4c49-a0bf-9d70bb1df8cd}, !- Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}; !- HVAC Component
+  {f545f63c-2f3a-4d5c-991d-7b5a20a5ae7f}, !- Handle
+  {284edc91-8f10-439d-b0bc-2fe1ef4299d7}, !- Name
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}; !- HVAC Component
 
 OS:PortList,
-  {1ac43259-f634-413f-9a94-9ef7e9e49097}, !- Handle
-  {15763d46-53b7-493b-862d-844590d91ce6}, !- Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- HVAC Component
-  {2109d080-3dd1-4e1e-95fb-96162b158021}, !- Port 1
-  {bece3946-8c39-4875-bbbf-0ab8f163b41b}; !- Port 2
+  {97803d60-67ed-48b0-ad67-9d49cca6e51f}, !- Handle
+  {5bcbdb57-6d29-4a37-92e4-6203aa855dfe}, !- Name
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- HVAC Component
+  {4efc135c-a21e-4678-a8f8-844eedf91361}, !- Port 1
+  {f56c75db-0fee-4519-b369-4550f6c6a460}; !- Port 2
 
 OS:Sizing:Zone,
-  {95794ad8-5656-4e23-a21e-2fa9fe46b276}, !- Handle
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- Zone or ZoneList Name
+  {407613ee-bb85-46c9-9096-c91c6fb018a8}, !- Handle
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1820,18 +1824,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {fbacd747-2dde-4539-aee6-ecfbdfc8112a}, !- Handle
+  {81451ba4-cd42-4fb8-a025-5bcd610867fe}, !- Handle
   Zone HVAC Equipment List 7,             !- Name
-  {6381f0c5-cfac-4c46-b680-57dcf7fb7f13}, !- Thermal Zone
-  {45255f53-2b67-4fe8-8758-8f019536684a}, !- Zone Equipment 1
+  {07a35c15-9faf-46bc-a5b8-0a03a4b84c84}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {0442d587-a8e5-4fe5-9c02-eb1c04817d4a}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {c726d2ef-209e-41b1-b97b-eb49e2c5877f}, !- Zone Equipment 2
+  {d30a8304-23e2-49e4-89a3-71e151d7d0a0}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- Handle
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- Handle
   Story 2 North Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1840,55 +1845,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {b170267c-aa2a-4cab-b508-4f08913dcb06}, !- Zone Air Inlet Port List
-  {358bfa73-750c-44c9-835f-604ec082f04c}, !- Zone Air Exhaust Port List
-  {ce329422-d45c-46a7-9ee7-be617f58ce0e}, !- Zone Air Node Name
-  {b4efd025-13e6-447a-b284-f912d5c35ae8}, !- Zone Return Air Port List
+  {e6c35a45-e312-4899-b164-f90bc07b1f8c}, !- Zone Air Inlet Port List
+  {a011e104-23be-4e7c-aeec-1c769c37ece3}, !- Zone Air Exhaust Port List
+  {cb04ad16-7978-4cc5-b6d5-97408881cd81}, !- Zone Air Node Name
+  {211feab5-a8be-4eae-9a23-92893c02fd56}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {faa32c87-f1be-4f63-92c1-342a577894ec}, !- Thermostat Name
+  {e3e4a44f-074c-4f6d-b5ed-52ee5b723e23}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {44cd41a2-3a91-4179-8fe9-71694ae6443a}, !- Handle
+  {7ad559c2-680d-4d2c-bf24-e84a3c62ce94}, !- Handle
   Node 8,                                 !- Name
-  {ce329422-d45c-46a7-9ee7-be617f58ce0e}, !- Inlet Port
+  {cb04ad16-7978-4cc5-b6d5-97408881cd81}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {ce329422-d45c-46a7-9ee7-be617f58ce0e}, !- Handle
-  {224b9855-d0f3-46a5-b8af-5f1b9c4d78fe}, !- Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- Source Object
+  {cb04ad16-7978-4cc5-b6d5-97408881cd81}, !- Handle
+  {ba882602-b126-4e2a-a16a-d82ad0c29d0d}, !- Name
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- Source Object
   11,                                     !- Outlet Port
-  {44cd41a2-3a91-4179-8fe9-71694ae6443a}, !- Target Object
+  {7ad559c2-680d-4d2c-bf24-e84a3c62ce94}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {b170267c-aa2a-4cab-b508-4f08913dcb06}, !- Handle
-  {c9df0f10-e45a-4dbb-bcf6-a074d275f3bd}, !- Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- HVAC Component
-  {d0bd5d4d-80c7-42cc-b0f4-0887e71ebf4e}, !- Port 1
-  {31a5a8d0-ab3b-4a0a-a8b6-e704b962b516}; !- Port 2
+  {e6c35a45-e312-4899-b164-f90bc07b1f8c}, !- Handle
+  {eabead34-6cad-41f2-a94d-000856e83721}, !- Name
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- HVAC Component
+  {4f9085b7-c352-48e0-b20d-31eaa553041e}, !- Port 1
+  {32e7c499-12ed-4140-a23d-6fc88fbb8cee}; !- Port 2
 
 OS:PortList,
-  {358bfa73-750c-44c9-835f-604ec082f04c}, !- Handle
-  {3d5b0e6a-afee-46ff-b224-cbf243c2e7dd}, !- Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}; !- HVAC Component
+  {a011e104-23be-4e7c-aeec-1c769c37ece3}, !- Handle
+  {0610fd30-da2e-4fb3-9e8b-5f7053b858cf}, !- Name
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}; !- HVAC Component
 
 OS:PortList,
-  {b4efd025-13e6-447a-b284-f912d5c35ae8}, !- Handle
-  {1f44f0ad-fdd5-432a-9ed4-85650c89bc0a}, !- Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- HVAC Component
-  {34a25964-83f0-43fb-b0ee-f6d22c98bcc4}, !- Port 1
-  {bdc4ff6e-5b5b-4f4d-afef-d7f9805ef5fa}; !- Port 2
+  {211feab5-a8be-4eae-9a23-92893c02fd56}, !- Handle
+  {c8f8ef7a-e673-4781-b093-f8dfdbda6968}, !- Name
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- HVAC Component
+  {897726d5-146b-47b7-bdbd-d5bc013a27c4}, !- Port 1
+  {6613156e-369c-4080-a3ef-8e1f57f6356e}; !- Port 2
 
 OS:Sizing:Zone,
-  {5f93130f-81ea-46ea-98aa-f68c34cc56ba}, !- Handle
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- Zone or ZoneList Name
+  {fd89c296-40c6-4476-945f-bb5289c6defa}, !- Handle
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -1917,18 +1922,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {b6f1e023-bde3-4889-b1ef-2df309525552}, !- Handle
+  {edf0e174-7d61-454b-bb71-b8a7da7fe12e}, !- Handle
   Zone HVAC Equipment List 8,             !- Name
-  {7d41068f-2505-43cf-8d51-c9f82578033e}, !- Thermal Zone
-  {064a47d4-d54e-4628-a7d0-f9b33315492d}, !- Zone Equipment 1
+  {10014611-015d-4a94-bd21-a8b8d8a0ec46}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {67d04328-a01e-4162-b2f0-3cafe9307180}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {5fe3590f-5597-4755-99ef-c16a20497832}, !- Zone Equipment 2
+  {3d9fe5d9-ef4b-43f0-ba88-e0428002fe46}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- Handle
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- Handle
   Story 2 South Perimeter Thermal Zone,   !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -1937,55 +1943,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {1d75dadb-55ec-4edd-b070-8265f6db36f0}, !- Zone Air Inlet Port List
-  {a767b18c-1525-44d6-a6a9-df82bc67d21c}, !- Zone Air Exhaust Port List
-  {f271eb80-f2a4-417a-a57b-045cd659906f}, !- Zone Air Node Name
-  {0d0c9790-59a6-4355-96d6-bc692c51f054}, !- Zone Return Air Port List
+  {cf354f66-ffe3-484b-a97f-674aa2d1a9ca}, !- Zone Air Inlet Port List
+  {fd513e62-6107-4fcc-8711-4acd20e97eeb}, !- Zone Air Exhaust Port List
+  {ba5201b3-7ed9-4fb7-9798-1b9ad6f28071}, !- Zone Air Node Name
+  {ae8f18cb-499a-47ef-8c94-1e994eac29f1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {1d763b01-359a-4edb-8c83-72d3bb2ca90e}, !- Thermostat Name
+  {356844db-5f5d-43b9-b872-97ff40956ddd}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {bcd22aff-10e9-4ee0-a7d9-c9cc66ace632}, !- Handle
+  {d651496b-29de-4f59-97f0-3ccb283624be}, !- Handle
   Node 9,                                 !- Name
-  {f271eb80-f2a4-417a-a57b-045cd659906f}, !- Inlet Port
+  {ba5201b3-7ed9-4fb7-9798-1b9ad6f28071}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {f271eb80-f2a4-417a-a57b-045cd659906f}, !- Handle
-  {479a8398-2896-40bf-8a0e-d5098e099f4f}, !- Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- Source Object
+  {ba5201b3-7ed9-4fb7-9798-1b9ad6f28071}, !- Handle
+  {db26392a-3138-4203-be67-b5e867804547}, !- Name
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- Source Object
   11,                                     !- Outlet Port
-  {bcd22aff-10e9-4ee0-a7d9-c9cc66ace632}, !- Target Object
+  {d651496b-29de-4f59-97f0-3ccb283624be}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {1d75dadb-55ec-4edd-b070-8265f6db36f0}, !- Handle
-  {47c050e8-bead-47af-8638-1d3f20f17fa4}, !- Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- HVAC Component
-  {af636675-2a9b-49e3-9330-e95a4217788d}, !- Port 1
-  {bcb65551-0237-44ac-a1e8-d02e9b06367e}; !- Port 2
+  {cf354f66-ffe3-484b-a97f-674aa2d1a9ca}, !- Handle
+  {da0a723f-6018-4b02-8447-032f1e449d12}, !- Name
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- HVAC Component
+  {0fdc523a-dfe3-4fa6-bce2-06597247d63b}, !- Port 1
+  {575bf6f9-b28e-492e-b925-508e04a57710}; !- Port 2
 
 OS:PortList,
-  {a767b18c-1525-44d6-a6a9-df82bc67d21c}, !- Handle
-  {84d889fc-15a8-486a-a4be-47068dab789a}, !- Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}; !- HVAC Component
+  {fd513e62-6107-4fcc-8711-4acd20e97eeb}, !- Handle
+  {e1cb984f-31fd-4625-bd57-45c7e7bf7642}, !- Name
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}; !- HVAC Component
 
 OS:PortList,
-  {0d0c9790-59a6-4355-96d6-bc692c51f054}, !- Handle
-  {e7b2a38e-8f5a-4bcb-9ae2-34d003bb644f}, !- Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- HVAC Component
-  {cbe854c7-d3e3-4a7b-9728-c90e3b6ac999}, !- Port 1
-  {2c67799d-9119-44c8-a599-ec35f558a519}; !- Port 2
+  {ae8f18cb-499a-47ef-8c94-1e994eac29f1}, !- Handle
+  {5e679976-b712-4462-854b-9c8406553948}, !- Name
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- HVAC Component
+  {fd77d3b8-830f-45c2-9777-48e3b2724a1b}, !- Port 1
+  {d723631a-dee2-437f-9892-658aae6973d5}; !- Port 2
 
 OS:Sizing:Zone,
-  {6ce93773-42cb-446c-a5a6-0590aaf24363}, !- Handle
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- Zone or ZoneList Name
+  {3d1686f8-825c-45b7-9483-2965157e63e1}, !- Handle
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -2014,18 +2020,19 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {aff03b24-f7df-44ef-8e1c-54f621bafdca}, !- Handle
+  {34278e29-dd1e-46bc-81da-685ac43cfeec}, !- Handle
   Zone HVAC Equipment List 9,             !- Name
-  {7c38ac53-d7e0-474d-88bb-5c2914c8c25c}, !- Thermal Zone
-  {f1ff8e41-03ff-4026-9f99-a76292df356c}, !- Zone Equipment 1
+  {c499acfe-eefa-44e8-ac2a-a06f4ecfcb35}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {0799162a-1fa1-48f8-b93c-192e5bb22da4}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {2dce302f-47fa-41d9-886b-3bea9d341580}, !- Zone Equipment 2
+  {86e8b49e-ba9c-4d1c-a155-e8d2e2701476}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:ThermalZone,
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- Handle
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- Handle
   Story 2 West Perimeter Thermal Zone,    !- Name
   ,                                       !- Multiplier
   ,                                       !- Ceiling Height {m}
@@ -2034,55 +2041,55 @@ OS:ThermalZone,
   ,                                       !- Zone Inside Convection Algorithm
   ,                                       !- Zone Outside Convection Algorithm
   ,                                       !- Zone Conditioning Equipment List Name
-  {1ca6b81d-2235-4acb-81a1-340ce4e2806a}, !- Zone Air Inlet Port List
-  {9bdc5daf-ece9-4eef-a813-a8e6a496b6d0}, !- Zone Air Exhaust Port List
-  {89dfc64e-a99a-4d5a-98b9-04276beb5f06}, !- Zone Air Node Name
-  {c23ee3d2-5aa7-49fe-9f99-2b1cd8737ea2}, !- Zone Return Air Port List
+  {58eb42cf-bea0-4c2c-b544-97ce9e67f0e9}, !- Zone Air Inlet Port List
+  {32a88df8-d99f-4e39-8206-834e5b0ff2df}, !- Zone Air Exhaust Port List
+  {9b320c93-14a7-40a9-9513-6b28f134ad50}, !- Zone Air Node Name
+  {1ed84698-ef20-454c-a2f3-757ec7a21171}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
   ,                                       !- Group Rendering Name
-  {291ea040-e8c3-4fad-9906-345fca45c424}, !- Thermostat Name
+  {346c0ace-0539-4ce1-a5a7-8413438ac986}, !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
 
 OS:Node,
-  {e1d2732c-e2b4-4a4c-aaf4-4e372cba5a93}, !- Handle
+  {80650a63-f5f0-4777-b71d-d810a48c070e}, !- Handle
   Node 10,                                !- Name
-  {89dfc64e-a99a-4d5a-98b9-04276beb5f06}, !- Inlet Port
+  {9b320c93-14a7-40a9-9513-6b28f134ad50}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {89dfc64e-a99a-4d5a-98b9-04276beb5f06}, !- Handle
-  {06863f74-0e5f-4cae-8873-42d5a848eee6}, !- Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- Source Object
+  {9b320c93-14a7-40a9-9513-6b28f134ad50}, !- Handle
+  {eefb79bd-8857-4759-90ae-73882c9755cd}, !- Name
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- Source Object
   11,                                     !- Outlet Port
-  {e1d2732c-e2b4-4a4c-aaf4-4e372cba5a93}, !- Target Object
+  {80650a63-f5f0-4777-b71d-d810a48c070e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PortList,
-  {1ca6b81d-2235-4acb-81a1-340ce4e2806a}, !- Handle
-  {da30ed81-b208-467b-8d57-79e601fa3854}, !- Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- HVAC Component
-  {17758b60-6c21-4612-84ee-fbc301e72fe6}, !- Port 1
-  {0827fea0-34de-4b63-bb1d-32d7524a5e1d}; !- Port 2
+  {58eb42cf-bea0-4c2c-b544-97ce9e67f0e9}, !- Handle
+  {30a7f4c5-a40a-43db-94de-c4c2cf3a5524}, !- Name
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- HVAC Component
+  {2007d205-4ebd-4273-b930-ff7c3b9d56c5}, !- Port 1
+  {8094879a-be03-40f9-b7b8-03b3f214806e}; !- Port 2
 
 OS:PortList,
-  {9bdc5daf-ece9-4eef-a813-a8e6a496b6d0}, !- Handle
-  {0c7ed02d-fe22-4b77-a965-22b5d33bcdb3}, !- Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}; !- HVAC Component
+  {32a88df8-d99f-4e39-8206-834e5b0ff2df}, !- Handle
+  {c51fe76b-bb82-4026-b40d-1ba946925a83}, !- Name
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}; !- HVAC Component
 
 OS:PortList,
-  {c23ee3d2-5aa7-49fe-9f99-2b1cd8737ea2}, !- Handle
-  {12ce1505-1434-4bf5-8557-324d57356da8}, !- Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- HVAC Component
-  {e7c93b9a-7437-4d52-b958-07adc8bfd68b}, !- Port 1
-  {b36db72d-b790-4b35-b513-a7449eacaae0}; !- Port 2
+  {1ed84698-ef20-454c-a2f3-757ec7a21171}, !- Handle
+  {9ddd094b-146d-4dd1-8740-f15d6b57e255}, !- Name
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- HVAC Component
+  {3512908d-c8d9-40d8-b71d-c93a3b339bd0}, !- Port 1
+  {6627cf59-9509-47d8-a2b9-1c6593c99675}; !- Port 2
 
 OS:Sizing:Zone,
-  {c9ce44ee-1d4f-4bcf-8736-b9ccc9255be8}, !- Handle
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- Zone or ZoneList Name
+  {f0ae5df7-4055-401b-a37d-84fa2a72f2ad}, !- Handle
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- Zone or ZoneList Name
   SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
   11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
@@ -2111,39 +2118,40 @@ OS:Sizing:Zone,
   autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
 
 OS:ZoneHVAC:EquipmentList,
-  {8449549c-ad43-4a8f-915b-9e58d99caf89}, !- Handle
+  {cdf6f278-5d77-4dbe-ac3a-ef651b3f645d}, !- Handle
   Zone HVAC Equipment List 10,            !- Name
-  {d326f72a-a1b6-4018-bb1f-8e4ad7368a99}, !- Thermal Zone
-  {a57dd1cc-74a6-4606-83c2-00ed85046b81}, !- Zone Equipment 1
+  {d42e8f1f-4b19-40cc-ac35-3ef02914d8f3}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {96953bdf-c616-48bb-92f1-a37b360f4e0f}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
   1,                                      !- Zone Equipment Heating or No-Load Sequence 1
-  {a14a36b0-44d0-4c50-8fb1-41c8ac341e5b}, !- Zone Equipment 2
+  {c48da182-3ab3-4ee5-9c9b-028cbd6d7aa7}, !- Zone Equipment 2
   2,                                      !- Zone Equipment Cooling Sequence 2
   2;                                      !- Zone Equipment Heating or No-Load Sequence 2
 
 OS:SubSurface,
-  {e1a61bd8-91a0-4a4a-aa2b-a8e0a1bf22d3}, !- Handle
+  {9ab25e76-3d1c-4266-97f3-05a3c2d0609a}, !- Handle
   Sub Surface 1,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {d0cb7038-3f65-4c57-874c-15c5ff64f5e8}, !- Surface Name
+  {d3fd35bc-00ac-4f36-9c5d-fab439107f10}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
-  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
-  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
-  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
+  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
+  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
+  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
+  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {a4eaa435-b259-41d2-8e24-091e0b15ab1a}, !- Handle
+  {01d5e1d8-a824-4c15-9e3c-79b8dd7331f4}, !- Handle
   Sub Surface 2,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {a7855523-bea6-4fe5-888b-4ed43e889fd0}, !- Surface Name
+  {3ba6f26a-e1c9-4fa3-92bd-5b2a99cdba71}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2156,28 +2164,28 @@ OS:SubSurface,
   0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {228f8a65-d027-478d-9964-38a096374d9e}, !- Handle
+  {40f6e355-c2e4-4c94-b1ae-a8cadbe9c4f1}, !- Handle
   Sub Surface 3,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {d94038b6-78bb-4dbb-b954-7891a6160ad6}, !- Surface Name
+  {b53dc4a9-987d-4259-a814-f98e9ed2a739}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
-  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
-  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
-  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
+  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
+  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {cdf3488e-ca87-47fd-b879-bffe1ca318cd}, !- Handle
+  {b24aaa02-2de7-4d16-896c-4fb1d99a2313}, !- Handle
   Sub Surface 4,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {97b88924-851b-46ed-b9b4-9b30ae148d5a}, !- Surface Name
+  {efa0488f-32fe-4cb6-8159-ad7b196b7df2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2190,28 +2198,11 @@ OS:SubSurface,
   99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {70807c11-f946-45ee-acce-0b8388dd40ea}, !- Handle
+  {5f07c469-3024-4ce3-9a0a-7caf6201366c}, !- Handle
   Sub Surface 5,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {315d0d86-2dfe-4a7f-bbe8-422498bcbaa2}, !- Surface Name
-  ,                                       !- Outside Boundary Condition Object
-  ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
-  ,                                       !- Frame and Divider Name
-  ,                                       !- Multiplier
-  ,                                       !- Number of Vertices
-  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
-  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
-  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
-  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
-
-OS:SubSurface,
-  {fb431ad2-4cdf-43ae-9493-fb3b48701d25}, !- Handle
-  Sub Surface 6,                          !- Name
-  FixedWindow,                            !- Sub Surface Type
-  ,                                       !- Construction Name
-  {ad5ffc9f-5844-43e6-a379-91e5dedc8387}, !- Surface Name
+  {ea907d1f-13ca-4181-a73f-9db08a8b1242}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2224,11 +2215,28 @@ OS:SubSurface,
   3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {7b362c27-d0ac-4008-b81f-1b760c098c8d}, !- Handle
+  {f592f5bc-d5f9-4269-8abd-8dddcd2a15cd}, !- Handle
+  Sub Surface 6,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {cb929871-4f38-4e67-9361-1f6dba09d026}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
+  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
+  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
+  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {133c5eef-989f-4f31-a430-cf45f9d886d1}, !- Handle
   Sub Surface 7,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {b91f8b86-e731-44ae-9f7a-3925940443a2}, !- Surface Name
+  {b82511d2-eaad-4da3-894c-f3b20fda9da6}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
@@ -2241,30 +2249,30 @@ OS:SubSurface,
   0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
-  {9f85204b-73bd-40a5-8047-a675f8c1491c}, !- Handle
+  {ead3a0e6-4d7c-46a4-8b17-171a25730333}, !- Handle
   Sub Surface 8,                          !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
-  {d381700d-768f-4688-a350-26cecdc76e5c}, !- Surface Name
+  {f10f1523-397d-4b5f-a410-0097411bffe4}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
   ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
-  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
-  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
-  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
+  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
+  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
+  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
+  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
 
 OS:Schedule:Constant,
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Handle
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Handle
   Always On Discrete,                     !- Name
-  {aff494cf-c643-42a2-abf1-cdba37314c99}, !- Schedule Type Limits Name
+  {f576cb45-0f2d-468f-95cb-52f80cd7adfd}, !- Schedule Type Limits Name
   1;                                      !- Value
 
 OS:ScheduleTypeLimits,
-  {aff494cf-c643-42a2-abf1-cdba37314c99}, !- Handle
+  {f576cb45-0f2d-468f-95cb-52f80cd7adfd}, !- Handle
   OnOff,                                  !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
@@ -2272,211 +2280,211 @@ OS:ScheduleTypeLimits,
   Availability;                           !- Unit Type
 
 OS:Schedule:Ruleset,
-  {ce214f85-b5d2-4691-9be2-dcc1de7cfe30}, !- Handle
+  {94d67c4e-e4a6-4822-ade5-2119d49611c4}, !- Handle
   Deck_Temperature,                       !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {bf0e7c6f-77af-49c7-a0ac-ebb91d88529b}, !- Default Day Schedule Name
-  {83e583cc-8278-4293-8026-5be6bd659ebe}, !- Summer Design Day Schedule Name
-  {1d8b4472-8178-4643-ad1b-e3c6a4bed499}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {f35fe8bd-72ed-4336-bb33-0fcdf40491e7}, !- Default Day Schedule Name
+  {bbb50c8a-75f7-41df-93ac-b9046a009123}, !- Summer Design Day Schedule Name
+  {493e59ba-0f9a-45bf-a4c5-72af4e6f6916}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {bf0e7c6f-77af-49c7-a0ac-ebb91d88529b}, !- Handle
+  {f35fe8bd-72ed-4336-bb33-0fcdf40491e7}, !- Handle
   Deck_Temperature_Default,               !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Day,
-  {83e583cc-8278-4293-8026-5be6bd659ebe}, !- Handle
+  {bbb50c8a-75f7-41df-93ac-b9046a009123}, !- Handle
   Deck_Temperature_Summer_Design_Day,     !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Day,
-  {1d8b4472-8178-4643-ad1b-e3c6a4bed499}, !- Handle
+  {493e59ba-0f9a-45bf-a4c5-72af4e6f6916}, !- Handle
   Deck_Temperature_Winter_Design_Day,     !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {61093f18-83b2-4e65-aa6a-565e79123efa}, !- Handle
+  {c02170ce-041a-45c6-8cd1-cf3fac2ec1d8}, !- Handle
   Hot_Water_Temperature,                  !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {f3e04c2d-d034-4db1-8712-1270502e2943}, !- Default Day Schedule Name
-  {651e9ed9-1f8f-42a5-8e46-97382573e5ec}, !- Summer Design Day Schedule Name
-  {dfbdc315-c424-495f-bd6a-f7b276f40a54}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {b5c837a2-6ae5-458e-8d25-54368f7475a4}, !- Default Day Schedule Name
+  {f4733f9d-ece5-4a51-980d-99701c34101e}, !- Summer Design Day Schedule Name
+  {dc27bb90-3994-42e5-b8e7-5d181f40f827}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {f3e04c2d-d034-4db1-8712-1270502e2943}, !- Handle
+  {b5c837a2-6ae5-458e-8d25-54368f7475a4}, !- Handle
   Hot_Water_Temperature_Default,          !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {651e9ed9-1f8f-42a5-8e46-97382573e5ec}, !- Handle
+  {f4733f9d-ece5-4a51-980d-99701c34101e}, !- Handle
   Hot_Water_Temperature_Summer_Design_Day, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {dfbdc315-c424-495f-bd6a-f7b276f40a54}, !- Handle
+  {dc27bb90-3994-42e5-b8e7-5d181f40f827}, !- Handle
   Hot_Water_Temperature_Winter_Design_Day, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {0ce6afd7-0b95-482b-914b-47b1c28747bb}, !- Handle
+  {ab211609-a1ba-40ad-8235-2376e1773582}, !- Handle
   Chilled_Water_Temperature,              !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {9d3edf2b-3087-4028-8124-f2d6617b83e7}, !- Default Day Schedule Name
-  {f5409578-0be8-4b99-a343-80f7ca3d111e}, !- Summer Design Day Schedule Name
-  {a313ff75-0f5f-4a49-be8b-3d6fd226a777}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {3b5c58ab-c48e-406f-8c30-2985d779c8ee}, !- Default Day Schedule Name
+  {4913bbde-4af8-4001-bbb4-94051bdc3f64}, !- Summer Design Day Schedule Name
+  {78a8198b-753c-40f8-a68f-62dc73e45c97}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {9d3edf2b-3087-4028-8124-f2d6617b83e7}, !- Handle
+  {3b5c58ab-c48e-406f-8c30-2985d779c8ee}, !- Handle
   Chilled_Water_Temperature_Default,      !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:Schedule:Day,
-  {f5409578-0be8-4b99-a343-80f7ca3d111e}, !- Handle
+  {4913bbde-4af8-4001-bbb4-94051bdc3f64}, !- Handle
   Chilled_Water_Temperature_Summer_Design_Day, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:Schedule:Day,
-  {a313ff75-0f5f-4a49-be8b-3d6fd226a777}, !- Handle
+  {78a8198b-753c-40f8-a68f-62dc73e45c97}, !- Handle
   Chilled_Water_Temperature_Winter_Design_Day, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:AirLoopHVAC,
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- Handle
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- Handle
   VAV with Reheat,                        !- Name
   ,                                       !- Controller List Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule
-  {575a1343-7148-4fd9-ad69-5e512347c49c}, !- Availability Manager List Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule
+  {1a15ef42-74f1-4a25-8b4c-997c8605fff2}, !- Availability Manager List Name
   AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
   ,                                       !- Branch List Name
   ,                                       !- Connector List Name
-  {699f25cf-7b96-406d-acbc-9d0b78462439}, !- Supply Side Inlet Node Name
-  {dbe7ccb6-6067-49fe-bc1c-4c545b6b0c31}, !- Demand Side Outlet Node Name
-  {d257ce15-6ad2-4762-a204-c144a74e9de6}, !- Demand Side Inlet Node A
-  {321915af-2c3d-460c-828a-12619195f843}, !- Supply Side Outlet Node A
+  {cd7d457b-6333-4e07-99a7-1630f89ba64b}, !- Supply Side Inlet Node Name
+  {5cee8685-30dc-4467-bc8a-64db9e2298ef}, !- Demand Side Outlet Node Name
+  {cb9b2b67-6d26-4535-af38-d2f2847ad833}, !- Demand Side Inlet Node A
+  {8384d4fd-9513-4c1c-9e04-494888d0141f}, !- Supply Side Outlet Node A
   ,                                       !- Demand Side Inlet Node B
   ,                                       !- Supply Side Outlet Node B
   ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
-  {8e7e4c46-65c2-4f3d-8c47-714e87868182}, !- Demand Mixer Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Demand Splitter A Name
+  {df72a029-e0f9-4916-9896-f4f03c08c3bb}, !- Demand Mixer Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Demand Splitter A Name
   ,                                       !- Demand Splitter B Name
   ;                                       !- Supply Splitter Name
 
 OS:Node,
-  {9ee24f09-09f6-485d-bea6-e0ef0b2f8997}, !- Handle
+  {110a03ab-fad4-4821-9a42-ab623cbc0f95}, !- Handle
   Node 11,                                !- Name
-  {699f25cf-7b96-406d-acbc-9d0b78462439}, !- Inlet Port
-  {d282eaa0-a3b3-4220-a447-4f7cb56d2ad3}; !- Outlet Port
+  {cd7d457b-6333-4e07-99a7-1630f89ba64b}, !- Inlet Port
+  {c3bdce0a-9d49-4c80-a691-02da2569af65}; !- Outlet Port
 
 OS:Node,
-  {efeb4583-895c-4a19-a1f9-f0fd526885ed}, !- Handle
+  {c1b40c7e-3dea-4f1a-ad78-77ea5686f98d}, !- Handle
   Node 12,                                !- Name
-  {4da49542-e371-40b2-872a-4e458447c9d4}, !- Inlet Port
-  {321915af-2c3d-460c-828a-12619195f843}; !- Outlet Port
+  {974e8d68-969f-455c-aa68-5ed4f88ca4d2}, !- Inlet Port
+  {8384d4fd-9513-4c1c-9e04-494888d0141f}; !- Outlet Port
 
 OS:Connection,
-  {699f25cf-7b96-406d-acbc-9d0b78462439}, !- Handle
-  {e2965409-153a-482d-b2ef-2371883f1ced}, !- Name
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- Source Object
+  {cd7d457b-6333-4e07-99a7-1630f89ba64b}, !- Handle
+  {54214722-2750-478e-92b7-7f61e43b4d78}, !- Name
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- Source Object
   8,                                      !- Outlet Port
-  {9ee24f09-09f6-485d-bea6-e0ef0b2f8997}, !- Target Object
+  {110a03ab-fad4-4821-9a42-ab623cbc0f95}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {321915af-2c3d-460c-828a-12619195f843}, !- Handle
-  {1bd87894-3195-4bdb-8805-a119c24e587b}, !- Name
-  {efeb4583-895c-4a19-a1f9-f0fd526885ed}, !- Source Object
+  {8384d4fd-9513-4c1c-9e04-494888d0141f}, !- Handle
+  {953acca7-3083-42ab-8909-702c53aa66fd}, !- Name
+  {c1b40c7e-3dea-4f1a-ad78-77ea5686f98d}, !- Source Object
   3,                                      !- Outlet Port
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- Target Object
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- Target Object
   11;                                     !- Inlet Port
 
 OS:Node,
-  {c9c4e101-602d-46d0-9b93-25310de28edf}, !- Handle
+  {ce4a8e1f-7d0b-44c0-8683-9534985c9289}, !- Handle
   Node 13,                                !- Name
-  {d257ce15-6ad2-4762-a204-c144a74e9de6}, !- Inlet Port
-  {e24c643e-5110-4470-886d-460d650a62cb}; !- Outlet Port
+  {cb9b2b67-6d26-4535-af38-d2f2847ad833}, !- Inlet Port
+  {5de490d7-0606-4564-8e30-9efa58f2db28}; !- Outlet Port
 
 OS:Node,
-  {c9d23938-151f-42de-84a4-b72a89c7e28c}, !- Handle
+  {68c14cc7-cccf-4a2e-8447-03a6f101be42}, !- Handle
   Node 14,                                !- Name
-  {d0770713-1c46-42d7-ab84-7ff8814c70da}, !- Inlet Port
-  {dbe7ccb6-6067-49fe-bc1c-4c545b6b0c31}; !- Outlet Port
+  {90cd7b89-de33-43df-9b50-9d9037bb7ee7}, !- Inlet Port
+  {5cee8685-30dc-4467-bc8a-64db9e2298ef}; !- Outlet Port
 
 OS:Node,
-  {e3793b17-3ca2-4da6-963c-11f2fcdc85d1}, !- Handle
+  {e4996cbb-8c3d-409e-987f-d01baab7731a}, !- Handle
   Node 15,                                !- Name
-  {4cb06ba0-379f-4294-9749-5ac728072a50}, !- Inlet Port
-  {68cd1584-e440-40f6-8a3d-78161a6a85e3}; !- Outlet Port
+  {bc1526bc-59c2-498d-80c7-4d7bc47722c7}, !- Inlet Port
+  {5d52656a-c140-436d-bb13-41035ba30175}; !- Outlet Port
 
 OS:Connection,
-  {d257ce15-6ad2-4762-a204-c144a74e9de6}, !- Handle
-  {37adf774-88b2-4db8-8883-57634591643c}, !- Name
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- Source Object
+  {cb9b2b67-6d26-4535-af38-d2f2847ad833}, !- Handle
+  {597bf7cf-1728-4c12-8e2f-bfdc2bef3bf8}, !- Name
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- Source Object
   10,                                     !- Outlet Port
-  {c9c4e101-602d-46d0-9b93-25310de28edf}, !- Target Object
+  {ce4a8e1f-7d0b-44c0-8683-9534985c9289}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {dbe7ccb6-6067-49fe-bc1c-4c545b6b0c31}, !- Handle
-  {67128c12-cd9e-485f-a3c0-a41767dad61d}, !- Name
-  {c9d23938-151f-42de-84a4-b72a89c7e28c}, !- Source Object
+  {5cee8685-30dc-4467-bc8a-64db9e2298ef}, !- Handle
+  {2c9296f3-21a1-4a19-8c21-48e2464271ec}, !- Name
+  {68c14cc7-cccf-4a2e-8447-03a6f101be42}, !- Source Object
   3,                                      !- Outlet Port
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- Target Object
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- Target Object
   9;                                      !- Inlet Port
 
 OS:AirLoopHVAC:ZoneSplitter,
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Handle
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Handle
   Air Loop HVAC Zone Splitter 1,          !- Name
-  {e24c643e-5110-4470-886d-460d650a62cb}, !- Inlet Node Name
-  {44b4150c-b409-4f44-b91b-dad670f8ab07}, !- Outlet Node Name 1
-  {30fe412b-477a-4ac3-9c81-2b9fd3e11953}, !- Outlet Node Name 2
-  {0526cc54-a063-49c5-ba6a-d2ca3c67f616}, !- Outlet Node Name 3
-  {18da5ca4-9b8c-42fd-810a-1dfb2ac8cf3c}, !- Outlet Node Name 4
-  {364d65e7-2bbd-465c-888e-d48aeee45ef3}, !- Outlet Node Name 5
-  {55a0e15e-8b15-45e6-a3d1-75ea40497d3e}, !- Outlet Node Name 6
-  {db806288-7cb4-45d1-b04b-3c038f252db4}, !- Outlet Node Name 7
-  {4d024f13-5166-40d7-9d0c-4639bb3ea48b}; !- Outlet Node Name 8
+  {5de490d7-0606-4564-8e30-9efa58f2db28}, !- Inlet Node Name
+  {4eacb56f-9f8d-42ce-b7cb-8064580662dc}, !- Outlet Node Name 1
+  {1843d656-bfd4-4aa9-ab50-588452bfd9fa}, !- Outlet Node Name 2
+  {c3df2f0c-ae8c-4b1c-adb8-bc6486adb727}, !- Outlet Node Name 3
+  {6c00b31f-ea66-4560-9ace-46d92fcc23ea}, !- Outlet Node Name 4
+  {b50c72c5-3e13-41ab-b843-2b9ea0a3dc79}, !- Outlet Node Name 5
+  {0e010d53-ca9e-4ddc-a61c-70cf086be9e5}, !- Outlet Node Name 6
+  {de733b25-322c-4519-a4b2-ea581d944d3f}, !- Outlet Node Name 7
+  {fecdcc31-c0f3-452f-8dfb-cd66e65938c1}; !- Outlet Node Name 8
 
 OS:AirLoopHVAC:ZoneMixer,
-  {8e7e4c46-65c2-4f3d-8c47-714e87868182}, !- Handle
+  {df72a029-e0f9-4916-9896-f4f03c08c3bb}, !- Handle
   Air Loop HVAC Zone Mixer 1,             !- Name
-  {d0770713-1c46-42d7-ab84-7ff8814c70da}, !- Outlet Node Name
-  {dc251d28-8264-4f5d-b7bc-8fcbf5da56aa}, !- Inlet Node Name 1
+  {90cd7b89-de33-43df-9b50-9d9037bb7ee7}, !- Outlet Node Name
+  {fc13eb40-488b-4a4b-909c-fb46a7d5e5bd}, !- Inlet Node Name 1
   ,                                       !- Inlet Node Name 2
   ,                                       !- Inlet Node Name 3
   ,                                       !- Inlet Node Name 4
@@ -2486,27 +2494,27 @@ OS:AirLoopHVAC:ZoneMixer,
   ;                                       !- Inlet Node Name 8
 
 OS:Connection,
-  {e24c643e-5110-4470-886d-460d650a62cb}, !- Handle
-  {d12dc0f5-8b11-4de5-a0a5-6f32809ea38e}, !- Name
-  {c9c4e101-602d-46d0-9b93-25310de28edf}, !- Source Object
+  {5de490d7-0606-4564-8e30-9efa58f2db28}, !- Handle
+  {41d01cb1-e686-4a31-806d-239140c14c92}, !- Name
+  {ce4a8e1f-7d0b-44c0-8683-9534985c9289}, !- Source Object
   3,                                      !- Outlet Port
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Target Object
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {d0770713-1c46-42d7-ab84-7ff8814c70da}, !- Handle
-  {2923bda3-9fd8-46ac-9733-cfc25ada240b}, !- Name
-  {8e7e4c46-65c2-4f3d-8c47-714e87868182}, !- Source Object
+  {90cd7b89-de33-43df-9b50-9d9037bb7ee7}, !- Handle
+  {63970aed-9f63-42df-9a98-20f1022a9dc2}, !- Name
+  {df72a029-e0f9-4916-9896-f4f03c08c3bb}, !- Source Object
   2,                                      !- Outlet Port
-  {c9d23938-151f-42de-84a4-b72a89c7e28c}, !- Target Object
+  {68c14cc7-cccf-4a2e-8447-03a6f101be42}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Sizing:System,
-  {fa35f3d2-6b65-423d-bc35-14baca653981}, !- Handle
-  {23e76938-ac5c-40ac-899b-6df7400803db}, !- AirLoop Name
+  {0f4c4b1c-0ede-4d9e-88fd-3af42eb823b6}, !- Handle
+  {dfdb6c17-9072-4fbf-9785-0a82b469ab22}, !- AirLoop Name
   Sensible,                               !- Type of Load to Size On
   Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
-  0.3,                                    !- Minimum System Air Flow Ratio
+  0.3,                                    !- Central Heating Maximum System Air Flow Ratio
   7,                                      !- Preheat Design Temperature {C}
   0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
   12.8,                                   !- Precool Design Temperature {C}
@@ -2542,13 +2550,13 @@ OS:Sizing:System,
   OnOff;                                  !- Central Cooling Capacity Control Method
 
 OS:AvailabilityManagerAssignmentList,
-  {575a1343-7148-4fd9-ad69-5e512347c49c}, !- Handle
+  {1a15ef42-74f1-4a25-8b4c-997c8605fff2}, !- Handle
   Air Loop HVAC 1 AvailabilityManagerAssignmentList; !- Name
 
 OS:Fan:VariableVolume,
-  {9942ef7e-b00e-4cc2-9067-c156ccdcdca8}, !- Handle
+  {d90d6b0e-ef08-4e57-89c1-f667f2a63abd}, !- Handle
   Fan Variable Volume 1,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   0.6045,                                 !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   Autosize,                               !- Maximum Flow Rate {m3/s}
@@ -2562,20 +2570,20 @@ OS:Fan:VariableVolume,
   -0.07292612,                            !- Fan Power Coefficient 3
   0.943739823,                            !- Fan Power Coefficient 4
   0,                                      !- Fan Power Coefficient 5
-  {bae56f74-7b02-4609-aea2-412567068d13}, !- Air Inlet Node Name
-  {4da49542-e371-40b2-872a-4e458447c9d4}, !- Air Outlet Node Name
+  {74ab3a82-2ad6-4fdf-862e-c800fd4cfb54}, !- Air Inlet Node Name
+  {974e8d68-969f-455c-aa68-5ed4f88ca4d2}, !- Air Outlet Node Name
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Handle
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Handle
   Coil Heating Water 1,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {338b6371-e79c-424f-8863-63b13cd009fd}, !- Water Inlet Node Name
-  {c44f6198-9c37-415f-9d8d-1dc91556481f}, !- Water Outlet Node Name
-  {c6a4d39e-4511-498e-a249-aa01bb01909d}, !- Air Inlet Node Name
-  {f5829b60-8fa6-46ef-8434-75583d4352f9}, !- Air Outlet Node Name
+  {d8392d11-40da-47be-849b-80d9586b3d2d}, !- Water Inlet Node Name
+  {34e513e1-853e-4bb1-91fe-c79f99adc3ff}, !- Water Outlet Node Name
+  {9805e7b6-e07c-4b0e-b7f8-b1c9388af1bd}, !- Air Inlet Node Name
+  {c128ed55-dceb-4dac-9b71-c3e982366bdc}, !- Air Outlet Node Name
   ,                                       !- Performance Input Method
   ,                                       !- Rated Capacity {W}
   ,                                       !- Rated Inlet Water Temperature {C}
@@ -2585,9 +2593,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:Water,
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Handle
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Handle
   Coil Cooling Water 1,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- Design Water Flow Rate {m3/s}
   ,                                       !- Design Air Flow Rate {m3/s}
   ,                                       !- Design Inlet Water Temperature {C}
@@ -2595,22 +2603,22 @@ OS:Coil:Cooling:Water,
   ,                                       !- Design Outlet Air Temperature {C}
   ,                                       !- Design Inlet Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Design Outlet Air Humidity Ratio {kg-H2O/kg-air}
-  {740973cf-0552-45c9-8b2c-b11a558e8198}, !- Water Inlet Node Name
-  {ef8f8491-249f-4223-bf71-bb07be4d274d}, !- Water Outlet Node Name
-  {af2f7ca4-ea68-4c79-a0bf-cbf25304f852}, !- Air Inlet Node Name
-  {24b3839d-0713-4460-9036-097ce828a966}, !- Air Outlet Node Name
+  {0a32b8a8-c0e8-42dd-8bfa-51a6336dc6bc}, !- Water Inlet Node Name
+  {dd9935a2-5217-42d8-bb97-48543d764bfd}, !- Water Outlet Node Name
+  {859085b9-545f-4336-bc18-d55e0979f65b}, !- Air Inlet Node Name
+  {0d5dad9e-b3e4-450e-958c-4c05aeb86128}, !- Air Outlet Node Name
   ,                                       !- Type of Analysis
   ;                                       !- Heat Exchanger Configuration
 
 OS:SetpointManager:Scheduled,
-  {30d794f1-92d1-4ad7-af5b-ecf35974f4c2}, !- Handle
+  {b30d32a3-083e-4aad-8c96-420321b3f969}, !- Handle
   Setpoint Manager Scheduled 1,           !- Name
   Temperature,                            !- Control Variable
-  {ce214f85-b5d2-4691-9be2-dcc1de7cfe30}, !- Schedule Name
-  {efeb4583-895c-4a19-a1f9-f0fd526885ed}; !- Setpoint Node or NodeList Name
+  {94d67c4e-e4a6-4822-ade5-2119d49611c4}, !- Schedule Name
+  {c1b40c7e-3dea-4f1a-ad78-77ea5686f98d}; !- Setpoint Node or NodeList Name
 
 OS:ScheduleTypeLimits,
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Handle
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Handle
   Temperature,                            !- Name
   ,                                       !- Lower Limit Value
   ,                                       !- Upper Limit Value
@@ -2618,7 +2626,7 @@ OS:ScheduleTypeLimits,
   Temperature;                            !- Unit Type
 
 OS:Controller:OutdoorAir,
-  {d8549c69-eaa2-4068-9920-803ac4846936}, !- Handle
+  {b989cf93-1ed8-4c19-868c-020d039ce4cd}, !- Handle
   Controller Outdoor Air 1,               !- Name
   ,                                       !- Relief Air Outlet Node Name
   ,                                       !- Return Air Node Name
@@ -2638,7 +2646,7 @@ OS:Controller:OutdoorAir,
   ,                                       !- Minimum Outdoor Air Schedule Name
   ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
   ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
-  {8b924f17-80c5-46ed-878e-771eb6540a81}, !- Controller Mechanical Ventilation
+  {f52de04d-f2ca-4d6d-b7b8-e49eb0b75138}, !- Controller Mechanical Ventilation
   ,                                       !- Time of Day Economizer Control Schedule Name
   No,                                     !- High Humidity Control
   ,                                       !- Humidistat Control Zone Name
@@ -2647,135 +2655,135 @@ OS:Controller:OutdoorAir,
   BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
 
 OS:Controller:MechanicalVentilation,
-  {8b924f17-80c5-46ed-878e-771eb6540a81}, !- Handle
+  {f52de04d-f2ca-4d6d-b7b8-e49eb0b75138}, !- Handle
   Controller Mechanical Ventilation 1,    !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule
   ,                                       !- Demand Controlled Ventilation
   ZoneSum;                                !- System Outdoor Air Method
 
 OS:AirLoopHVAC:OutdoorAirSystem,
-  {172898d1-21aa-4e3c-9d22-04161e5775bd}, !- Handle
+  {fa196475-2d98-4b2e-ae59-0915dfeb8a3c}, !- Handle
   Air Loop HVAC Outdoor Air System 1,     !- Name
-  {d8549c69-eaa2-4068-9920-803ac4846936}, !- Controller Name
+  {b989cf93-1ed8-4c19-868c-020d039ce4cd}, !- Controller Name
   ,                                       !- Outdoor Air Equipment List Name
   ,                                       !- Availability Manager List Name
-  {c0e169d4-a904-46e6-9b62-a61f3898f011}, !- Mixed Air Node Name
-  {cba93cdc-ce78-4c5b-bf3b-54194013c769}, !- Outdoor Air Stream Node Name
-  {ff1ec418-9aea-4dff-867c-c462763f8c85}, !- Relief Air Stream Node Name
-  {d282eaa0-a3b3-4220-a447-4f7cb56d2ad3}; !- Return Air Stream Node Name
+  {cd7699de-f088-4708-acec-64384cd29db1}, !- Mixed Air Node Name
+  {e88393b3-0593-48fe-ac09-ffd54645a45a}, !- Outdoor Air Stream Node Name
+  {b3c039c2-5bf5-4b40-8101-cda88afc2517}, !- Relief Air Stream Node Name
+  {c3bdce0a-9d49-4c80-a691-02da2569af65}; !- Return Air Stream Node Name
 
 OS:Node,
-  {69bd0b4f-af0e-4679-9671-a99e8df3ead3}, !- Handle
+  {4af71148-05f4-421b-9f4d-3e7eb23ae47a}, !- Handle
   Node 16,                                !- Name
   ,                                       !- Inlet Port
-  {cba93cdc-ce78-4c5b-bf3b-54194013c769}; !- Outlet Port
+  {e88393b3-0593-48fe-ac09-ffd54645a45a}; !- Outlet Port
 
 OS:Connection,
-  {cba93cdc-ce78-4c5b-bf3b-54194013c769}, !- Handle
-  {a68ecf17-a2b7-44cf-8fe0-425b5ffa7aa3}, !- Name
-  {69bd0b4f-af0e-4679-9671-a99e8df3ead3}, !- Source Object
+  {e88393b3-0593-48fe-ac09-ffd54645a45a}, !- Handle
+  {cc96a36e-b4cd-4b27-9eee-32db99a596f2}, !- Name
+  {4af71148-05f4-421b-9f4d-3e7eb23ae47a}, !- Source Object
   3,                                      !- Outlet Port
-  {172898d1-21aa-4e3c-9d22-04161e5775bd}, !- Target Object
+  {fa196475-2d98-4b2e-ae59-0915dfeb8a3c}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Node,
-  {772de888-1456-4a5e-a0b7-1d3a736bdc75}, !- Handle
+  {fde96be2-2bba-43cf-af4f-f778c8afb190}, !- Handle
   Node 17,                                !- Name
-  {ff1ec418-9aea-4dff-867c-c462763f8c85}, !- Inlet Port
+  {b3c039c2-5bf5-4b40-8101-cda88afc2517}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {ff1ec418-9aea-4dff-867c-c462763f8c85}, !- Handle
-  {24a51ca6-a2a6-4386-bf6b-94d4c35b0fc6}, !- Name
-  {172898d1-21aa-4e3c-9d22-04161e5775bd}, !- Source Object
+  {b3c039c2-5bf5-4b40-8101-cda88afc2517}, !- Handle
+  {b8a0955b-abe6-43e7-98d3-b9dd94f30d75}, !- Name
+  {fa196475-2d98-4b2e-ae59-0915dfeb8a3c}, !- Source Object
   7,                                      !- Outlet Port
-  {772de888-1456-4a5e-a0b7-1d3a736bdc75}, !- Target Object
+  {fde96be2-2bba-43cf-af4f-f778c8afb190}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {d282eaa0-a3b3-4220-a447-4f7cb56d2ad3}, !- Handle
-  {2b6de645-76d9-44af-8160-0fdc6cb96c50}, !- Name
-  {9ee24f09-09f6-485d-bea6-e0ef0b2f8997}, !- Source Object
+  {c3bdce0a-9d49-4c80-a691-02da2569af65}, !- Handle
+  {13262bbc-76c3-4ab1-b547-d72957ea01f8}, !- Name
+  {110a03ab-fad4-4821-9a42-ab623cbc0f95}, !- Source Object
   3,                                      !- Outlet Port
-  {172898d1-21aa-4e3c-9d22-04161e5775bd}, !- Target Object
+  {fa196475-2d98-4b2e-ae59-0915dfeb8a3c}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Node,
-  {e0afee4f-f2e9-487d-8aca-257e64e43c59}, !- Handle
+  {d3793aa4-1b32-46a0-afe0-c931a991664f}, !- Handle
   Node 18,                                !- Name
-  {c0e169d4-a904-46e6-9b62-a61f3898f011}, !- Inlet Port
-  {af2f7ca4-ea68-4c79-a0bf-cbf25304f852}; !- Outlet Port
+  {cd7699de-f088-4708-acec-64384cd29db1}, !- Inlet Port
+  {859085b9-545f-4336-bc18-d55e0979f65b}; !- Outlet Port
 
 OS:Connection,
-  {c0e169d4-a904-46e6-9b62-a61f3898f011}, !- Handle
-  {47e0835a-4343-4c5f-b27c-9f0f27f3495f}, !- Name
-  {172898d1-21aa-4e3c-9d22-04161e5775bd}, !- Source Object
+  {cd7699de-f088-4708-acec-64384cd29db1}, !- Handle
+  {da1bfd89-200c-41fa-9453-87d517deabe1}, !- Name
+  {fa196475-2d98-4b2e-ae59-0915dfeb8a3c}, !- Source Object
   5,                                      !- Outlet Port
-  {e0afee4f-f2e9-487d-8aca-257e64e43c59}, !- Target Object
+  {d3793aa4-1b32-46a0-afe0-c931a991664f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {af2f7ca4-ea68-4c79-a0bf-cbf25304f852}, !- Handle
-  {a9bcbec2-055c-4567-8ff1-4699068163cd}, !- Name
-  {e0afee4f-f2e9-487d-8aca-257e64e43c59}, !- Source Object
+  {859085b9-545f-4336-bc18-d55e0979f65b}, !- Handle
+  {4af9eca6-37c8-4928-bf49-4956d6ac61df}, !- Name
+  {d3793aa4-1b32-46a0-afe0-c931a991664f}, !- Source Object
   3,                                      !- Outlet Port
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Target Object
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Node,
-  {8a1b24d3-80ab-449f-a576-900d4b1617e4}, !- Handle
+  {aad92177-e561-4fcb-b22e-6c0e8674d7e8}, !- Handle
   Node 19,                                !- Name
-  {24b3839d-0713-4460-9036-097ce828a966}, !- Inlet Port
-  {c6a4d39e-4511-498e-a249-aa01bb01909d}; !- Outlet Port
+  {0d5dad9e-b3e4-450e-958c-4c05aeb86128}, !- Inlet Port
+  {9805e7b6-e07c-4b0e-b7f8-b1c9388af1bd}; !- Outlet Port
 
 OS:Connection,
-  {24b3839d-0713-4460-9036-097ce828a966}, !- Handle
-  {a5066174-b6fe-4276-9dfc-9a845bc0df8c}, !- Name
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Source Object
+  {0d5dad9e-b3e4-450e-958c-4c05aeb86128}, !- Handle
+  {0d8e90ad-ce55-41fe-914b-7b4df5bc39c4}, !- Name
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Source Object
   13,                                     !- Outlet Port
-  {8a1b24d3-80ab-449f-a576-900d4b1617e4}, !- Target Object
+  {aad92177-e561-4fcb-b22e-6c0e8674d7e8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c6a4d39e-4511-498e-a249-aa01bb01909d}, !- Handle
-  {df3f246c-6170-4f05-89ec-36083573d4e4}, !- Name
-  {8a1b24d3-80ab-449f-a576-900d4b1617e4}, !- Source Object
+  {9805e7b6-e07c-4b0e-b7f8-b1c9388af1bd}, !- Handle
+  {ef0ee049-4f76-4d35-8a90-2412e0523aec}, !- Name
+  {aad92177-e561-4fcb-b22e-6c0e8674d7e8}, !- Source Object
   3,                                      !- Outlet Port
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Target Object
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Node,
-  {6a9dc5ba-1f6c-4bbc-8fd6-9ea25d5620d8}, !- Handle
+  {de2945de-2a3c-440d-8b62-2035c97639ee}, !- Handle
   Node 20,                                !- Name
-  {f5829b60-8fa6-46ef-8434-75583d4352f9}, !- Inlet Port
-  {bae56f74-7b02-4609-aea2-412567068d13}; !- Outlet Port
+  {c128ed55-dceb-4dac-9b71-c3e982366bdc}, !- Inlet Port
+  {74ab3a82-2ad6-4fdf-862e-c800fd4cfb54}; !- Outlet Port
 
 OS:Connection,
-  {f5829b60-8fa6-46ef-8434-75583d4352f9}, !- Handle
-  {aaf1ef07-5168-4ec9-b707-e17fd8c544d7}, !- Name
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Source Object
+  {c128ed55-dceb-4dac-9b71-c3e982366bdc}, !- Handle
+  {70290ed9-d7a5-4c49-a339-49d027bda8bb}, !- Name
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Source Object
   8,                                      !- Outlet Port
-  {6a9dc5ba-1f6c-4bbc-8fd6-9ea25d5620d8}, !- Target Object
+  {de2945de-2a3c-440d-8b62-2035c97639ee}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bae56f74-7b02-4609-aea2-412567068d13}, !- Handle
-  {52c66926-fe84-43be-a09d-eac875350525}, !- Name
-  {6a9dc5ba-1f6c-4bbc-8fd6-9ea25d5620d8}, !- Source Object
+  {74ab3a82-2ad6-4fdf-862e-c800fd4cfb54}, !- Handle
+  {21d7d456-22f8-4395-a541-2cf5a8514ecf}, !- Name
+  {de2945de-2a3c-440d-8b62-2035c97639ee}, !- Source Object
   3,                                      !- Outlet Port
-  {9942ef7e-b00e-4cc2-9067-c156ccdcdca8}, !- Target Object
+  {d90d6b0e-ef08-4e57-89c1-f667f2a63abd}, !- Target Object
   16;                                     !- Inlet Port
 
 OS:Connection,
-  {4da49542-e371-40b2-872a-4e458447c9d4}, !- Handle
-  {c00dadbb-a2dc-42b1-b232-0d68b61faf35}, !- Name
-  {9942ef7e-b00e-4cc2-9067-c156ccdcdca8}, !- Source Object
+  {974e8d68-969f-455c-aa68-5ed4f88ca4d2}, !- Handle
+  {8cb821f6-1004-41cc-a724-05771659dd6e}, !- Name
+  {d90d6b0e-ef08-4e57-89c1-f667f2a63abd}, !- Source Object
   17,                                     !- Outlet Port
-  {efeb4583-895c-4a19-a1f9-f0fd526885ed}, !- Target Object
+  {c1b40c7e-3dea-4f1a-ad78-77ea5686f98d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PlantLoop,
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Handle
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Handle
   Hot Water Loop,                         !- Name
   Water,                                  !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -2783,21 +2791,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {c001eafe-765e-45bf-9dcc-afed8f2b70c5}, !- Loop Temperature Setpoint Node Name
+  {43e194e8-083c-421d-85c9-73f88c721a9d}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {c0419fb6-7f2a-4915-9d16-8d99e0cbe61a}, !- Plant Side Inlet Node Name
-  {ba7de17e-48bc-44d8-b003-adf53667c890}, !- Plant Side Outlet Node Name
+  {9c541a20-41bc-4981-bea2-83588cea07ca}, !- Plant Side Inlet Node Name
+  {bce940bd-de2b-4bbd-8825-a6511952a298}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {afa6c69f-3c62-426b-a246-96103b1c829e}, !- Demand Side Inlet Node Name
-  {4d52c8a8-51a0-42de-940f-b0735c96fcf4}, !- Demand Side Outlet Node Name
+  {526bbf9e-d7cb-451f-9f22-81f50ed606b8}, !- Demand Side Inlet Node Name
+  {d7a89de7-14ad-452a-8c50-8311733973ac}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {5c3f7719-20e3-4e1e-a8e8-f481e45f8bbe}, !- Availability Manager List Name
+  {346d4e6f-5d5d-4bda-a958-279f1d527d43}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -2805,14 +2813,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Demand Mixer Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Demand Splitter Name
-  {102c1893-1a16-46c8-aa5e-98dc8470e2e7}, !- Supply Mixer Name
-  {16a9f854-be9c-42b6-a4ba-233299fb72d4}; !- Supply Splitter Name
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Demand Mixer Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Demand Splitter Name
+  {baf7ab40-5b02-41bd-abbd-5dee87c03c20}, !- Supply Mixer Name
+  {c87a038f-fd7e-4286-b8ea-2c35fa5d00a8}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {93b6879a-a350-47bc-a4ed-422733a23983}, !- Handle
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Plant or Condenser Loop Name
+  {346837d6-a91d-4a97-90f4-3b01e2ee29a4}, !- Handle
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Plant or Condenser Loop Name
   Heating,                                !- Loop Type
   82,                                     !- Design Loop Exit Temperature {C}
   11,                                     !- Loop Design Temperature Difference {deltaC}
@@ -2821,142 +2829,142 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {fa4e5b51-1c79-4846-b1ac-b039a8ecbd91}, !- Handle
+  {92e31002-ab8f-48c8-ad9c-b12ef60e0ae6}, !- Handle
   Node 21,                                !- Name
-  {c0419fb6-7f2a-4915-9d16-8d99e0cbe61a}, !- Inlet Port
-  {1c61791c-7a91-4113-8cf8-9aafcf8211ec}; !- Outlet Port
+  {9c541a20-41bc-4981-bea2-83588cea07ca}, !- Inlet Port
+  {ad530bb0-b36b-4d63-b9be-3da72c40aacd}; !- Outlet Port
 
 OS:Node,
-  {c001eafe-765e-45bf-9dcc-afed8f2b70c5}, !- Handle
+  {43e194e8-083c-421d-85c9-73f88c721a9d}, !- Handle
   Node 22,                                !- Name
-  {2832afa4-e788-4a51-aff4-59ba5e62c1bd}, !- Inlet Port
-  {ba7de17e-48bc-44d8-b003-adf53667c890}; !- Outlet Port
+  {81ea4b69-6e47-43d6-9290-249be0bc51fc}, !- Inlet Port
+  {bce940bd-de2b-4bbd-8825-a6511952a298}; !- Outlet Port
 
 OS:Node,
-  {18dc77ef-81aa-49c6-91e5-b5b5190f88fb}, !- Handle
+  {ddb53880-fa11-4720-9d0f-2c1bd92a58c6}, !- Handle
   Node 23,                                !- Name
-  {23cbef41-acc6-4ae3-9d25-c39e9f350b0e}, !- Inlet Port
-  {4b93b8c0-f4b6-48be-bbf0-581f1d3a3e21}; !- Outlet Port
+  {d3ea9e21-fb26-4628-9a73-d481736e7c3c}, !- Inlet Port
+  {75be5c9e-08f9-489d-8dd2-d375b1bf1af3}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {102c1893-1a16-46c8-aa5e-98dc8470e2e7}, !- Handle
+  {baf7ab40-5b02-41bd-abbd-5dee87c03c20}, !- Handle
   Connector Mixer 1,                      !- Name
-  {b60d3d56-762c-44a7-9d75-9d11069c4ecf}, !- Outlet Branch Name
-  {cf0b57d6-3900-468f-872c-4072464ad056}, !- Inlet Branch Name 1
-  {a0963caa-88af-42b5-8aa3-934673cb2c99}; !- Inlet Branch Name 2
+  {d327cb06-b635-450e-86b3-9bb5cef9d0e9}, !- Outlet Branch Name
+  {ca23e8ba-2d1a-49b7-94d1-686e69101a7c}, !- Inlet Branch Name 1
+  {791fe422-15db-4bec-90b5-ea89b44227f6}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {16a9f854-be9c-42b6-a4ba-233299fb72d4}, !- Handle
+  {c87a038f-fd7e-4286-b8ea-2c35fa5d00a8}, !- Handle
   Connector Splitter 1,                   !- Name
-  {269607fd-422a-468a-abaa-bfb5035d6b32}, !- Inlet Branch Name
-  {23cbef41-acc6-4ae3-9d25-c39e9f350b0e}, !- Outlet Branch Name 1
-  {6ce3c100-163e-4fc4-b298-2c58a34ac66d}; !- Outlet Branch Name 2
+  {802be074-84ad-4b55-bdad-bb744191508e}, !- Inlet Branch Name
+  {d3ea9e21-fb26-4628-9a73-d481736e7c3c}, !- Outlet Branch Name 1
+  {db34f34f-2020-4efd-931a-d3b0f896dda2}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {c0419fb6-7f2a-4915-9d16-8d99e0cbe61a}, !- Handle
-  {6e3869a9-13e9-4baa-876c-5097e0c1634e}, !- Name
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Source Object
+  {9c541a20-41bc-4981-bea2-83588cea07ca}, !- Handle
+  {80da0af5-0c15-4053-9a28-4e6c6bd8be10}, !- Name
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Source Object
   14,                                     !- Outlet Port
-  {fa4e5b51-1c79-4846-b1ac-b039a8ecbd91}, !- Target Object
+  {92e31002-ab8f-48c8-ad9c-b12ef60e0ae6}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {23cbef41-acc6-4ae3-9d25-c39e9f350b0e}, !- Handle
-  {99d3c520-1ac4-4b8f-a55a-85118eb381e6}, !- Name
-  {16a9f854-be9c-42b6-a4ba-233299fb72d4}, !- Source Object
+  {d3ea9e21-fb26-4628-9a73-d481736e7c3c}, !- Handle
+  {573e5b53-b726-4090-ae37-1c6eece47bc7}, !- Name
+  {c87a038f-fd7e-4286-b8ea-2c35fa5d00a8}, !- Source Object
   3,                                      !- Outlet Port
-  {18dc77ef-81aa-49c6-91e5-b5b5190f88fb}, !- Target Object
+  {ddb53880-fa11-4720-9d0f-2c1bd92a58c6}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {ba7de17e-48bc-44d8-b003-adf53667c890}, !- Handle
-  {65b4e38b-4e97-4116-ac7d-3ddb0f9081a4}, !- Name
-  {c001eafe-765e-45bf-9dcc-afed8f2b70c5}, !- Source Object
+  {bce940bd-de2b-4bbd-8825-a6511952a298}, !- Handle
+  {84c71ab4-2418-4d57-8045-8951a90b350f}, !- Name
+  {43e194e8-083c-421d-85c9-73f88c721a9d}, !- Source Object
   3,                                      !- Outlet Port
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Target Object
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {bc1938ca-a44f-4cb2-826d-a0a07940d61b}, !- Handle
+  {20015a46-d80f-4e69-b478-c19c898e5d06}, !- Handle
   Node 24,                                !- Name
-  {afa6c69f-3c62-426b-a246-96103b1c829e}, !- Inlet Port
-  {121e7f34-7e08-4bff-bea2-d640dc9cd555}; !- Outlet Port
+  {526bbf9e-d7cb-451f-9f22-81f50ed606b8}, !- Inlet Port
+  {87381f19-5841-4bff-9af6-1e9330d7c7c8}; !- Outlet Port
 
 OS:Node,
-  {9d9ffe0a-b4b7-4fc7-9a52-161a2f342750}, !- Handle
+  {e670768a-7684-410c-9511-2fc95923106c}, !- Handle
   Node 25,                                !- Name
-  {4a7693a2-8f22-4f2a-ac38-bf53fe750fc8}, !- Inlet Port
-  {4d52c8a8-51a0-42de-940f-b0735c96fcf4}; !- Outlet Port
+  {0704c3b6-c810-4e2b-b56f-b8e6b778585e}, !- Inlet Port
+  {d7a89de7-14ad-452a-8c50-8311733973ac}; !- Outlet Port
 
 OS:Node,
-  {7a2018c5-2bcc-4e9e-a240-d74b99cace59}, !- Handle
+  {a5952b3a-d0e0-4efd-8c3d-341178d4a2cb}, !- Handle
   Node 26,                                !- Name
-  {ba03e3ff-9550-4213-8239-34e7277cc90a}, !- Inlet Port
-  {dcd81fe2-3442-4a90-8cad-292d7c0c527f}; !- Outlet Port
+  {a52f4028-34e2-4841-8847-5e37ff9d3fa7}, !- Inlet Port
+  {d9b065e4-6d3b-4e0a-b40d-dcfa58a2cdd1}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Handle
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Handle
   Connector Mixer 2,                      !- Name
-  {552a8edf-8512-4e77-a81e-a4f284d40828}, !- Outlet Branch Name
-  {a02f07bd-3e00-48b8-850a-56e7bd5f9563}, !- Inlet Branch Name 1
-  {f44e15a4-e5ed-4485-b21f-f72cf0fa09bf}, !- Inlet Branch Name 2
-  {42d19447-ca0e-41be-bd0c-410cfe7b2713}, !- Inlet Branch Name 3
-  {95849612-703e-4aca-b108-9b0c30f0c90d}, !- Inlet Branch Name 4
-  {3b941dd9-48ba-41d1-a39b-a3efd46631cf}, !- Inlet Branch Name 5
-  {f53d4c85-24da-4500-9d80-d51bcbdc4672}, !- Inlet Branch Name 6
-  {6adfad65-fb86-442d-8a53-97197745427d}, !- Inlet Branch Name 7
-  {f0739955-9750-4252-b080-23ec71392f7c}, !- Inlet Branch Name 8
-  {4967e7f5-33e6-43d9-a956-6b6c2a02ee5e}, !- Inlet Branch Name 9
-  {eebcf3ea-79ee-401c-b759-d4467984d767}; !- Inlet Branch Name 10
+  {da3a1469-74cc-4a0a-999e-b6d57b21b774}, !- Outlet Branch Name
+  {d894e250-f615-40c5-acd4-e7e26db2630e}, !- Inlet Branch Name 1
+  {bf869980-826d-4b0d-a86c-38d81551cd98}, !- Inlet Branch Name 2
+  {f1f7b79b-25e8-41fa-95c3-4da8bbb5c1be}, !- Inlet Branch Name 3
+  {9bc3f8e8-59a9-4fa5-8cb7-2e33d163d6cb}, !- Inlet Branch Name 4
+  {3d018a21-b19a-4106-be83-cc40fcf33282}, !- Inlet Branch Name 5
+  {3666745f-1666-405a-97c7-f56cfe73cb8d}, !- Inlet Branch Name 6
+  {3050413d-24c7-46e5-9098-b2f1ec525ab2}, !- Inlet Branch Name 7
+  {e1c85cdd-008b-48df-85e7-17eccc20d9b4}, !- Inlet Branch Name 8
+  {04c089a7-65d7-4ad6-a7b5-4a9a5e22658c}, !- Inlet Branch Name 9
+  {4a71f1fb-4eb3-4743-80d1-3a37d49e80cb}; !- Inlet Branch Name 10
 
 OS:Connector:Splitter,
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Handle
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Handle
   Connector Splitter 2,                   !- Name
-  {27ecbab3-f678-42b5-a40d-01b358199c8a}, !- Inlet Branch Name
-  {ba03e3ff-9550-4213-8239-34e7277cc90a}, !- Outlet Branch Name 1
-  {3595546a-7102-46b1-85a8-8f9f9cd45281}, !- Outlet Branch Name 2
-  {0977b5af-680b-45e1-a74d-0dc7ac1f013d}, !- Outlet Branch Name 3
-  {18d3863b-f81d-4098-b28b-d4b8746dd143}, !- Outlet Branch Name 4
-  {d5c457b9-9efc-49b6-b478-8526aa343962}, !- Outlet Branch Name 5
-  {dbbea107-105c-4b71-b359-f226723280e0}, !- Outlet Branch Name 6
-  {aa17d262-20e5-4567-a91a-90040eac5940}, !- Outlet Branch Name 7
-  {2088155f-2b93-4116-8675-f7f46f5feded}, !- Outlet Branch Name 8
-  {37e2e4f8-5462-44e9-be99-661c3e72fb13}, !- Outlet Branch Name 9
-  {38c516c4-49b4-41c6-a1f7-c719477055f2}; !- Outlet Branch Name 10
+  {4e150906-f976-4d98-89e8-0a07fbfc647e}, !- Inlet Branch Name
+  {a52f4028-34e2-4841-8847-5e37ff9d3fa7}, !- Outlet Branch Name 1
+  {6c86de75-7b1d-44f9-bf48-c02ae1fefe80}, !- Outlet Branch Name 2
+  {39132141-0133-4bac-b054-57cce443c59e}, !- Outlet Branch Name 3
+  {e26df7d1-9b27-4649-8487-043b669a41ac}, !- Outlet Branch Name 4
+  {64cc8bd9-16ce-41bb-818e-004931b65858}, !- Outlet Branch Name 5
+  {e8053859-f805-4144-9bb0-84c64851b3a6}, !- Outlet Branch Name 6
+  {90de4ab5-1988-40d8-bc96-9ac1c633c5b4}, !- Outlet Branch Name 7
+  {fe6a891a-f00b-4ba6-b1ea-db04fd565691}, !- Outlet Branch Name 8
+  {698a749b-69a9-4397-9aca-ddd126aa7c55}, !- Outlet Branch Name 9
+  {b6f05ecb-d537-401c-901e-6d092208d28d}; !- Outlet Branch Name 10
 
 OS:Connection,
-  {afa6c69f-3c62-426b-a246-96103b1c829e}, !- Handle
-  {5c80609e-6216-488a-8df0-5bc3c0218304}, !- Name
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Source Object
+  {526bbf9e-d7cb-451f-9f22-81f50ed606b8}, !- Handle
+  {1255b0cc-6bc2-4075-99f7-0d835b93f2d6}, !- Name
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Source Object
   17,                                     !- Outlet Port
-  {bc1938ca-a44f-4cb2-826d-a0a07940d61b}, !- Target Object
+  {20015a46-d80f-4e69-b478-c19c898e5d06}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {ba03e3ff-9550-4213-8239-34e7277cc90a}, !- Handle
-  {458e6ef2-ac4d-440e-8cfa-55686413a39c}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {a52f4028-34e2-4841-8847-5e37ff9d3fa7}, !- Handle
+  {979477a6-7e73-491a-a8f2-e3bacb17b638}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   3,                                      !- Outlet Port
-  {7a2018c5-2bcc-4e9e-a240-d74b99cace59}, !- Target Object
+  {a5952b3a-d0e0-4efd-8c3d-341178d4a2cb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4d52c8a8-51a0-42de-940f-b0735c96fcf4}, !- Handle
-  {ca0c0f2d-fe8b-4dff-811b-0c38e670e87f}, !- Name
-  {9d9ffe0a-b4b7-4fc7-9a52-161a2f342750}, !- Source Object
+  {d7a89de7-14ad-452a-8c50-8311733973ac}, !- Handle
+  {cf248a27-a3a1-4096-882b-3f22389d0d5c}, !- Name
+  {e670768a-7684-410c-9511-2fc95923106c}, !- Source Object
   3,                                      !- Outlet Port
-  {246150ee-55c2-458f-87dd-95c5d50781a4}, !- Target Object
+  {265c5caa-1b04-452b-a0de-0255a8e60329}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {5c3f7719-20e3-4e1e-a8e8-f481e45f8bbe}, !- Handle
+  {346d4e6f-5d5d-4bda-a958-279f1d527d43}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList; !- Name
 
 OS:Pump:VariableSpeed,
-  {575c4979-dbc3-4c7e-b7d4-9c7fd383fcab}, !- Handle
+  {0860352f-471d-4c3f-8c0e-59936cee570d}, !- Handle
   Pump Variable Speed 1,                  !- Name
-  {1c61791c-7a91-4113-8cf8-9aafcf8211ec}, !- Inlet Node Name
-  {393fe8de-be33-4e60-bbf2-72ca494b0824}, !- Outlet Node Name
+  {ad530bb0-b36b-4d63-b9be-3da72c40aacd}, !- Inlet Node Name
+  {3a4a073e-8c10-4951-a9d6-2eceb673bc79}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -2985,20 +2993,20 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Boiler:HotWater,
-  {30126834-de44-44ac-8cba-715157c77bb5}, !- Handle
+  {346a20b0-8f41-4648-916b-942035fef7cf}, !- Handle
   Boiler Hot Water 1,                     !- Name
   ,                                       !- Fuel Type
   ,                                       !- Nominal Capacity {W}
   ,                                       !- Nominal Thermal Efficiency
   LeavingBoiler,                          !- Efficiency Curve Temperature Evaluation Variable
-  {9cf10365-ffdf-4278-a48a-a2c9c6caaab8}, !- Normalized Boiler Efficiency Curve Name
+  {2b88c313-434b-4665-82b2-2bc47ee3eed5}, !- Normalized Boiler Efficiency Curve Name
   ,                                       !- Design Water Outlet Temperature {C}
   ,                                       !- Design Water Flow Rate {m3/s}
   ,                                       !- Minimum Part Load Ratio
   ,                                       !- Maximum Part Load Ratio
   ,                                       !- Optimum Part Load Ratio
-  {4b93b8c0-f4b6-48be-bbf0-581f1d3a3e21}, !- Boiler Water Inlet Node Name
-  {eb8fd88e-29a2-419a-94d0-92b39380e9ca}, !- Boiler Water Outlet Node Name
+  {75be5c9e-08f9-489d-8dd2-d375b1bf1af3}, !- Boiler Water Inlet Node Name
+  {192cec07-958f-4f66-89d3-79cd54b7db8f}, !- Boiler Water Outlet Node Name
   99,                                     !- Water Outlet Upper Temperature Limit {C}
   ConstantFlow,                           !- Boiler Flow Mode
   0,                                      !- Parasitic Electric Load {W}
@@ -3006,7 +3014,7 @@ OS:Boiler:HotWater,
   General;                                !- End-Use Subcategory
 
 OS:Curve:Biquadratic,
-  {9cf10365-ffdf-4278-a48a-a2c9c6caaab8}, !- Handle
+  {2b88c313-434b-4665-82b2-2bc47ee3eed5}, !- Handle
   Boiler Efficiency,                      !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 x
@@ -3025,199 +3033,199 @@ OS:Curve:Biquadratic,
   Dimensionless;                          !- Output Unit Type
 
 OS:Node,
-  {88c52fbe-8e2e-4020-94e4-c5c0b7f1acc2}, !- Handle
+  {44da2ffe-0e7d-4f5c-b781-488fcd5c6f3c}, !- Handle
   Node 27,                                !- Name
-  {393fe8de-be33-4e60-bbf2-72ca494b0824}, !- Inlet Port
-  {269607fd-422a-468a-abaa-bfb5035d6b32}; !- Outlet Port
+  {3a4a073e-8c10-4951-a9d6-2eceb673bc79}, !- Inlet Port
+  {802be074-84ad-4b55-bdad-bb744191508e}; !- Outlet Port
 
 OS:Connection,
-  {1c61791c-7a91-4113-8cf8-9aafcf8211ec}, !- Handle
-  {f13908e0-0929-41c7-86ad-7fa39f620a8d}, !- Name
-  {fa4e5b51-1c79-4846-b1ac-b039a8ecbd91}, !- Source Object
+  {ad530bb0-b36b-4d63-b9be-3da72c40aacd}, !- Handle
+  {a7332a80-268b-47f5-920c-0d7e458b4235}, !- Name
+  {92e31002-ab8f-48c8-ad9c-b12ef60e0ae6}, !- Source Object
   3,                                      !- Outlet Port
-  {575c4979-dbc3-4c7e-b7d4-9c7fd383fcab}, !- Target Object
+  {0860352f-471d-4c3f-8c0e-59936cee570d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {393fe8de-be33-4e60-bbf2-72ca494b0824}, !- Handle
-  {9283f57e-4d84-48a6-a8ea-708d0834b890}, !- Name
-  {575c4979-dbc3-4c7e-b7d4-9c7fd383fcab}, !- Source Object
+  {3a4a073e-8c10-4951-a9d6-2eceb673bc79}, !- Handle
+  {8aaf662d-8706-4de9-bd00-4ca972e003c3}, !- Name
+  {0860352f-471d-4c3f-8c0e-59936cee570d}, !- Source Object
   3,                                      !- Outlet Port
-  {88c52fbe-8e2e-4020-94e4-c5c0b7f1acc2}, !- Target Object
+  {44da2ffe-0e7d-4f5c-b781-488fcd5c6f3c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {269607fd-422a-468a-abaa-bfb5035d6b32}, !- Handle
-  {4f0bd7a5-65d4-42d2-992e-2558d9b4afb3}, !- Name
-  {88c52fbe-8e2e-4020-94e4-c5c0b7f1acc2}, !- Source Object
+  {802be074-84ad-4b55-bdad-bb744191508e}, !- Handle
+  {7f6cb8ba-a815-46d5-8d64-b363bec251d0}, !- Name
+  {44da2ffe-0e7d-4f5c-b781-488fcd5c6f3c}, !- Source Object
   3,                                      !- Outlet Port
-  {16a9f854-be9c-42b6-a4ba-233299fb72d4}, !- Target Object
+  {c87a038f-fd7e-4286-b8ea-2c35fa5d00a8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {a7371e61-65fc-4ee9-96b8-c46984270552}, !- Handle
+  {3e965226-1747-4087-98dc-598d10105d65}, !- Handle
   Node 28,                                !- Name
-  {eb8fd88e-29a2-419a-94d0-92b39380e9ca}, !- Inlet Port
-  {cf0b57d6-3900-468f-872c-4072464ad056}; !- Outlet Port
+  {192cec07-958f-4f66-89d3-79cd54b7db8f}, !- Inlet Port
+  {ca23e8ba-2d1a-49b7-94d1-686e69101a7c}; !- Outlet Port
 
 OS:Connection,
-  {4b93b8c0-f4b6-48be-bbf0-581f1d3a3e21}, !- Handle
-  {34714e5b-b197-4173-9497-6b8b519e82b7}, !- Name
-  {18dc77ef-81aa-49c6-91e5-b5b5190f88fb}, !- Source Object
+  {75be5c9e-08f9-489d-8dd2-d375b1bf1af3}, !- Handle
+  {6c79302f-7e43-4ede-9713-3ab5614ff8d1}, !- Name
+  {ddb53880-fa11-4720-9d0f-2c1bd92a58c6}, !- Source Object
   3,                                      !- Outlet Port
-  {30126834-de44-44ac-8cba-715157c77bb5}, !- Target Object
+  {346a20b0-8f41-4648-916b-942035fef7cf}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Connection,
-  {eb8fd88e-29a2-419a-94d0-92b39380e9ca}, !- Handle
-  {5ca5214b-6b13-4f45-9214-a33c67830a2e}, !- Name
-  {30126834-de44-44ac-8cba-715157c77bb5}, !- Source Object
+  {192cec07-958f-4f66-89d3-79cd54b7db8f}, !- Handle
+  {12f9d0e4-a259-4a63-a9ed-01d5da2f63a8}, !- Name
+  {346a20b0-8f41-4648-916b-942035fef7cf}, !- Source Object
   13,                                     !- Outlet Port
-  {a7371e61-65fc-4ee9-96b8-c46984270552}, !- Target Object
+  {3e965226-1747-4087-98dc-598d10105d65}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {cf0b57d6-3900-468f-872c-4072464ad056}, !- Handle
-  {6243f532-4b82-46a1-b756-e20c24287b78}, !- Name
-  {a7371e61-65fc-4ee9-96b8-c46984270552}, !- Source Object
+  {ca23e8ba-2d1a-49b7-94d1-686e69101a7c}, !- Handle
+  {9ea73b4e-b293-459b-9411-fd4dc5fafd57}, !- Name
+  {3e965226-1747-4087-98dc-598d10105d65}, !- Source Object
   3,                                      !- Outlet Port
-  {102c1893-1a16-46c8-aa5e-98dc8470e2e7}, !- Target Object
+  {baf7ab40-5b02-41bd-abbd-5dee87c03c20}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {4bcadda6-d045-4d7d-be95-e552e54f5bd3}, !- Handle
+  {0930f0dc-24bf-465e-b0f0-e81fd01b0eac}, !- Handle
   Pipe Adiabatic 1,                       !- Name
-  {2fa92989-e645-4b63-a071-146a6866f715}, !- Inlet Node Name
-  {3457e098-1b6c-41d9-aefc-d322c5ca31c6}; !- Outlet Node Name
+  {b37d589b-c931-4fdb-b7b9-447bb5ea7e4c}, !- Inlet Node Name
+  {ff209889-a25d-4db3-8b0c-296a0ef17fa2}; !- Outlet Node Name
 
 OS:Node,
-  {69a627ae-fc71-4e3a-be66-ccf84ca115e4}, !- Handle
+  {1421fc48-4bf2-4828-ab60-a2c6885afd5b}, !- Handle
   Node 29,                                !- Name
-  {6ce3c100-163e-4fc4-b298-2c58a34ac66d}, !- Inlet Port
-  {2fa92989-e645-4b63-a071-146a6866f715}; !- Outlet Port
+  {db34f34f-2020-4efd-931a-d3b0f896dda2}, !- Inlet Port
+  {b37d589b-c931-4fdb-b7b9-447bb5ea7e4c}; !- Outlet Port
 
 OS:Connection,
-  {6ce3c100-163e-4fc4-b298-2c58a34ac66d}, !- Handle
-  {580d4abf-9b49-489b-957e-dc3238e7c269}, !- Name
-  {16a9f854-be9c-42b6-a4ba-233299fb72d4}, !- Source Object
+  {db34f34f-2020-4efd-931a-d3b0f896dda2}, !- Handle
+  {43b27a76-9ae2-423d-8dbe-cc9a18b06c3f}, !- Name
+  {c87a038f-fd7e-4286-b8ea-2c35fa5d00a8}, !- Source Object
   4,                                      !- Outlet Port
-  {69a627ae-fc71-4e3a-be66-ccf84ca115e4}, !- Target Object
+  {1421fc48-4bf2-4828-ab60-a2c6885afd5b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {22294c6c-8cbc-409a-bb55-4650fb7970cc}, !- Handle
+  {2bcf8419-b7b0-4ee5-8a43-2696c7273842}, !- Handle
   Node 30,                                !- Name
-  {3457e098-1b6c-41d9-aefc-d322c5ca31c6}, !- Inlet Port
-  {a0963caa-88af-42b5-8aa3-934673cb2c99}; !- Outlet Port
+  {ff209889-a25d-4db3-8b0c-296a0ef17fa2}, !- Inlet Port
+  {791fe422-15db-4bec-90b5-ea89b44227f6}; !- Outlet Port
 
 OS:Connection,
-  {2fa92989-e645-4b63-a071-146a6866f715}, !- Handle
-  {90c2197e-7d3b-42a9-a9c5-edaeede9ddd0}, !- Name
-  {69a627ae-fc71-4e3a-be66-ccf84ca115e4}, !- Source Object
+  {b37d589b-c931-4fdb-b7b9-447bb5ea7e4c}, !- Handle
+  {cb08a1b1-bfc7-4fe8-9432-203ce647fdb3}, !- Name
+  {1421fc48-4bf2-4828-ab60-a2c6885afd5b}, !- Source Object
   3,                                      !- Outlet Port
-  {4bcadda6-d045-4d7d-be95-e552e54f5bd3}, !- Target Object
+  {0930f0dc-24bf-465e-b0f0-e81fd01b0eac}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {3457e098-1b6c-41d9-aefc-d322c5ca31c6}, !- Handle
-  {a9b920d3-4349-456b-9763-cc3a80ed5341}, !- Name
-  {4bcadda6-d045-4d7d-be95-e552e54f5bd3}, !- Source Object
+  {ff209889-a25d-4db3-8b0c-296a0ef17fa2}, !- Handle
+  {b51947d0-d776-44b6-814f-66e5e9840ccc}, !- Name
+  {0930f0dc-24bf-465e-b0f0-e81fd01b0eac}, !- Source Object
   3,                                      !- Outlet Port
-  {22294c6c-8cbc-409a-bb55-4650fb7970cc}, !- Target Object
+  {2bcf8419-b7b0-4ee5-8a43-2696c7273842}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a0963caa-88af-42b5-8aa3-934673cb2c99}, !- Handle
-  {4282fa63-e0d9-4917-b94b-19689dce1a6b}, !- Name
-  {22294c6c-8cbc-409a-bb55-4650fb7970cc}, !- Source Object
+  {791fe422-15db-4bec-90b5-ea89b44227f6}, !- Handle
+  {910d688d-9f83-48cc-862d-497142d4fbd1}, !- Name
+  {2bcf8419-b7b0-4ee5-8a43-2696c7273842}, !- Source Object
   3,                                      !- Outlet Port
-  {102c1893-1a16-46c8-aa5e-98dc8470e2e7}, !- Target Object
+  {baf7ab40-5b02-41bd-abbd-5dee87c03c20}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {cec29d87-e343-4f1e-b226-fe289317238d}, !- Handle
+  {44d99c55-b5d5-4374-b38f-fd3fe8ce6bd7}, !- Handle
   Pipe Adiabatic 2,                       !- Name
-  {dcd81fe2-3442-4a90-8cad-292d7c0c527f}, !- Inlet Node Name
-  {cf5616a9-1bb2-48a7-aeb3-3da1ee4e299a}; !- Outlet Node Name
+  {d9b065e4-6d3b-4e0a-b40d-dcfa58a2cdd1}, !- Inlet Node Name
+  {592ae7a3-530d-469e-8506-1978a1ce458c}; !- Outlet Node Name
 
 OS:Node,
-  {8046b2b0-2a5a-437d-a750-1bdc66a8dcd0}, !- Handle
+  {6513be98-37d0-474f-af58-8d6c320ae270}, !- Handle
   Node 31,                                !- Name
-  {cf5616a9-1bb2-48a7-aeb3-3da1ee4e299a}, !- Inlet Port
-  {a02f07bd-3e00-48b8-850a-56e7bd5f9563}; !- Outlet Port
+  {592ae7a3-530d-469e-8506-1978a1ce458c}, !- Inlet Port
+  {d894e250-f615-40c5-acd4-e7e26db2630e}; !- Outlet Port
 
 OS:Connection,
-  {dcd81fe2-3442-4a90-8cad-292d7c0c527f}, !- Handle
-  {161fc54c-063e-47cb-a0ad-25b0d8dfa4de}, !- Name
-  {7a2018c5-2bcc-4e9e-a240-d74b99cace59}, !- Source Object
+  {d9b065e4-6d3b-4e0a-b40d-dcfa58a2cdd1}, !- Handle
+  {512e702c-5d92-437f-ae9a-8311e0aa55a5}, !- Name
+  {a5952b3a-d0e0-4efd-8c3d-341178d4a2cb}, !- Source Object
   3,                                      !- Outlet Port
-  {cec29d87-e343-4f1e-b226-fe289317238d}, !- Target Object
+  {44d99c55-b5d5-4374-b38f-fd3fe8ce6bd7}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {cf5616a9-1bb2-48a7-aeb3-3da1ee4e299a}, !- Handle
-  {9fbd5034-4a18-48fd-be66-19437f3b0261}, !- Name
-  {cec29d87-e343-4f1e-b226-fe289317238d}, !- Source Object
+  {592ae7a3-530d-469e-8506-1978a1ce458c}, !- Handle
+  {7fbdc0f5-f679-4866-b27d-70409347c503}, !- Name
+  {44d99c55-b5d5-4374-b38f-fd3fe8ce6bd7}, !- Source Object
   3,                                      !- Outlet Port
-  {8046b2b0-2a5a-437d-a750-1bdc66a8dcd0}, !- Target Object
+  {6513be98-37d0-474f-af58-8d6c320ae270}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a02f07bd-3e00-48b8-850a-56e7bd5f9563}, !- Handle
-  {a75084dc-a08d-4c6f-a236-845ba93ffd52}, !- Name
-  {8046b2b0-2a5a-437d-a750-1bdc66a8dcd0}, !- Source Object
+  {d894e250-f615-40c5-acd4-e7e26db2630e}, !- Handle
+  {478d4c64-e1ca-4634-a8b6-d6594f4dea87}, !- Name
+  {6513be98-37d0-474f-af58-8d6c320ae270}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {35b04215-678f-4a04-9bbf-ea235d3db7d7}, !- Handle
+  {c8a64464-2bb0-45ba-8cc5-fe5c6335fa14}, !- Handle
   Node 32,                                !- Name
-  {3595546a-7102-46b1-85a8-8f9f9cd45281}, !- Inlet Port
-  {338b6371-e79c-424f-8863-63b13cd009fd}; !- Outlet Port
+  {6c86de75-7b1d-44f9-bf48-c02ae1fefe80}, !- Inlet Port
+  {d8392d11-40da-47be-849b-80d9586b3d2d}; !- Outlet Port
 
 OS:Connection,
-  {3595546a-7102-46b1-85a8-8f9f9cd45281}, !- Handle
-  {58a996b5-a9f6-47c6-9282-36ced803c66a}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {6c86de75-7b1d-44f9-bf48-c02ae1fefe80}, !- Handle
+  {fe4175d4-47a8-4a18-9ab1-0d72735717b3}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   4,                                      !- Outlet Port
-  {35b04215-678f-4a04-9bbf-ea235d3db7d7}, !- Target Object
+  {c8a64464-2bb0-45ba-8cc5-fe5c6335fa14}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {5d7af30d-f5d5-47df-8402-e8ca6b4f1235}, !- Handle
+  {a013241a-c501-4479-8c8c-29fe112220ea}, !- Handle
   Node 33,                                !- Name
-  {c44f6198-9c37-415f-9d8d-1dc91556481f}, !- Inlet Port
-  {f44e15a4-e5ed-4485-b21f-f72cf0fa09bf}; !- Outlet Port
+  {34e513e1-853e-4bb1-91fe-c79f99adc3ff}, !- Inlet Port
+  {bf869980-826d-4b0d-a86c-38d81551cd98}; !- Outlet Port
 
 OS:Connection,
-  {338b6371-e79c-424f-8863-63b13cd009fd}, !- Handle
-  {61afed22-f5e8-4715-b855-3c5fef4d4c85}, !- Name
-  {35b04215-678f-4a04-9bbf-ea235d3db7d7}, !- Source Object
+  {d8392d11-40da-47be-849b-80d9586b3d2d}, !- Handle
+  {80504c05-ece8-4f1a-bf22-cdeebdca4144}, !- Name
+  {c8a64464-2bb0-45ba-8cc5-fe5c6335fa14}, !- Source Object
   3,                                      !- Outlet Port
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Target Object
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {c44f6198-9c37-415f-9d8d-1dc91556481f}, !- Handle
-  {7f9b0a5c-a3b7-4c7b-8bba-4b23e4b52f60}, !- Name
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Source Object
+  {34e513e1-853e-4bb1-91fe-c79f99adc3ff}, !- Handle
+  {b203eb75-20c9-4eb5-ab6e-5de3b233d567}, !- Name
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Source Object
   6,                                      !- Outlet Port
-  {5d7af30d-f5d5-47df-8402-e8ca6b4f1235}, !- Target Object
+  {a013241a-c501-4479-8c8c-29fe112220ea}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f44e15a4-e5ed-4485-b21f-f72cf0fa09bf}, !- Handle
-  {f6c5fcc2-29d3-4047-a5fb-3d2042a947ff}, !- Name
-  {5d7af30d-f5d5-47df-8402-e8ca6b4f1235}, !- Source Object
+  {bf869980-826d-4b0d-a86c-38d81551cd98}, !- Handle
+  {ec86e121-180e-4c72-b06e-96ecafa6454e}, !- Name
+  {a013241a-c501-4479-8c8c-29fe112220ea}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Controller:WaterCoil,
-  {b7a955f4-e207-4883-99e2-bf45af1de7a2}, !- Handle
+  {ad5890ee-0cad-4d99-b0f1-4c0bcd3504c7}, !- Handle
   Controller Water Coil 1,                !- Name
-  {a7807c03-cf0f-4bf1-8abe-b68a269d99e8}, !- Water Coil Name
+  {f2804257-9cd6-4d40-9346-fd060241ffd3}, !- Water Coil Name
   ,                                       !- Control Variable
   Normal,                                 !- Action
   ,                                       !- Actuator Variable
@@ -3228,122 +3236,122 @@ OS:Controller:WaterCoil,
   0;                                      !- Minimum Actuated Flow {m3/s}
 
 OS:Pipe:Adiabatic,
-  {b90590db-a081-4a0e-859b-52525459b5bb}, !- Handle
+  {03b6f2ff-8360-4523-9ff5-4db4f100178f}, !- Handle
   Pipe Adiabatic 3,                       !- Name
-  {121e7f34-7e08-4bff-bea2-d640dc9cd555}, !- Inlet Node Name
-  {5e49d3a4-d71a-4b60-9495-4a069d0612ef}; !- Outlet Node Name
+  {87381f19-5841-4bff-9af6-1e9330d7c7c8}, !- Inlet Node Name
+  {ad2d34db-a0a9-4696-b702-3be54953e8fd}; !- Outlet Node Name
 
 OS:Pipe:Adiabatic,
-  {a193e2f3-9dcb-4189-812e-d936b36df016}, !- Handle
+  {e44da33f-2809-4ad0-830a-db885c337c03}, !- Handle
   Pipe Adiabatic 4,                       !- Name
-  {fe6e41bc-9530-4020-9955-16e9f1aa4421}, !- Inlet Node Name
-  {4a7693a2-8f22-4f2a-ac38-bf53fe750fc8}; !- Outlet Node Name
+  {7f16134e-db2e-4a9b-a3cc-acddda2ea4c8}, !- Inlet Node Name
+  {0704c3b6-c810-4e2b-b56f-b8e6b778585e}; !- Outlet Node Name
 
 OS:Node,
-  {302b1396-0599-4f34-837b-4f0b4eb1b962}, !- Handle
+  {85247079-ec3a-4549-a37f-987d986d1367}, !- Handle
   Node 34,                                !- Name
-  {552a8edf-8512-4e77-a81e-a4f284d40828}, !- Inlet Port
-  {fe6e41bc-9530-4020-9955-16e9f1aa4421}; !- Outlet Port
+  {da3a1469-74cc-4a0a-999e-b6d57b21b774}, !- Inlet Port
+  {7f16134e-db2e-4a9b-a3cc-acddda2ea4c8}; !- Outlet Port
 
 OS:Connection,
-  {552a8edf-8512-4e77-a81e-a4f284d40828}, !- Handle
-  {b8a62d74-3bcc-4b98-abbb-a2cd7a4af27d}, !- Name
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Source Object
+  {da3a1469-74cc-4a0a-999e-b6d57b21b774}, !- Handle
+  {eb492532-6d6d-406b-9a78-e3ecd7991e9d}, !- Name
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Source Object
   2,                                      !- Outlet Port
-  {302b1396-0599-4f34-837b-4f0b4eb1b962}, !- Target Object
+  {85247079-ec3a-4549-a37f-987d986d1367}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {fe6e41bc-9530-4020-9955-16e9f1aa4421}, !- Handle
-  {d5ada24e-636d-4a68-9670-f5020116076c}, !- Name
-  {302b1396-0599-4f34-837b-4f0b4eb1b962}, !- Source Object
+  {7f16134e-db2e-4a9b-a3cc-acddda2ea4c8}, !- Handle
+  {51c50b8f-270b-4576-9987-0b11bb1be8f9}, !- Name
+  {85247079-ec3a-4549-a37f-987d986d1367}, !- Source Object
   3,                                      !- Outlet Port
-  {a193e2f3-9dcb-4189-812e-d936b36df016}, !- Target Object
+  {e44da33f-2809-4ad0-830a-db885c337c03}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4a7693a2-8f22-4f2a-ac38-bf53fe750fc8}, !- Handle
-  {0e0f6c48-3982-4db0-a3ea-f4ac0bd9b7c6}, !- Name
-  {a193e2f3-9dcb-4189-812e-d936b36df016}, !- Source Object
+  {0704c3b6-c810-4e2b-b56f-b8e6b778585e}, !- Handle
+  {f8c58a45-2de5-4339-9de0-e117719c8514}, !- Name
+  {e44da33f-2809-4ad0-830a-db885c337c03}, !- Source Object
   3,                                      !- Outlet Port
-  {9d9ffe0a-b4b7-4fc7-9a52-161a2f342750}, !- Target Object
+  {e670768a-7684-410c-9511-2fc95923106c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {1c8db266-b917-49e1-8658-e56dd3c1aee8}, !- Handle
+  {b2c32f39-a1f7-4bf8-ada9-f65ba2accc07}, !- Handle
   Node 35,                                !- Name
-  {5e49d3a4-d71a-4b60-9495-4a069d0612ef}, !- Inlet Port
-  {27ecbab3-f678-42b5-a40d-01b358199c8a}; !- Outlet Port
+  {ad2d34db-a0a9-4696-b702-3be54953e8fd}, !- Inlet Port
+  {4e150906-f976-4d98-89e8-0a07fbfc647e}; !- Outlet Port
 
 OS:Connection,
-  {121e7f34-7e08-4bff-bea2-d640dc9cd555}, !- Handle
-  {279113da-042a-4953-9cff-856e66e4c908}, !- Name
-  {bc1938ca-a44f-4cb2-826d-a0a07940d61b}, !- Source Object
+  {87381f19-5841-4bff-9af6-1e9330d7c7c8}, !- Handle
+  {9dead8a4-aa08-4c12-b93c-fe112fc065bf}, !- Name
+  {20015a46-d80f-4e69-b478-c19c898e5d06}, !- Source Object
   3,                                      !- Outlet Port
-  {b90590db-a081-4a0e-859b-52525459b5bb}, !- Target Object
+  {03b6f2ff-8360-4523-9ff5-4db4f100178f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5e49d3a4-d71a-4b60-9495-4a069d0612ef}, !- Handle
-  {4bab941e-5f38-4d6f-8d98-c17277a2cfbe}, !- Name
-  {b90590db-a081-4a0e-859b-52525459b5bb}, !- Source Object
+  {ad2d34db-a0a9-4696-b702-3be54953e8fd}, !- Handle
+  {805888cd-798e-4971-9889-61366b60aad4}, !- Name
+  {03b6f2ff-8360-4523-9ff5-4db4f100178f}, !- Source Object
   3,                                      !- Outlet Port
-  {1c8db266-b917-49e1-8658-e56dd3c1aee8}, !- Target Object
+  {b2c32f39-a1f7-4bf8-ada9-f65ba2accc07}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {27ecbab3-f678-42b5-a40d-01b358199c8a}, !- Handle
-  {28995844-c82c-49de-bb5f-8936a2ba0fa7}, !- Name
-  {1c8db266-b917-49e1-8658-e56dd3c1aee8}, !- Source Object
+  {4e150906-f976-4d98-89e8-0a07fbfc647e}, !- Handle
+  {c54b8727-ba9e-4fc6-a24f-909a4d72085d}, !- Name
+  {b2c32f39-a1f7-4bf8-ada9-f65ba2accc07}, !- Source Object
   3,                                      !- Outlet Port
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Target Object
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {3fd9abf6-d094-4938-b775-0c892d63aeb1}, !- Handle
+  {a7f096fa-8fa2-40d7-8768-9bd36102c032}, !- Handle
   Pipe Adiabatic 5,                       !- Name
-  {57de9781-b37e-4e37-a76f-944b8942c571}, !- Inlet Node Name
-  {2832afa4-e788-4a51-aff4-59ba5e62c1bd}; !- Outlet Node Name
+  {4c19a969-f74e-424d-b96a-df3329680ea1}, !- Inlet Node Name
+  {81ea4b69-6e47-43d6-9290-249be0bc51fc}; !- Outlet Node Name
 
 OS:Node,
-  {758a2a25-ea26-4bea-9e79-c8cf9ad4105f}, !- Handle
+  {a4479ef6-e396-4d8b-8cab-cf88ed839122}, !- Handle
   Node 36,                                !- Name
-  {b60d3d56-762c-44a7-9d75-9d11069c4ecf}, !- Inlet Port
-  {57de9781-b37e-4e37-a76f-944b8942c571}; !- Outlet Port
+  {d327cb06-b635-450e-86b3-9bb5cef9d0e9}, !- Inlet Port
+  {4c19a969-f74e-424d-b96a-df3329680ea1}; !- Outlet Port
 
 OS:Connection,
-  {b60d3d56-762c-44a7-9d75-9d11069c4ecf}, !- Handle
-  {05cf14b9-4dec-4faa-82e5-688ead31e976}, !- Name
-  {102c1893-1a16-46c8-aa5e-98dc8470e2e7}, !- Source Object
+  {d327cb06-b635-450e-86b3-9bb5cef9d0e9}, !- Handle
+  {58e348a0-d059-4cb8-8b13-af21dab6e885}, !- Name
+  {baf7ab40-5b02-41bd-abbd-5dee87c03c20}, !- Source Object
   2,                                      !- Outlet Port
-  {758a2a25-ea26-4bea-9e79-c8cf9ad4105f}, !- Target Object
+  {a4479ef6-e396-4d8b-8cab-cf88ed839122}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {57de9781-b37e-4e37-a76f-944b8942c571}, !- Handle
-  {8fa289d8-5608-4092-85da-139f9fc07e00}, !- Name
-  {758a2a25-ea26-4bea-9e79-c8cf9ad4105f}, !- Source Object
+  {4c19a969-f74e-424d-b96a-df3329680ea1}, !- Handle
+  {c2123599-df90-40ff-b967-11ea2943a067}, !- Name
+  {a4479ef6-e396-4d8b-8cab-cf88ed839122}, !- Source Object
   3,                                      !- Outlet Port
-  {3fd9abf6-d094-4938-b775-0c892d63aeb1}, !- Target Object
+  {a7f096fa-8fa2-40d7-8768-9bd36102c032}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2832afa4-e788-4a51-aff4-59ba5e62c1bd}, !- Handle
-  {ac31e679-c356-42e3-8014-bb4d0c6f36d8}, !- Name
-  {3fd9abf6-d094-4938-b775-0c892d63aeb1}, !- Source Object
+  {81ea4b69-6e47-43d6-9290-249be0bc51fc}, !- Handle
+  {caff5a20-c7d7-4fc9-86c1-926839372c9f}, !- Name
+  {a7f096fa-8fa2-40d7-8768-9bd36102c032}, !- Source Object
   3,                                      !- Outlet Port
-  {c001eafe-765e-45bf-9dcc-afed8f2b70c5}, !- Target Object
+  {43e194e8-083c-421d-85c9-73f88c721a9d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:SetpointManager:Scheduled,
-  {2e3e09d9-4663-4a13-9a45-0145ce583527}, !- Handle
+  {555d0e4c-e562-4ecf-89e4-1bf910d7a6e3}, !- Handle
   Setpoint Manager Scheduled 2,           !- Name
   Temperature,                            !- Control Variable
-  {61093f18-83b2-4e65-aa6a-565e79123efa}, !- Schedule Name
-  {c001eafe-765e-45bf-9dcc-afed8f2b70c5}; !- Setpoint Node or NodeList Name
+  {c02170ce-041a-45c6-8cd1-cf3fac2ec1d8}, !- Schedule Name
+  {43e194e8-083c-421d-85c9-73f88c721a9d}; !- Setpoint Node or NodeList Name
 
 OS:PlantLoop,
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Handle
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Handle
   Chilled Water Loop,                     !- Name
   ,                                       !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -3351,21 +3359,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {7d7aecc7-e808-4afb-ae71-b3748d468945}, !- Loop Temperature Setpoint Node Name
+  {9cf6d2b1-e6ee-48ff-a9ec-ff38dc775190}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {a075bb8f-d4d7-4a02-945f-c15f50944905}, !- Plant Side Inlet Node Name
-  {b49d599d-2d38-4efd-9252-2c8604168404}, !- Plant Side Outlet Node Name
+  {b27f7cbc-4b24-4b4b-b1e1-5699760e3f36}, !- Plant Side Inlet Node Name
+  {83df8df5-377d-40ca-b3f8-f31a7409ea9e}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {d105161a-dcad-41db-ad2b-ded1f3a4348d}, !- Demand Side Inlet Node Name
-  {f0ad74da-5779-4520-a5b8-74f710e0a3cf}, !- Demand Side Outlet Node Name
+  {39648d7c-2d3f-4b85-919d-6be64497690d}, !- Demand Side Inlet Node Name
+  {09b0eae1-8980-4d32-9f62-c5f4a12daae1}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {172a4a85-c73e-473d-bf75-a2d55ca4b2ed}, !- Availability Manager List Name
+  {5aa0c60c-0ecc-464c-a69d-efb72ef3941c}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -3373,14 +3381,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {ce25fa74-5fc6-4bda-9998-a822eb962f71}, !- Demand Mixer Name
-  {54005676-0a5d-4dbc-ba67-aca5df51fb1e}, !- Demand Splitter Name
-  {626438c3-e10d-4dd5-ae8a-3b52eec4ea4d}, !- Supply Mixer Name
-  {74183eab-6dc3-4e4c-928d-67953dd1c0a7}; !- Supply Splitter Name
+  {805edd4a-64d4-4014-b707-cabb54578f80}, !- Demand Mixer Name
+  {578b22f1-ebc9-4761-b4b8-70f678a532c4}, !- Demand Splitter Name
+  {67318359-189e-4e8c-8f7f-cd5e324d49ec}, !- Supply Mixer Name
+  {ef710045-5bce-42ef-a6fa-ea4b1c6635ff}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {c46453d1-8879-4554-91db-d3890f091b1b}, !- Handle
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Plant or Condenser Loop Name
+  {bad1a2e1-e09a-42f3-9db0-33ffb4939220}, !- Handle
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Plant or Condenser Loop Name
   Cooling,                                !- Loop Type
   7.22,                                   !- Design Loop Exit Temperature {C}
   6.67,                                   !- Loop Design Temperature Difference {deltaC}
@@ -3389,126 +3397,126 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {6751a6c2-bbae-43f9-9073-1593f8344f89}, !- Handle
+  {3e80dfbb-e252-4362-a2dc-17e71596119d}, !- Handle
   Node 37,                                !- Name
-  {a075bb8f-d4d7-4a02-945f-c15f50944905}, !- Inlet Port
-  {0496cf6a-b0b5-49b9-a86e-370a41a245cc}; !- Outlet Port
+  {b27f7cbc-4b24-4b4b-b1e1-5699760e3f36}, !- Inlet Port
+  {7337362a-60c0-4e62-9209-0b8e09c7e059}; !- Outlet Port
 
 OS:Node,
-  {7d7aecc7-e808-4afb-ae71-b3748d468945}, !- Handle
+  {9cf6d2b1-e6ee-48ff-a9ec-ff38dc775190}, !- Handle
   Node 38,                                !- Name
-  {412aaeb0-c54d-41cc-b414-d547f73a0eaf}, !- Inlet Port
-  {b49d599d-2d38-4efd-9252-2c8604168404}; !- Outlet Port
+  {c75db921-6472-4813-8b0d-3ef3a91bb44a}, !- Inlet Port
+  {83df8df5-377d-40ca-b3f8-f31a7409ea9e}; !- Outlet Port
 
 OS:Node,
-  {e07750e0-1411-4a57-846d-5e7e3accd1d7}, !- Handle
+  {e16a9cf6-6680-4f11-bca9-331c9c85f831}, !- Handle
   Node 39,                                !- Name
-  {cdaa7079-e2cc-4559-acfd-e57a9a3e5787}, !- Inlet Port
-  {ea1d06d3-f2ca-44cf-8447-863228a9166b}; !- Outlet Port
+  {c95737c2-8682-462f-9268-6304e4cdb265}, !- Inlet Port
+  {cd80f3f5-90f5-4e13-ba45-6e95d57bf329}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {626438c3-e10d-4dd5-ae8a-3b52eec4ea4d}, !- Handle
+  {67318359-189e-4e8c-8f7f-cd5e324d49ec}, !- Handle
   Connector Mixer 3,                      !- Name
-  {653394b6-fa81-4752-bd59-f8b3713e6af3}, !- Outlet Branch Name
-  {6da1669b-f374-4aa3-bd83-4465a5c36e44}, !- Inlet Branch Name 1
-  {6abb33e0-68a9-4d14-9241-2afef96153b3}; !- Inlet Branch Name 2
+  {cc8e97a0-e58a-4f0a-a311-332da4088110}, !- Outlet Branch Name
+  {493113ff-58db-4532-9ded-84116fc5fa75}, !- Inlet Branch Name 1
+  {ce463a8f-9e28-40d6-b3a8-dda3bce44c07}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {74183eab-6dc3-4e4c-928d-67953dd1c0a7}, !- Handle
+  {ef710045-5bce-42ef-a6fa-ea4b1c6635ff}, !- Handle
   Connector Splitter 3,                   !- Name
-  {410b6da9-4f7c-496d-8b07-3faf5073a78d}, !- Inlet Branch Name
-  {cdaa7079-e2cc-4559-acfd-e57a9a3e5787}, !- Outlet Branch Name 1
-  {115d17c9-3304-4a52-8a65-8982e77dac5b}; !- Outlet Branch Name 2
+  {5e0e72fc-160f-4d62-98a4-986a6a6eb64e}, !- Inlet Branch Name
+  {c95737c2-8682-462f-9268-6304e4cdb265}, !- Outlet Branch Name 1
+  {0e5eb602-73b5-4fe2-8e93-ec8674107010}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {a075bb8f-d4d7-4a02-945f-c15f50944905}, !- Handle
-  {4b26aa03-f930-4231-8773-be028f29bbef}, !- Name
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Source Object
+  {b27f7cbc-4b24-4b4b-b1e1-5699760e3f36}, !- Handle
+  {1e9914f5-d433-47ba-9874-330ddbbdcf7f}, !- Name
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Source Object
   14,                                     !- Outlet Port
-  {6751a6c2-bbae-43f9-9073-1593f8344f89}, !- Target Object
+  {3e80dfbb-e252-4362-a2dc-17e71596119d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {cdaa7079-e2cc-4559-acfd-e57a9a3e5787}, !- Handle
-  {46ad2316-d586-482f-b174-7584406f0c8a}, !- Name
-  {74183eab-6dc3-4e4c-928d-67953dd1c0a7}, !- Source Object
+  {c95737c2-8682-462f-9268-6304e4cdb265}, !- Handle
+  {e19c96f5-9a50-4135-974e-89fde1284152}, !- Name
+  {ef710045-5bce-42ef-a6fa-ea4b1c6635ff}, !- Source Object
   3,                                      !- Outlet Port
-  {e07750e0-1411-4a57-846d-5e7e3accd1d7}, !- Target Object
+  {e16a9cf6-6680-4f11-bca9-331c9c85f831}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b49d599d-2d38-4efd-9252-2c8604168404}, !- Handle
-  {60ba7cb6-473e-4783-ac0c-31df1421972c}, !- Name
-  {7d7aecc7-e808-4afb-ae71-b3748d468945}, !- Source Object
+  {83df8df5-377d-40ca-b3f8-f31a7409ea9e}, !- Handle
+  {6e6b3b9e-c7e0-4ec4-9ebc-40d34a99f86b}, !- Name
+  {9cf6d2b1-e6ee-48ff-a9ec-ff38dc775190}, !- Source Object
   3,                                      !- Outlet Port
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Target Object
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {8667c4a2-af3e-414a-9b96-4614243fee5a}, !- Handle
+  {6cf2c64d-4020-43e0-958f-7b33196ae1b0}, !- Handle
   Node 40,                                !- Name
-  {d105161a-dcad-41db-ad2b-ded1f3a4348d}, !- Inlet Port
-  {e2381d23-0423-4e8d-b371-cd356506683f}; !- Outlet Port
+  {39648d7c-2d3f-4b85-919d-6be64497690d}, !- Inlet Port
+  {c9149398-84b7-4a76-8ecd-454bb244e028}; !- Outlet Port
 
 OS:Node,
-  {6294f172-b393-471d-b187-553bf7c42223}, !- Handle
+  {4bf2fe47-97b0-417a-a69c-29e8af1598ce}, !- Handle
   Node 41,                                !- Name
-  {9b85fd5f-13d2-4759-a9a2-61085e52768a}, !- Inlet Port
-  {f0ad74da-5779-4520-a5b8-74f710e0a3cf}; !- Outlet Port
+  {62275654-d139-49b3-bbf4-3fe9f7fc4fc8}, !- Inlet Port
+  {09b0eae1-8980-4d32-9f62-c5f4a12daae1}; !- Outlet Port
 
 OS:Node,
-  {95083978-5936-4caa-9824-8cdd3af77f3c}, !- Handle
+  {2c963a96-53e7-4b5d-be01-f47bf06820ae}, !- Handle
   Node 42,                                !- Name
-  {75b96599-3044-4f92-b7d2-f2fc77ad8a69}, !- Inlet Port
-  {740973cf-0552-45c9-8b2c-b11a558e8198}; !- Outlet Port
+  {c9bf4cfd-abc0-46cc-997e-ca119c9f93d0}, !- Inlet Port
+  {0a32b8a8-c0e8-42dd-8bfa-51a6336dc6bc}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {ce25fa74-5fc6-4bda-9998-a822eb962f71}, !- Handle
+  {805edd4a-64d4-4014-b707-cabb54578f80}, !- Handle
   Connector Mixer 4,                      !- Name
-  {341a196c-8aea-4b4f-ac45-7344c5e60113}, !- Outlet Branch Name
-  {f4581aea-1966-4fed-83a3-41fea64c5bc3}, !- Inlet Branch Name 1
-  {738dc083-2014-4043-a625-8d31163ebb3f}; !- Inlet Branch Name 2
+  {b658cc1d-3b89-4db0-ae71-b4f1922ed2c5}, !- Outlet Branch Name
+  {6f724b2e-9052-48ca-8f8c-f0b1b1c44b23}, !- Inlet Branch Name 1
+  {354a8d9d-dc03-4f21-9aa4-4fdfcbde9296}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {54005676-0a5d-4dbc-ba67-aca5df51fb1e}, !- Handle
+  {578b22f1-ebc9-4761-b4b8-70f678a532c4}, !- Handle
   Connector Splitter 4,                   !- Name
-  {2a81b083-7bae-4e18-a66c-ec14110982a2}, !- Inlet Branch Name
-  {75b96599-3044-4f92-b7d2-f2fc77ad8a69}, !- Outlet Branch Name 1
-  {a3135a08-894a-4a58-ac06-c01ec28c1dda}; !- Outlet Branch Name 2
+  {6f7092d1-5fd9-4137-be5c-c7c1a560ea9f}, !- Inlet Branch Name
+  {c9bf4cfd-abc0-46cc-997e-ca119c9f93d0}, !- Outlet Branch Name 1
+  {adc2c1e3-78d0-42f6-bc2e-4cd395b3920f}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {d105161a-dcad-41db-ad2b-ded1f3a4348d}, !- Handle
-  {2487d179-0af0-4969-b327-5fa5916d7823}, !- Name
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Source Object
+  {39648d7c-2d3f-4b85-919d-6be64497690d}, !- Handle
+  {07d6bede-8956-4498-a2af-3f6433e3401f}, !- Name
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Source Object
   17,                                     !- Outlet Port
-  {8667c4a2-af3e-414a-9b96-4614243fee5a}, !- Target Object
+  {6cf2c64d-4020-43e0-958f-7b33196ae1b0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {75b96599-3044-4f92-b7d2-f2fc77ad8a69}, !- Handle
-  {f760db83-ca5a-40ac-b816-9c3672dcbc9c}, !- Name
-  {54005676-0a5d-4dbc-ba67-aca5df51fb1e}, !- Source Object
+  {c9bf4cfd-abc0-46cc-997e-ca119c9f93d0}, !- Handle
+  {7516d04a-534d-40da-9b85-fa2387e35194}, !- Name
+  {578b22f1-ebc9-4761-b4b8-70f678a532c4}, !- Source Object
   3,                                      !- Outlet Port
-  {95083978-5936-4caa-9824-8cdd3af77f3c}, !- Target Object
+  {2c963a96-53e7-4b5d-be01-f47bf06820ae}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f0ad74da-5779-4520-a5b8-74f710e0a3cf}, !- Handle
-  {51814d67-6724-4536-9cba-4e5ef8cbb175}, !- Name
-  {6294f172-b393-471d-b187-553bf7c42223}, !- Source Object
+  {09b0eae1-8980-4d32-9f62-c5f4a12daae1}, !- Handle
+  {de534e37-4673-4a9a-a30d-215af5763e38}, !- Name
+  {4bf2fe47-97b0-417a-a69c-29e8af1598ce}, !- Source Object
   3,                                      !- Outlet Port
-  {f4a5068e-6229-4ac0-ae99-aa3953de20c5}, !- Target Object
+  {7176efad-5be7-4c4c-b8d6-14a8deb7a15e}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {172a4a85-c73e-473d-bf75-a2d55ca4b2ed}, !- Handle
+  {5aa0c60c-0ecc-464c-a69d-efb72ef3941c}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList 1; !- Name
 
 OS:Pump:VariableSpeed,
-  {36aa3882-9df4-40f8-a51d-d2cfb25c4b4f}, !- Handle
+  {906d0f1b-1b6f-4f08-8ffa-e5b7c415ba1f}, !- Handle
   Pump Variable Speed 2,                  !- Name
-  {0496cf6a-b0b5-49b9-a86e-370a41a245cc}, !- Inlet Node Name
-  {5bbfb043-526c-4e8c-8983-01740306f56d}, !- Outlet Node Name
+  {7337362a-60c0-4e62-9209-0b8e09c7e059}, !- Inlet Node Name
+  {caa62ad1-fcf1-43d4-9e66-30e886a65b06}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -3537,37 +3545,37 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Node,
-  {1254a54b-886f-46b2-954c-ce1c770092f9}, !- Handle
+  {05fbc336-431f-4e21-8c81-3b1ef887b4ab}, !- Handle
   Node 43,                                !- Name
-  {5bbfb043-526c-4e8c-8983-01740306f56d}, !- Inlet Port
-  {410b6da9-4f7c-496d-8b07-3faf5073a78d}; !- Outlet Port
+  {caa62ad1-fcf1-43d4-9e66-30e886a65b06}, !- Inlet Port
+  {5e0e72fc-160f-4d62-98a4-986a6a6eb64e}; !- Outlet Port
 
 OS:Connection,
-  {0496cf6a-b0b5-49b9-a86e-370a41a245cc}, !- Handle
-  {316a4fb6-3a7e-4eb9-84c2-c06bbb4eaf61}, !- Name
-  {6751a6c2-bbae-43f9-9073-1593f8344f89}, !- Source Object
+  {7337362a-60c0-4e62-9209-0b8e09c7e059}, !- Handle
+  {9a8872a0-d002-4103-92fb-8e10aed09552}, !- Name
+  {3e80dfbb-e252-4362-a2dc-17e71596119d}, !- Source Object
   3,                                      !- Outlet Port
-  {36aa3882-9df4-40f8-a51d-d2cfb25c4b4f}, !- Target Object
+  {906d0f1b-1b6f-4f08-8ffa-e5b7c415ba1f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5bbfb043-526c-4e8c-8983-01740306f56d}, !- Handle
-  {ed33086a-fb7e-4c0c-8db3-7ff3f28bd6ad}, !- Name
-  {36aa3882-9df4-40f8-a51d-d2cfb25c4b4f}, !- Source Object
+  {caa62ad1-fcf1-43d4-9e66-30e886a65b06}, !- Handle
+  {65e6887b-6df2-48e6-977a-d7a4ad7880d7}, !- Name
+  {906d0f1b-1b6f-4f08-8ffa-e5b7c415ba1f}, !- Source Object
   3,                                      !- Outlet Port
-  {1254a54b-886f-46b2-954c-ce1c770092f9}, !- Target Object
+  {05fbc336-431f-4e21-8c81-3b1ef887b4ab}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {410b6da9-4f7c-496d-8b07-3faf5073a78d}, !- Handle
-  {2174084b-df77-4ea6-99c1-fe6cea4578b8}, !- Name
-  {1254a54b-886f-46b2-954c-ce1c770092f9}, !- Source Object
+  {5e0e72fc-160f-4d62-98a4-986a6a6eb64e}, !- Handle
+  {d87af83b-7692-41bb-a818-507c06211aad}, !- Name
+  {05fbc336-431f-4e21-8c81-3b1ef887b4ab}, !- Source Object
   3,                                      !- Outlet Port
-  {74183eab-6dc3-4e4c-928d-67953dd1c0a7}, !- Target Object
+  {ef710045-5bce-42ef-a6fa-ea4b1c6635ff}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Curve:Biquadratic,
-  {b421404b-ae4a-42cc-a4e1-664d0d4eddac}, !- Handle
+  {07b66521-ee49-4b01-93e5-3f0a2578ae04}, !- Handle
   Curve Biquadratic 1,                    !- Name
   0.258,                                  !- Coefficient1 Constant
   0.0389,                                 !- Coefficient2 x
@@ -3581,7 +3589,7 @@ OS:Curve:Biquadratic,
   35;                                     !- Maximum Value of y
 
 OS:Curve:Biquadratic,
-  {3738f134-c790-4b2b-8ca7-c75b250d8d32}, !- Handle
+  {a85cc0ff-3565-4f65-92cc-86c35b61e906}, !- Handle
   Curve Biquadratic 2,                    !- Name
   0.934,                                  !- Coefficient1 Constant
   -0.0582,                                !- Coefficient2 x
@@ -3595,7 +3603,7 @@ OS:Curve:Biquadratic,
   35;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {1ccd97d1-c71b-4582-9c65-492887956005}, !- Handle
+  {ccbd1e16-2aae-41e9-b227-0c882fe0664a}, !- Handle
   Curve Quadratic 1,                      !- Name
   0.222903,                               !- Coefficient1 Constant
   0.313387,                               !- Coefficient2 x
@@ -3604,7 +3612,7 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:Chiller:Electric:EIR,
-  {29291873-7155-4f63-a17d-083b69b07d6f}, !- Handle
+  {b55c11e3-32c8-4032-8edd-913f341daffa}, !- Handle
   Chiller Electric EIR 1,                 !- Name
   Autosize,                               !- Reference Capacity {W}
   5.5,                                    !- Reference COP {W/W}
@@ -3612,17 +3620,17 @@ OS:Chiller:Electric:EIR,
   ,                                       !- Reference Entering Condenser Fluid Temperature {C}
   ,                                       !- Reference Chilled Water Flow Rate {m3/s}
   ,                                       !- Reference Condenser Fluid Flow Rate {m3/s}
-  {b421404b-ae4a-42cc-a4e1-664d0d4eddac}, !- Cooling Capacity Function of Temperature Curve Name
-  {3738f134-c790-4b2b-8ca7-c75b250d8d32}, !- Electric Input to Cooling Output Ratio Function of Temperature Curve Name
-  {1ccd97d1-c71b-4582-9c65-492887956005}, !- Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
+  {07b66521-ee49-4b01-93e5-3f0a2578ae04}, !- Cooling Capacity Function of Temperature Curve Name
+  {a85cc0ff-3565-4f65-92cc-86c35b61e906}, !- Electric Input to Cooling Output Ratio Function of Temperature Curve Name
+  {ccbd1e16-2aae-41e9-b227-0c882fe0664a}, !- Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
   ,                                       !- Minimum Part Load Ratio
   ,                                       !- Maximum Part Load Ratio
   ,                                       !- Optimum Part Load Ratio
   ,                                       !- Minimum Unloading Ratio
-  {ea1d06d3-f2ca-44cf-8447-863228a9166b}, !- Chilled Water Inlet Node Name
-  {8ff7445d-a2e3-45c0-bb6f-7ef8608bf14f}, !- Chilled Water Outlet Node Name
-  {1a0ba7cd-73fd-4d72-b55d-aa2fc1548481}, !- Condenser Inlet Node Name
-  {f411fc52-d087-4122-8b3c-ca2006a343c0}, !- Condenser Outlet Node Name
+  {cd80f3f5-90f5-4e13-ba45-6e95d57bf329}, !- Chilled Water Inlet Node Name
+  {161f1eba-233e-4506-a435-52f0bca6bde3}, !- Chilled Water Outlet Node Name
+  {d97bcfb6-8dd7-4b24-9385-c7d26c5d7deb}, !- Condenser Inlet Node Name
+  {fffc5d2f-214b-4178-b378-69353b745b4b}, !- Condenser Outlet Node Name
   WaterCooled,                            !- Condenser Type
   ,                                       !- Condenser Fan Power Ratio {W/W}
   ,                                       !- Compressor Motor Efficiency
@@ -3641,155 +3649,155 @@ OS:Chiller:Electric:EIR,
   General;                                !- End-Use Subcategory
 
 OS:Node,
-  {afbd98c4-26bf-4ca7-b07f-2826ce5eadc8}, !- Handle
+  {8bd1afa7-78e2-40fd-916a-f784fcffab1f}, !- Handle
   Node 44,                                !- Name
-  {8ff7445d-a2e3-45c0-bb6f-7ef8608bf14f}, !- Inlet Port
-  {6da1669b-f374-4aa3-bd83-4465a5c36e44}; !- Outlet Port
+  {161f1eba-233e-4506-a435-52f0bca6bde3}, !- Inlet Port
+  {493113ff-58db-4532-9ded-84116fc5fa75}; !- Outlet Port
 
 OS:Connection,
-  {ea1d06d3-f2ca-44cf-8447-863228a9166b}, !- Handle
-  {1fc29637-a740-41b6-ba57-6534199c0869}, !- Name
-  {e07750e0-1411-4a57-846d-5e7e3accd1d7}, !- Source Object
+  {cd80f3f5-90f5-4e13-ba45-6e95d57bf329}, !- Handle
+  {dcc9d790-9f28-486b-8346-b417e832847e}, !- Name
+  {e16a9cf6-6680-4f11-bca9-331c9c85f831}, !- Source Object
   3,                                      !- Outlet Port
-  {29291873-7155-4f63-a17d-083b69b07d6f}, !- Target Object
+  {b55c11e3-32c8-4032-8edd-913f341daffa}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Connection,
-  {8ff7445d-a2e3-45c0-bb6f-7ef8608bf14f}, !- Handle
-  {aacb321a-f484-4ea9-b041-aeb0997fadb9}, !- Name
-  {29291873-7155-4f63-a17d-083b69b07d6f}, !- Source Object
+  {161f1eba-233e-4506-a435-52f0bca6bde3}, !- Handle
+  {7357cf53-2e78-4774-b6c5-8373ac5e855b}, !- Name
+  {b55c11e3-32c8-4032-8edd-913f341daffa}, !- Source Object
   16,                                     !- Outlet Port
-  {afbd98c4-26bf-4ca7-b07f-2826ce5eadc8}, !- Target Object
+  {8bd1afa7-78e2-40fd-916a-f784fcffab1f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {6da1669b-f374-4aa3-bd83-4465a5c36e44}, !- Handle
-  {3ed66cf0-7a64-4821-b010-1332b1d29702}, !- Name
-  {afbd98c4-26bf-4ca7-b07f-2826ce5eadc8}, !- Source Object
+  {493113ff-58db-4532-9ded-84116fc5fa75}, !- Handle
+  {04beae1f-5ff7-47d2-a538-da963be88674}, !- Name
+  {8bd1afa7-78e2-40fd-916a-f784fcffab1f}, !- Source Object
   3,                                      !- Outlet Port
-  {626438c3-e10d-4dd5-ae8a-3b52eec4ea4d}, !- Target Object
+  {67318359-189e-4e8c-8f7f-cd5e324d49ec}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {4f8cffdd-1682-4643-baad-9854336a54ca}, !- Handle
+  {5c21ca7b-e8ff-44ab-a04c-719961f291b2}, !- Handle
   Pipe Adiabatic 6,                       !- Name
-  {972f8569-b229-49ec-bf80-b56b996d4ac5}, !- Inlet Node Name
-  {7f37a7c5-e7ef-4aa1-a0cd-4ce1dbce3217}; !- Outlet Node Name
+  {31f98dcd-b162-4f64-b8bf-50881c4ed34c}, !- Inlet Node Name
+  {81d68679-8d70-4556-831c-44a0fc8b903c}; !- Outlet Node Name
 
 OS:Node,
-  {96ed0c90-3c66-4049-a22f-bc4ba6d1f9db}, !- Handle
+  {350b5e37-566e-4fd7-b7b5-d9c6b26ba482}, !- Handle
   Node 45,                                !- Name
-  {115d17c9-3304-4a52-8a65-8982e77dac5b}, !- Inlet Port
-  {972f8569-b229-49ec-bf80-b56b996d4ac5}; !- Outlet Port
+  {0e5eb602-73b5-4fe2-8e93-ec8674107010}, !- Inlet Port
+  {31f98dcd-b162-4f64-b8bf-50881c4ed34c}; !- Outlet Port
 
 OS:Connection,
-  {115d17c9-3304-4a52-8a65-8982e77dac5b}, !- Handle
-  {221bd52c-b352-4e4c-bf6b-3f66df80fb2c}, !- Name
-  {74183eab-6dc3-4e4c-928d-67953dd1c0a7}, !- Source Object
+  {0e5eb602-73b5-4fe2-8e93-ec8674107010}, !- Handle
+  {9518ffcb-1130-414c-b6c5-11c68b5f1712}, !- Name
+  {ef710045-5bce-42ef-a6fa-ea4b1c6635ff}, !- Source Object
   4,                                      !- Outlet Port
-  {96ed0c90-3c66-4049-a22f-bc4ba6d1f9db}, !- Target Object
+  {350b5e37-566e-4fd7-b7b5-d9c6b26ba482}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {369054a6-45b5-4b7f-a7d3-8962d0d39282}, !- Handle
+  {0794b602-fe90-475e-bab1-be7e2c0bb702}, !- Handle
   Node 46,                                !- Name
-  {7f37a7c5-e7ef-4aa1-a0cd-4ce1dbce3217}, !- Inlet Port
-  {6abb33e0-68a9-4d14-9241-2afef96153b3}; !- Outlet Port
+  {81d68679-8d70-4556-831c-44a0fc8b903c}, !- Inlet Port
+  {ce463a8f-9e28-40d6-b3a8-dda3bce44c07}; !- Outlet Port
 
 OS:Connection,
-  {972f8569-b229-49ec-bf80-b56b996d4ac5}, !- Handle
-  {f3f22084-b62d-4538-94e3-dde22ae2de46}, !- Name
-  {96ed0c90-3c66-4049-a22f-bc4ba6d1f9db}, !- Source Object
+  {31f98dcd-b162-4f64-b8bf-50881c4ed34c}, !- Handle
+  {062f95a8-4f96-41d8-91e8-7bd6e742c2c7}, !- Name
+  {350b5e37-566e-4fd7-b7b5-d9c6b26ba482}, !- Source Object
   3,                                      !- Outlet Port
-  {4f8cffdd-1682-4643-baad-9854336a54ca}, !- Target Object
+  {5c21ca7b-e8ff-44ab-a04c-719961f291b2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7f37a7c5-e7ef-4aa1-a0cd-4ce1dbce3217}, !- Handle
-  {e608a7d1-acd7-4125-b8c7-2bc7884a006a}, !- Name
-  {4f8cffdd-1682-4643-baad-9854336a54ca}, !- Source Object
+  {81d68679-8d70-4556-831c-44a0fc8b903c}, !- Handle
+  {71eb0d54-c08f-4344-af54-e5878449f3a8}, !- Name
+  {5c21ca7b-e8ff-44ab-a04c-719961f291b2}, !- Source Object
   3,                                      !- Outlet Port
-  {369054a6-45b5-4b7f-a7d3-8962d0d39282}, !- Target Object
+  {0794b602-fe90-475e-bab1-be7e2c0bb702}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {6abb33e0-68a9-4d14-9241-2afef96153b3}, !- Handle
-  {862afc0b-9d94-4655-8d7a-e8e86f4bd57b}, !- Name
-  {369054a6-45b5-4b7f-a7d3-8962d0d39282}, !- Source Object
+  {ce463a8f-9e28-40d6-b3a8-dda3bce44c07}, !- Handle
+  {1d76a310-78f5-4ad6-8f11-7d00ba799f4e}, !- Name
+  {0794b602-fe90-475e-bab1-be7e2c0bb702}, !- Source Object
   3,                                      !- Outlet Port
-  {626438c3-e10d-4dd5-ae8a-3b52eec4ea4d}, !- Target Object
+  {67318359-189e-4e8c-8f7f-cd5e324d49ec}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {7f30f022-e68b-4b75-b50b-45bcdc8ac329}, !- Handle
+  {b0de2389-5ca9-406f-b8da-a44f15068904}, !- Handle
   Pipe Adiabatic 7,                       !- Name
-  {7a405cd4-81b7-44fe-81a5-cf1c03fd294f}, !- Inlet Node Name
-  {412aaeb0-c54d-41cc-b414-d547f73a0eaf}; !- Outlet Node Name
+  {96341d4e-54c5-4334-810d-3d9f2ef267e1}, !- Inlet Node Name
+  {c75db921-6472-4813-8b0d-3ef3a91bb44a}; !- Outlet Node Name
 
 OS:Node,
-  {cd8ffd4b-c892-43f8-bb4b-16502fe80623}, !- Handle
+  {eb83051b-0cca-4a1a-b66a-d54a976a182c}, !- Handle
   Node 47,                                !- Name
-  {653394b6-fa81-4752-bd59-f8b3713e6af3}, !- Inlet Port
-  {7a405cd4-81b7-44fe-81a5-cf1c03fd294f}; !- Outlet Port
+  {cc8e97a0-e58a-4f0a-a311-332da4088110}, !- Inlet Port
+  {96341d4e-54c5-4334-810d-3d9f2ef267e1}; !- Outlet Port
 
 OS:Connection,
-  {653394b6-fa81-4752-bd59-f8b3713e6af3}, !- Handle
-  {88d3e40b-01ed-43ac-93d1-0dcb08d18c54}, !- Name
-  {626438c3-e10d-4dd5-ae8a-3b52eec4ea4d}, !- Source Object
+  {cc8e97a0-e58a-4f0a-a311-332da4088110}, !- Handle
+  {cb0e888a-b0e6-4003-afa2-ae7d0ed9d6f1}, !- Name
+  {67318359-189e-4e8c-8f7f-cd5e324d49ec}, !- Source Object
   2,                                      !- Outlet Port
-  {cd8ffd4b-c892-43f8-bb4b-16502fe80623}, !- Target Object
+  {eb83051b-0cca-4a1a-b66a-d54a976a182c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7a405cd4-81b7-44fe-81a5-cf1c03fd294f}, !- Handle
-  {416446dd-8e9b-44bc-b16b-0749c9afe2d8}, !- Name
-  {cd8ffd4b-c892-43f8-bb4b-16502fe80623}, !- Source Object
+  {96341d4e-54c5-4334-810d-3d9f2ef267e1}, !- Handle
+  {48434812-f98e-4e51-a9c7-89b32ca2c5c7}, !- Name
+  {eb83051b-0cca-4a1a-b66a-d54a976a182c}, !- Source Object
   3,                                      !- Outlet Port
-  {7f30f022-e68b-4b75-b50b-45bcdc8ac329}, !- Target Object
+  {b0de2389-5ca9-406f-b8da-a44f15068904}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {412aaeb0-c54d-41cc-b414-d547f73a0eaf}, !- Handle
-  {b293bd26-84c7-4130-8822-c92c82280b65}, !- Name
-  {7f30f022-e68b-4b75-b50b-45bcdc8ac329}, !- Source Object
+  {c75db921-6472-4813-8b0d-3ef3a91bb44a}, !- Handle
+  {693cd2a3-c957-4101-b074-f913df110cc6}, !- Name
+  {b0de2389-5ca9-406f-b8da-a44f15068904}, !- Source Object
   3,                                      !- Outlet Port
-  {7d7aecc7-e808-4afb-ae71-b3748d468945}, !- Target Object
+  {9cf6d2b1-e6ee-48ff-a9ec-ff38dc775190}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {26e5e9e0-3216-47ca-89ca-ed73db7bb796}, !- Handle
+  {b467dcba-37cd-4241-ba70-7dc20dd23136}, !- Handle
   Node 48,                                !- Name
-  {ef8f8491-249f-4223-bf71-bb07be4d274d}, !- Inlet Port
-  {f4581aea-1966-4fed-83a3-41fea64c5bc3}; !- Outlet Port
+  {dd9935a2-5217-42d8-bb97-48543d764bfd}, !- Inlet Port
+  {6f724b2e-9052-48ca-8f8c-f0b1b1c44b23}; !- Outlet Port
 
 OS:Connection,
-  {740973cf-0552-45c9-8b2c-b11a558e8198}, !- Handle
-  {cb9e1ffb-f923-4f9b-9857-7618d9315b10}, !- Name
-  {95083978-5936-4caa-9824-8cdd3af77f3c}, !- Source Object
+  {0a32b8a8-c0e8-42dd-8bfa-51a6336dc6bc}, !- Handle
+  {5c46ac86-479b-45fb-98ba-f9c31256b53e}, !- Name
+  {2c963a96-53e7-4b5d-be01-f47bf06820ae}, !- Source Object
   3,                                      !- Outlet Port
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Target Object
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Target Object
   10;                                     !- Inlet Port
 
 OS:Connection,
-  {ef8f8491-249f-4223-bf71-bb07be4d274d}, !- Handle
-  {0c38d400-e759-43ba-ba68-058e8a3f6432}, !- Name
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Source Object
+  {dd9935a2-5217-42d8-bb97-48543d764bfd}, !- Handle
+  {73055312-2fff-4f46-965b-3f204178598f}, !- Name
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Source Object
   11,                                     !- Outlet Port
-  {26e5e9e0-3216-47ca-89ca-ed73db7bb796}, !- Target Object
+  {b467dcba-37cd-4241-ba70-7dc20dd23136}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f4581aea-1966-4fed-83a3-41fea64c5bc3}, !- Handle
-  {a84e8fc6-601f-456f-acdb-7f967c8487c6}, !- Name
-  {26e5e9e0-3216-47ca-89ca-ed73db7bb796}, !- Source Object
+  {6f724b2e-9052-48ca-8f8c-f0b1b1c44b23}, !- Handle
+  {3b387a49-8ee3-4f1e-b62d-43414b898642}, !- Name
+  {b467dcba-37cd-4241-ba70-7dc20dd23136}, !- Source Object
   3,                                      !- Outlet Port
-  {ce25fa74-5fc6-4bda-9998-a822eb962f71}, !- Target Object
+  {805edd4a-64d4-4014-b707-cabb54578f80}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Controller:WaterCoil,
-  {bca21efb-a9aa-4db8-962f-7174f2bfbc8d}, !- Handle
+  {1688532e-d8b1-43f7-9b1b-1e4800aff144}, !- Handle
   Controller Water Coil 2,                !- Name
-  {092f4a09-6c71-427a-9251-e8f470801495}, !- Water Coil Name
+  {ce320307-053f-46a1-a8a5-91fb2db064d2}, !- Water Coil Name
   ,                                       !- Control Variable
   Reverse,                                !- Action
   ,                                       !- Actuator Variable
@@ -3800,20 +3808,20 @@ OS:Controller:WaterCoil,
   0;                                      !- Minimum Actuated Flow {m3/s}
 
 OS:SetpointManager:Scheduled,
-  {8cf04214-c436-4302-a08e-47d9cb67420b}, !- Handle
+  {860d610a-9c91-408f-9ec6-9849f5415088}, !- Handle
   Setpoint Manager Scheduled 3,           !- Name
   Temperature,                            !- Control Variable
-  {0ce6afd7-0b95-482b-914b-47b1c28747bb}, !- Schedule Name
-  {7d7aecc7-e808-4afb-ae71-b3748d468945}; !- Setpoint Node or NodeList Name
+  {ab211609-a1ba-40ad-8235-2376e1773582}, !- Schedule Name
+  {9cf6d2b1-e6ee-48ff-a9ec-ff38dc775190}; !- Setpoint Node or NodeList Name
 
 OS:Coil:Heating:Water,
-  {8989cccf-ad72-4955-ba99-e37b8e9091ff}, !- Handle
+  {2905d19d-4d08-4910-aff0-89d0e9efb712}, !- Handle
   Coil Heating Water 2,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {08b348fa-aa21-4b4b-8865-1277e05dd63c}, !- Water Inlet Node Name
-  {5b5bd1e6-8e22-4f89-ad32-48f890ad4eeb}, !- Water Outlet Node Name
+  {14db6b58-6d40-4df3-bcaa-9a5d5f33e870}, !- Water Inlet Node Name
+  {8843edd9-fbce-4d0a-a58c-3d1e903afd77}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -3825,19 +3833,19 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {0caa970c-b2ce-4104-b41e-11a5536d44b7}, !- Handle
+  {5931adcd-1fd7-417b-8755-69fb9991e32d}, !- Handle
   Air Terminal Single Duct VAV Reheat 1,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {1e00e1e8-4d1b-48e1-844e-72cdc6ef774f}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {fd1e2315-30d8-4e8e-9f00-7ce4199ca598}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {8989cccf-ad72-4955-ba99-e37b8e9091ff}, !- Reheat Coil Name
+  {2905d19d-4d08-4910-aff0-89d0e9efb712}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {4cb06ba0-379f-4294-9749-5ac728072a50}, !- Air Outlet Node Name
+  {bc1526bc-59c2-498d-80c7-4d7bc47722c7}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -3846,203 +3854,203 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Node,
-  {fe96057c-ab96-415b-832f-8c61f91b29cb}, !- Handle
+  {2ea637bf-8fb1-4ede-872e-04c43f305d49}, !- Handle
   Node 49,                                !- Name
-  {44b4150c-b409-4f44-b91b-dad670f8ab07}, !- Inlet Port
-  {1e00e1e8-4d1b-48e1-844e-72cdc6ef774f}; !- Outlet Port
+  {4eacb56f-9f8d-42ce-b7cb-8064580662dc}, !- Inlet Port
+  {fd1e2315-30d8-4e8e-9f00-7ce4199ca598}; !- Outlet Port
 
 OS:Connection,
-  {44b4150c-b409-4f44-b91b-dad670f8ab07}, !- Handle
-  {4d03d1cb-d4ce-442a-8493-3d1d267bf6bd}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {4eacb56f-9f8d-42ce-b7cb-8064580662dc}, !- Handle
+  {325a4dca-d96e-4a56-8fce-adb969e8f2aa}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   3,                                      !- Outlet Port
-  {fe96057c-ab96-415b-832f-8c61f91b29cb}, !- Target Object
+  {2ea637bf-8fb1-4ede-872e-04c43f305d49}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {1e00e1e8-4d1b-48e1-844e-72cdc6ef774f}, !- Handle
-  {34d0e13b-473f-4dc1-af27-b61cb28aff34}, !- Name
-  {fe96057c-ab96-415b-832f-8c61f91b29cb}, !- Source Object
+  {fd1e2315-30d8-4e8e-9f00-7ce4199ca598}, !- Handle
+  {b68e804f-5f1e-4434-b3b6-914a4a85bbd9}, !- Name
+  {2ea637bf-8fb1-4ede-872e-04c43f305d49}, !- Source Object
   3,                                      !- Outlet Port
-  {0caa970c-b2ce-4104-b41e-11a5536d44b7}, !- Target Object
+  {5931adcd-1fd7-417b-8755-69fb9991e32d}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {4cb06ba0-379f-4294-9749-5ac728072a50}, !- Handle
-  {51b2cd0a-eb91-4b1d-b2f7-3de52acb363d}, !- Name
-  {0caa970c-b2ce-4104-b41e-11a5536d44b7}, !- Source Object
+  {bc1526bc-59c2-498d-80c7-4d7bc47722c7}, !- Handle
+  {b3b7ed02-d906-4e9b-b2a2-a29bc2ad9375}, !- Name
+  {5931adcd-1fd7-417b-8755-69fb9991e32d}, !- Source Object
   12,                                     !- Outlet Port
-  {e3793b17-3ca2-4da6-963c-11f2fcdc85d1}, !- Target Object
+  {e4996cbb-8c3d-409e-987f-d01baab7731a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {ed7420b3-565f-468f-b6c6-b1e26a56fe0f}, !- Handle
+  {605866a7-c5ff-46b5-aefa-c2a9c3e83c03}, !- Handle
   Pipe Adiabatic 8,                       !- Name
-  {58a52752-2d44-40c5-9b74-6524d4437511}, !- Inlet Node Name
-  {b50f10d0-ad84-495e-80e5-21cf5a625e74}; !- Outlet Node Name
+  {7b845367-574d-4227-ab59-6f57741ce3b3}, !- Inlet Node Name
+  {94593670-bc7e-4f66-97e0-7c519b2da8a8}; !- Outlet Node Name
 
 OS:Node,
-  {833b3b6f-d9aa-4a5e-8e2e-094ab4b7f4eb}, !- Handle
+  {613b4cd3-3635-44f1-b7d8-870e4328c3b4}, !- Handle
   Node 50,                                !- Name
-  {a3135a08-894a-4a58-ac06-c01ec28c1dda}, !- Inlet Port
-  {58a52752-2d44-40c5-9b74-6524d4437511}; !- Outlet Port
+  {adc2c1e3-78d0-42f6-bc2e-4cd395b3920f}, !- Inlet Port
+  {7b845367-574d-4227-ab59-6f57741ce3b3}; !- Outlet Port
 
 OS:Connection,
-  {a3135a08-894a-4a58-ac06-c01ec28c1dda}, !- Handle
-  {d2fbb2b2-9206-4311-94ef-227b99d89db8}, !- Name
-  {54005676-0a5d-4dbc-ba67-aca5df51fb1e}, !- Source Object
+  {adc2c1e3-78d0-42f6-bc2e-4cd395b3920f}, !- Handle
+  {608f9431-51a5-480a-9ff7-8004302c7ee8}, !- Name
+  {578b22f1-ebc9-4761-b4b8-70f678a532c4}, !- Source Object
   4,                                      !- Outlet Port
-  {833b3b6f-d9aa-4a5e-8e2e-094ab4b7f4eb}, !- Target Object
+  {613b4cd3-3635-44f1-b7d8-870e4328c3b4}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {c65403b1-6405-4bf2-8d68-62f60bec5038}, !- Handle
+  {a470b9f5-c547-4807-9224-90f774894614}, !- Handle
   Node 51,                                !- Name
-  {b50f10d0-ad84-495e-80e5-21cf5a625e74}, !- Inlet Port
-  {738dc083-2014-4043-a625-8d31163ebb3f}; !- Outlet Port
+  {94593670-bc7e-4f66-97e0-7c519b2da8a8}, !- Inlet Port
+  {354a8d9d-dc03-4f21-9aa4-4fdfcbde9296}; !- Outlet Port
 
 OS:Connection,
-  {58a52752-2d44-40c5-9b74-6524d4437511}, !- Handle
-  {bca2ae43-d72d-4dc9-b425-8130c1f73eb8}, !- Name
-  {833b3b6f-d9aa-4a5e-8e2e-094ab4b7f4eb}, !- Source Object
+  {7b845367-574d-4227-ab59-6f57741ce3b3}, !- Handle
+  {fc2de749-fa68-4159-95de-9cdeb6703d47}, !- Name
+  {613b4cd3-3635-44f1-b7d8-870e4328c3b4}, !- Source Object
   3,                                      !- Outlet Port
-  {ed7420b3-565f-468f-b6c6-b1e26a56fe0f}, !- Target Object
+  {605866a7-c5ff-46b5-aefa-c2a9c3e83c03}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b50f10d0-ad84-495e-80e5-21cf5a625e74}, !- Handle
-  {c786c31d-ce0e-4d6d-a01e-48e8e0af1e62}, !- Name
-  {ed7420b3-565f-468f-b6c6-b1e26a56fe0f}, !- Source Object
+  {94593670-bc7e-4f66-97e0-7c519b2da8a8}, !- Handle
+  {2fd803f8-40cc-46d7-a0a4-02f1b95faf22}, !- Name
+  {605866a7-c5ff-46b5-aefa-c2a9c3e83c03}, !- Source Object
   3,                                      !- Outlet Port
-  {c65403b1-6405-4bf2-8d68-62f60bec5038}, !- Target Object
+  {a470b9f5-c547-4807-9224-90f774894614}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {738dc083-2014-4043-a625-8d31163ebb3f}, !- Handle
-  {f6d219da-a3d1-4113-9856-6fc5acbab7bc}, !- Name
-  {c65403b1-6405-4bf2-8d68-62f60bec5038}, !- Source Object
+  {354a8d9d-dc03-4f21-9aa4-4fdfcbde9296}, !- Handle
+  {0bca4499-e9bc-4805-978f-77754e6815b0}, !- Name
+  {a470b9f5-c547-4807-9224-90f774894614}, !- Source Object
   3,                                      !- Outlet Port
-  {ce25fa74-5fc6-4bda-9998-a822eb962f71}, !- Target Object
+  {805edd4a-64d4-4014-b707-cabb54578f80}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Node,
-  {7ba4e796-8542-4151-bca5-6f3816c36912}, !- Handle
+  {e0d6af53-5e7e-487a-80a1-51e7260e6501}, !- Handle
   Node 52,                                !- Name
-  {0977b5af-680b-45e1-a74d-0dc7ac1f013d}, !- Inlet Port
-  {08b348fa-aa21-4b4b-8865-1277e05dd63c}; !- Outlet Port
+  {39132141-0133-4bac-b054-57cce443c59e}, !- Inlet Port
+  {14db6b58-6d40-4df3-bcaa-9a5d5f33e870}; !- Outlet Port
 
 OS:Connection,
-  {0977b5af-680b-45e1-a74d-0dc7ac1f013d}, !- Handle
-  {2522b4ba-6ab6-4ae6-b115-4a7b96e25ee3}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {39132141-0133-4bac-b054-57cce443c59e}, !- Handle
+  {260e0f91-040d-4825-963b-f12582e65962}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   5,                                      !- Outlet Port
-  {7ba4e796-8542-4151-bca5-6f3816c36912}, !- Target Object
+  {e0d6af53-5e7e-487a-80a1-51e7260e6501}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {d8acc13c-943c-4395-ba0c-6b7f8a94c1c4}, !- Handle
+  {54e37013-8aa8-48ab-ad7c-971fd734f6e4}, !- Handle
   Node 53,                                !- Name
-  {5b5bd1e6-8e22-4f89-ad32-48f890ad4eeb}, !- Inlet Port
-  {42d19447-ca0e-41be-bd0c-410cfe7b2713}; !- Outlet Port
+  {8843edd9-fbce-4d0a-a58c-3d1e903afd77}, !- Inlet Port
+  {f1f7b79b-25e8-41fa-95c3-4da8bbb5c1be}; !- Outlet Port
 
 OS:Connection,
-  {08b348fa-aa21-4b4b-8865-1277e05dd63c}, !- Handle
-  {2b00eaaa-7aa6-49db-8439-e3a2c43f6c8d}, !- Name
-  {7ba4e796-8542-4151-bca5-6f3816c36912}, !- Source Object
+  {14db6b58-6d40-4df3-bcaa-9a5d5f33e870}, !- Handle
+  {5586be9c-0a1d-4aaf-bd8a-9595b53e218e}, !- Name
+  {e0d6af53-5e7e-487a-80a1-51e7260e6501}, !- Source Object
   3,                                      !- Outlet Port
-  {8989cccf-ad72-4955-ba99-e37b8e9091ff}, !- Target Object
+  {2905d19d-4d08-4910-aff0-89d0e9efb712}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {5b5bd1e6-8e22-4f89-ad32-48f890ad4eeb}, !- Handle
-  {d98333de-c729-455d-b080-ba10228fd9c3}, !- Name
-  {8989cccf-ad72-4955-ba99-e37b8e9091ff}, !- Source Object
+  {8843edd9-fbce-4d0a-a58c-3d1e903afd77}, !- Handle
+  {cfe65984-b642-4fce-8974-1dc7a161ef7e}, !- Name
+  {2905d19d-4d08-4910-aff0-89d0e9efb712}, !- Source Object
   6,                                      !- Outlet Port
-  {d8acc13c-943c-4395-ba0c-6b7f8a94c1c4}, !- Target Object
+  {54e37013-8aa8-48ab-ad7c-971fd734f6e4}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {42d19447-ca0e-41be-bd0c-410cfe7b2713}, !- Handle
-  {3be5798e-1327-4eee-a224-96b57ec8972a}, !- Name
-  {d8acc13c-943c-4395-ba0c-6b7f8a94c1c4}, !- Source Object
+  {f1f7b79b-25e8-41fa-95c3-4da8bbb5c1be}, !- Handle
+  {801f27c3-b494-479c-bdbe-42eeec79a045}, !- Name
+  {54e37013-8aa8-48ab-ad7c-971fd734f6e4}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {4ee220f0-f931-4b1f-9108-b7b9fbe312a8}, !- Handle
+  {fe4374f6-0d3d-4ead-94c6-376b7c90bae5}, !- Handle
   Pipe Adiabatic 9,                       !- Name
-  {e2381d23-0423-4e8d-b371-cd356506683f}, !- Inlet Node Name
-  {1c8af362-8115-4154-aef3-ab6f6e8a6700}; !- Outlet Node Name
+  {c9149398-84b7-4a76-8ecd-454bb244e028}, !- Inlet Node Name
+  {a85d9cd2-b151-4684-bba7-b648660aa6d3}; !- Outlet Node Name
 
 OS:Node,
-  {1d4670c9-6461-4e67-8304-2e1aef04ba60}, !- Handle
+  {2041740b-8616-42c3-9541-d00f540802d0}, !- Handle
   Node 54,                                !- Name
-  {1c8af362-8115-4154-aef3-ab6f6e8a6700}, !- Inlet Port
-  {2a81b083-7bae-4e18-a66c-ec14110982a2}; !- Outlet Port
+  {a85d9cd2-b151-4684-bba7-b648660aa6d3}, !- Inlet Port
+  {6f7092d1-5fd9-4137-be5c-c7c1a560ea9f}; !- Outlet Port
 
 OS:Connection,
-  {e2381d23-0423-4e8d-b371-cd356506683f}, !- Handle
-  {e6e90175-87c8-41cb-8900-9d7c2b2c9d99}, !- Name
-  {8667c4a2-af3e-414a-9b96-4614243fee5a}, !- Source Object
+  {c9149398-84b7-4a76-8ecd-454bb244e028}, !- Handle
+  {c6b8f190-41b1-4f43-beb9-224cefa272fb}, !- Name
+  {6cf2c64d-4020-43e0-958f-7b33196ae1b0}, !- Source Object
   3,                                      !- Outlet Port
-  {4ee220f0-f931-4b1f-9108-b7b9fbe312a8}, !- Target Object
+  {fe4374f6-0d3d-4ead-94c6-376b7c90bae5}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {1c8af362-8115-4154-aef3-ab6f6e8a6700}, !- Handle
-  {3f1cdbc9-135f-4c39-ad4c-2b1b2371ad70}, !- Name
-  {4ee220f0-f931-4b1f-9108-b7b9fbe312a8}, !- Source Object
+  {a85d9cd2-b151-4684-bba7-b648660aa6d3}, !- Handle
+  {fe3fdd25-ff12-44a8-9450-59bf11f89117}, !- Name
+  {fe4374f6-0d3d-4ead-94c6-376b7c90bae5}, !- Source Object
   3,                                      !- Outlet Port
-  {1d4670c9-6461-4e67-8304-2e1aef04ba60}, !- Target Object
+  {2041740b-8616-42c3-9541-d00f540802d0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2a81b083-7bae-4e18-a66c-ec14110982a2}, !- Handle
-  {f1c93c63-6597-4f05-8126-a76daf157229}, !- Name
-  {1d4670c9-6461-4e67-8304-2e1aef04ba60}, !- Source Object
+  {6f7092d1-5fd9-4137-be5c-c7c1a560ea9f}, !- Handle
+  {2a2546a9-f97d-446c-9385-a64a6530b92e}, !- Name
+  {2041740b-8616-42c3-9541-d00f540802d0}, !- Source Object
   3,                                      !- Outlet Port
-  {54005676-0a5d-4dbc-ba67-aca5df51fb1e}, !- Target Object
+  {578b22f1-ebc9-4761-b4b8-70f678a532c4}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {081396a3-e380-43e6-986c-fea170f2f9f2}, !- Handle
+  {1423de60-e719-4289-a23d-0ccf9f0e58fe}, !- Handle
   Pipe Adiabatic 10,                      !- Name
-  {7509a440-6d7d-40dd-befa-b8d575b7f465}, !- Inlet Node Name
-  {9b85fd5f-13d2-4759-a9a2-61085e52768a}; !- Outlet Node Name
+  {8d5db3ef-f288-4581-b4da-268824cfaa58}, !- Inlet Node Name
+  {62275654-d139-49b3-bbf4-3fe9f7fc4fc8}; !- Outlet Node Name
 
 OS:Node,
-  {d8407a7a-895c-4e8f-b93d-60d459784b1a}, !- Handle
+  {fe52a3d1-2502-4fba-8750-db5a24c56341}, !- Handle
   Node 55,                                !- Name
-  {341a196c-8aea-4b4f-ac45-7344c5e60113}, !- Inlet Port
-  {7509a440-6d7d-40dd-befa-b8d575b7f465}; !- Outlet Port
+  {b658cc1d-3b89-4db0-ae71-b4f1922ed2c5}, !- Inlet Port
+  {8d5db3ef-f288-4581-b4da-268824cfaa58}; !- Outlet Port
 
 OS:Connection,
-  {341a196c-8aea-4b4f-ac45-7344c5e60113}, !- Handle
-  {1019ebc8-d621-49a3-8f71-0b7e861c1f63}, !- Name
-  {ce25fa74-5fc6-4bda-9998-a822eb962f71}, !- Source Object
+  {b658cc1d-3b89-4db0-ae71-b4f1922ed2c5}, !- Handle
+  {c7581423-d10c-45e2-a372-e4ac29eb30d6}, !- Name
+  {805edd4a-64d4-4014-b707-cabb54578f80}, !- Source Object
   2,                                      !- Outlet Port
-  {d8407a7a-895c-4e8f-b93d-60d459784b1a}, !- Target Object
+  {fe52a3d1-2502-4fba-8750-db5a24c56341}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7509a440-6d7d-40dd-befa-b8d575b7f465}, !- Handle
-  {1f066468-e754-4257-b03a-660b7f4df548}, !- Name
-  {d8407a7a-895c-4e8f-b93d-60d459784b1a}, !- Source Object
+  {8d5db3ef-f288-4581-b4da-268824cfaa58}, !- Handle
+  {cd3b6007-ea03-4a0e-857d-f393b4474a04}, !- Name
+  {fe52a3d1-2502-4fba-8750-db5a24c56341}, !- Source Object
   3,                                      !- Outlet Port
-  {081396a3-e380-43e6-986c-fea170f2f9f2}, !- Target Object
+  {1423de60-e719-4289-a23d-0ccf9f0e58fe}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {9b85fd5f-13d2-4759-a9a2-61085e52768a}, !- Handle
-  {0f03a9b2-6cc5-4f3f-8246-1edd3226408e}, !- Name
-  {081396a3-e380-43e6-986c-fea170f2f9f2}, !- Source Object
+  {62275654-d139-49b3-bbf4-3fe9f7fc4fc8}, !- Handle
+  {96e74cde-a61b-45cb-9408-66d0d8f221c0}, !- Name
+  {1423de60-e719-4289-a23d-0ccf9f0e58fe}, !- Source Object
   3,                                      !- Outlet Port
-  {6294f172-b393-471d-b187-553bf7c42223}, !- Target Object
+  {4bf2fe47-97b0-417a-a69c-29e8af1598ce}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PlantLoop,
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Handle
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Handle
   Condenser Water Loop,                   !- Name
   ,                                       !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -4050,21 +4058,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {f4b4563c-deb8-4cff-8c98-1a9b81b12e7f}, !- Loop Temperature Setpoint Node Name
+  {e8ad1aea-207f-45f0-b0d9-7b604e92e375}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {148199c5-0a6a-4dc5-a952-fbe374daeb88}, !- Plant Side Inlet Node Name
-  {f829b884-b62f-45e3-98ca-73ea8fceab9c}, !- Plant Side Outlet Node Name
+  {1ef97b5f-fc7f-4807-8b74-70f0f851acd7}, !- Plant Side Inlet Node Name
+  {70108631-aefa-49f6-96c7-6ef3e9af4a8d}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {7aff1771-398a-4b05-a806-c68e20e5e18f}, !- Demand Side Inlet Node Name
-  {5da8dba5-506b-4029-8954-2a84b08117b0}, !- Demand Side Outlet Node Name
+  {0d4bb4c6-d1f9-4113-a106-8fdd154895c8}, !- Demand Side Inlet Node Name
+  {45eacf07-e786-4b13-a12f-f67dd2660d6f}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {b5e70716-fba7-48b3-a0ca-c8dcb0720407}, !- Availability Manager List Name
+  {71623022-4241-48d1-8133-f4c8b37483ad}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -4072,14 +4080,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {11ba5bdd-5306-4072-bd91-c8576487db9f}, !- Demand Mixer Name
-  {c4c39251-55bb-4831-a928-45e25490932e}, !- Demand Splitter Name
-  {d7d62dd2-76fa-4905-aa88-7ca21b9b2e29}, !- Supply Mixer Name
-  {0e612484-6562-48f2-94fe-dfa2bec40815}; !- Supply Splitter Name
+  {47e0f0d1-68e9-47e4-9387-b5984348b316}, !- Demand Mixer Name
+  {d4715868-c84d-4c31-b3c7-8f48e302a1ed}, !- Demand Splitter Name
+  {c5943d00-2c5d-4a94-87e7-c34b1a3d8e0f}, !- Supply Mixer Name
+  {5595fabe-b20f-4212-89f9-e6e348cbbc95}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {33309dd2-a4c5-4e0a-b546-f334c09d5117}, !- Handle
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Plant or Condenser Loop Name
+  {55383397-b254-42f7-b6b7-4d8ce14fa92d}, !- Handle
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Plant or Condenser Loop Name
   Condenser,                              !- Loop Type
   29.4,                                   !- Design Loop Exit Temperature {C}
   5.6,                                    !- Loop Design Temperature Difference {deltaC}
@@ -4088,126 +4096,126 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {e67cf4de-291d-4110-86db-f104233d729c}, !- Handle
+  {1444bf8c-b0fc-4dee-bbc4-7bd09d9457a9}, !- Handle
   Node 56,                                !- Name
-  {148199c5-0a6a-4dc5-a952-fbe374daeb88}, !- Inlet Port
-  {8f53e68e-7cb1-4b79-9bd9-8016d205ca25}; !- Outlet Port
+  {1ef97b5f-fc7f-4807-8b74-70f0f851acd7}, !- Inlet Port
+  {28b1865c-18c0-473f-b82f-e1f70bc60a68}; !- Outlet Port
 
 OS:Node,
-  {f4b4563c-deb8-4cff-8c98-1a9b81b12e7f}, !- Handle
+  {e8ad1aea-207f-45f0-b0d9-7b604e92e375}, !- Handle
   Node 57,                                !- Name
-  {4d97d1c2-d10c-47b2-8ec1-cb8fba7f477f}, !- Inlet Port
-  {f829b884-b62f-45e3-98ca-73ea8fceab9c}; !- Outlet Port
+  {224b8d93-0f4d-42c5-8a0a-4d5fe719a354}, !- Inlet Port
+  {70108631-aefa-49f6-96c7-6ef3e9af4a8d}; !- Outlet Port
 
 OS:Node,
-  {3b27fc60-f00c-404f-8fa9-b91dfb00397b}, !- Handle
+  {8665e746-2db4-4b88-a8cf-9b4f74722fbb}, !- Handle
   Node 58,                                !- Name
-  {5ab904bd-69bf-475f-aaff-26c3f378bd7d}, !- Inlet Port
-  {cac1b417-fd6b-45db-8c62-7bc03e3fa536}; !- Outlet Port
+  {72bb74ba-ae75-4605-a924-316ad52837eb}, !- Inlet Port
+  {12f3ef06-74dc-4da2-bf97-7c64817a64af}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {d7d62dd2-76fa-4905-aa88-7ca21b9b2e29}, !- Handle
+  {c5943d00-2c5d-4a94-87e7-c34b1a3d8e0f}, !- Handle
   Connector Mixer 5,                      !- Name
-  {b4665d87-3a46-4eb3-a060-3db952b71292}, !- Outlet Branch Name
-  {134f8ac2-c6a7-492f-bfa1-22d738eae2fe}, !- Inlet Branch Name 1
-  {adcf01d5-091b-4d2a-a00a-0b4a451d4403}; !- Inlet Branch Name 2
+  {59c1b0f4-f8a0-4efc-b012-944be131055f}, !- Outlet Branch Name
+  {4beedb63-2020-4a08-8dd9-746642a6fe9f}, !- Inlet Branch Name 1
+  {f721df11-e178-4a84-a909-be8ab4dfa05a}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {0e612484-6562-48f2-94fe-dfa2bec40815}, !- Handle
+  {5595fabe-b20f-4212-89f9-e6e348cbbc95}, !- Handle
   Connector Splitter 5,                   !- Name
-  {bdd50753-eb2f-4c76-9af7-eb0c631fc6b6}, !- Inlet Branch Name
-  {5ab904bd-69bf-475f-aaff-26c3f378bd7d}, !- Outlet Branch Name 1
-  {1a939952-52f9-4d6e-8ad2-bb1924cb25ee}; !- Outlet Branch Name 2
+  {87786c62-e0a6-49e1-a1b3-5eb7310644aa}, !- Inlet Branch Name
+  {72bb74ba-ae75-4605-a924-316ad52837eb}, !- Outlet Branch Name 1
+  {78b52719-c234-4b0a-99ff-c822a0b221bd}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {148199c5-0a6a-4dc5-a952-fbe374daeb88}, !- Handle
-  {98ab0a0b-dd00-478e-b49d-0b70f2e76ca1}, !- Name
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Source Object
+  {1ef97b5f-fc7f-4807-8b74-70f0f851acd7}, !- Handle
+  {77dff1ec-57be-4b82-89a0-1ae3bc1dd3be}, !- Name
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Source Object
   14,                                     !- Outlet Port
-  {e67cf4de-291d-4110-86db-f104233d729c}, !- Target Object
+  {1444bf8c-b0fc-4dee-bbc4-7bd09d9457a9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5ab904bd-69bf-475f-aaff-26c3f378bd7d}, !- Handle
-  {9e4c170f-d39b-4dfc-b1b7-ec4fbf7723f6}, !- Name
-  {0e612484-6562-48f2-94fe-dfa2bec40815}, !- Source Object
+  {72bb74ba-ae75-4605-a924-316ad52837eb}, !- Handle
+  {83809c17-870d-4629-83bd-3f940cddbc79}, !- Name
+  {5595fabe-b20f-4212-89f9-e6e348cbbc95}, !- Source Object
   3,                                      !- Outlet Port
-  {3b27fc60-f00c-404f-8fa9-b91dfb00397b}, !- Target Object
+  {8665e746-2db4-4b88-a8cf-9b4f74722fbb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f829b884-b62f-45e3-98ca-73ea8fceab9c}, !- Handle
-  {00528d0f-8dfc-4c25-879e-f990d788e3f1}, !- Name
-  {f4b4563c-deb8-4cff-8c98-1a9b81b12e7f}, !- Source Object
+  {70108631-aefa-49f6-96c7-6ef3e9af4a8d}, !- Handle
+  {67a763fe-c031-4d86-951c-08d047364f5e}, !- Name
+  {e8ad1aea-207f-45f0-b0d9-7b604e92e375}, !- Source Object
   3,                                      !- Outlet Port
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Target Object
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {67f2f4a4-6948-4b42-b841-c3052089d462}, !- Handle
+  {e67c905b-39cb-4857-9f8f-bf8f1afcbfbb}, !- Handle
   Node 59,                                !- Name
-  {7aff1771-398a-4b05-a806-c68e20e5e18f}, !- Inlet Port
-  {0f7b6ace-dbd5-4f70-b870-eae21f6c38f6}; !- Outlet Port
+  {0d4bb4c6-d1f9-4113-a106-8fdd154895c8}, !- Inlet Port
+  {3da4a3aa-d256-410b-bfcd-05826701d8cf}; !- Outlet Port
 
 OS:Node,
-  {975a6a07-4f83-4fc3-aae0-9b6eed1a1447}, !- Handle
+  {b8dcd231-9cd6-4eff-a3d9-0fc18af5174c}, !- Handle
   Node 60,                                !- Name
-  {463e71a0-9f85-4e12-93ec-c75482805535}, !- Inlet Port
-  {5da8dba5-506b-4029-8954-2a84b08117b0}; !- Outlet Port
+  {e6ff1e96-b716-4dda-8baa-377f8c83f90b}, !- Inlet Port
+  {45eacf07-e786-4b13-a12f-f67dd2660d6f}; !- Outlet Port
 
 OS:Node,
-  {ba1d4654-6ae4-4273-a01e-94ccc7a7d744}, !- Handle
+  {e8e2f38f-9ea1-4d70-a067-8ee799b8aa0b}, !- Handle
   Node 61,                                !- Name
-  {483f29a5-4a25-47cf-8c70-dc3a30ddd85b}, !- Inlet Port
-  {1a0ba7cd-73fd-4d72-b55d-aa2fc1548481}; !- Outlet Port
+  {8dc4bbb9-692f-4bec-9444-eabfc2f6a880}, !- Inlet Port
+  {d97bcfb6-8dd7-4b24-9385-c7d26c5d7deb}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {11ba5bdd-5306-4072-bd91-c8576487db9f}, !- Handle
+  {47e0f0d1-68e9-47e4-9387-b5984348b316}, !- Handle
   Connector Mixer 6,                      !- Name
-  {e5b47d10-c386-4484-ad13-4f2060e27d6d}, !- Outlet Branch Name
-  {200795c2-33e3-4c90-9d16-eb6bbf5fea85}, !- Inlet Branch Name 1
-  {67dbb00b-6783-41ec-8620-87b80c259c61}; !- Inlet Branch Name 2
+  {a92ce90e-53c6-4e1c-a1cc-426778a97c66}, !- Outlet Branch Name
+  {ddc1b30a-a988-41c8-9252-9017fc140b82}, !- Inlet Branch Name 1
+  {96c0c457-4496-49cb-b1f7-7243f6b05fc0}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {c4c39251-55bb-4831-a928-45e25490932e}, !- Handle
+  {d4715868-c84d-4c31-b3c7-8f48e302a1ed}, !- Handle
   Connector Splitter 6,                   !- Name
-  {2bb45e50-881c-4480-a77a-f51d4699001c}, !- Inlet Branch Name
-  {483f29a5-4a25-47cf-8c70-dc3a30ddd85b}, !- Outlet Branch Name 1
-  {24677607-8567-4bd2-8dbb-115862afc5a6}; !- Outlet Branch Name 2
+  {db8587fe-03ba-4c03-9888-4bd3dd7b4fe0}, !- Inlet Branch Name
+  {8dc4bbb9-692f-4bec-9444-eabfc2f6a880}, !- Outlet Branch Name 1
+  {36c2802f-cfd7-4a33-a8b6-cdc0b3a47d93}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {7aff1771-398a-4b05-a806-c68e20e5e18f}, !- Handle
-  {c16250c1-ed4f-4681-8527-fc1afc50e960}, !- Name
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Source Object
+  {0d4bb4c6-d1f9-4113-a106-8fdd154895c8}, !- Handle
+  {1d3e1b60-e054-4918-b0cc-29a06d5d32f1}, !- Name
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Source Object
   17,                                     !- Outlet Port
-  {67f2f4a4-6948-4b42-b841-c3052089d462}, !- Target Object
+  {e67c905b-39cb-4857-9f8f-bf8f1afcbfbb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {483f29a5-4a25-47cf-8c70-dc3a30ddd85b}, !- Handle
-  {13625c6a-eb52-4e3a-861d-dc7e4b8c813d}, !- Name
-  {c4c39251-55bb-4831-a928-45e25490932e}, !- Source Object
+  {8dc4bbb9-692f-4bec-9444-eabfc2f6a880}, !- Handle
+  {35bc8f82-aa48-47e2-8752-75875bc82e76}, !- Name
+  {d4715868-c84d-4c31-b3c7-8f48e302a1ed}, !- Source Object
   3,                                      !- Outlet Port
-  {ba1d4654-6ae4-4273-a01e-94ccc7a7d744}, !- Target Object
+  {e8e2f38f-9ea1-4d70-a067-8ee799b8aa0b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5da8dba5-506b-4029-8954-2a84b08117b0}, !- Handle
-  {6ac67b71-5156-4b2b-a50f-f69c2fb3ae2f}, !- Name
-  {975a6a07-4f83-4fc3-aae0-9b6eed1a1447}, !- Source Object
+  {45eacf07-e786-4b13-a12f-f67dd2660d6f}, !- Handle
+  {46df8899-71d2-4227-82f6-b258498b8e7b}, !- Name
+  {b8dcd231-9cd6-4eff-a3d9-0fc18af5174c}, !- Source Object
   3,                                      !- Outlet Port
-  {2a777b3e-47af-4aa7-a45b-3ea9e62d5ce0}, !- Target Object
+  {0ad3d8e0-81ee-4395-934f-7737eceab13f}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {b5e70716-fba7-48b3-a0ca-c8dcb0720407}, !- Handle
+  {71623022-4241-48d1-8133-f4c8b37483ad}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList 2; !- Name
 
 OS:CoolingTower:SingleSpeed,
-  {2b2eefe9-ea46-4971-9c00-16798ce1c2e9}, !- Handle
+  {006fad9e-e100-4acc-bc8e-6e33c166d287}, !- Handle
   Cooling Tower Single Speed 1,           !- Name
-  {cac1b417-fd6b-45db-8c62-7bc03e3fa536}, !- Water Inlet Node Name
-  {6590d08c-00c1-4d60-9671-14667be573fb}, !- Water Outlet Node Name
+  {12f3ef06-74dc-4da2-bf97-7c64817a64af}, !- Water Inlet Node Name
+  {913ecf30-1a25-40e3-9723-955dc87308db}, !- Water Outlet Node Name
   autosize,                               !- Design Water Flow Rate {m3/s}
   autosize,                               !- Design Air Flow Rate {m3/s}
   autosize,                               !- Fan Power at Design Air Flow Rate {W}
@@ -4244,126 +4252,126 @@ OS:CoolingTower:SingleSpeed,
   General;                                !- End-Use Subcategory
 
 OS:Node,
-  {5d191dea-8519-451e-8250-c15056fa1f81}, !- Handle
+  {2231ff46-5a5d-4be7-82b1-df0fab7fb81f}, !- Handle
   Node 62,                                !- Name
-  {6590d08c-00c1-4d60-9671-14667be573fb}, !- Inlet Port
-  {134f8ac2-c6a7-492f-bfa1-22d738eae2fe}; !- Outlet Port
+  {913ecf30-1a25-40e3-9723-955dc87308db}, !- Inlet Port
+  {4beedb63-2020-4a08-8dd9-746642a6fe9f}; !- Outlet Port
 
 OS:Connection,
-  {cac1b417-fd6b-45db-8c62-7bc03e3fa536}, !- Handle
-  {0438ea85-7cca-498b-bb8e-2870fe615cd4}, !- Name
-  {3b27fc60-f00c-404f-8fa9-b91dfb00397b}, !- Source Object
+  {12f3ef06-74dc-4da2-bf97-7c64817a64af}, !- Handle
+  {d299cac0-d079-4aa6-9937-dc02b7a4f04d}, !- Name
+  {8665e746-2db4-4b88-a8cf-9b4f74722fbb}, !- Source Object
   3,                                      !- Outlet Port
-  {2b2eefe9-ea46-4971-9c00-16798ce1c2e9}, !- Target Object
+  {006fad9e-e100-4acc-bc8e-6e33c166d287}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {6590d08c-00c1-4d60-9671-14667be573fb}, !- Handle
-  {7059e787-66f4-4676-8a5f-3bf15c4f9dbc}, !- Name
-  {2b2eefe9-ea46-4971-9c00-16798ce1c2e9}, !- Source Object
+  {913ecf30-1a25-40e3-9723-955dc87308db}, !- Handle
+  {af2dcb6c-7184-42e7-86c9-64b372e0d028}, !- Name
+  {006fad9e-e100-4acc-bc8e-6e33c166d287}, !- Source Object
   3,                                      !- Outlet Port
-  {5d191dea-8519-451e-8250-c15056fa1f81}, !- Target Object
+  {2231ff46-5a5d-4be7-82b1-df0fab7fb81f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {134f8ac2-c6a7-492f-bfa1-22d738eae2fe}, !- Handle
-  {eee72a85-de71-4a8e-b0f5-aa2ed9761a9a}, !- Name
-  {5d191dea-8519-451e-8250-c15056fa1f81}, !- Source Object
+  {4beedb63-2020-4a08-8dd9-746642a6fe9f}, !- Handle
+  {07c04f77-96d7-4fe0-bcf1-bc66bc0b8553}, !- Name
+  {2231ff46-5a5d-4be7-82b1-df0fab7fb81f}, !- Source Object
   3,                                      !- Outlet Port
-  {d7d62dd2-76fa-4905-aa88-7ca21b9b2e29}, !- Target Object
+  {c5943d00-2c5d-4a94-87e7-c34b1a3d8e0f}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {716d5267-5edb-4409-bb3d-1f7bd011ca17}, !- Handle
+  {cf8d1b41-7ee5-4e83-94f3-b53fa933cf4f}, !- Handle
   Pipe Adiabatic 11,                      !- Name
-  {f99b000a-2587-40d8-9538-c670cf71bde0}, !- Inlet Node Name
-  {6fd0cfe5-1b08-4300-8c0c-f6ec9be57db6}; !- Outlet Node Name
+  {8834f852-3fc4-4549-9538-518a9815d79e}, !- Inlet Node Name
+  {ddb06416-1006-4241-bad3-6dc221a4e566}; !- Outlet Node Name
 
 OS:Node,
-  {19090a9e-ea5c-40ff-8e55-e17c5c43cffa}, !- Handle
+  {dea8cd68-6f4c-4491-a22f-c7e634271c43}, !- Handle
   Node 63,                                !- Name
-  {1a939952-52f9-4d6e-8ad2-bb1924cb25ee}, !- Inlet Port
-  {f99b000a-2587-40d8-9538-c670cf71bde0}; !- Outlet Port
+  {78b52719-c234-4b0a-99ff-c822a0b221bd}, !- Inlet Port
+  {8834f852-3fc4-4549-9538-518a9815d79e}; !- Outlet Port
 
 OS:Connection,
-  {1a939952-52f9-4d6e-8ad2-bb1924cb25ee}, !- Handle
-  {920a4b8d-44a4-47a7-98f3-003e1655a6da}, !- Name
-  {0e612484-6562-48f2-94fe-dfa2bec40815}, !- Source Object
+  {78b52719-c234-4b0a-99ff-c822a0b221bd}, !- Handle
+  {c56f802e-b333-4a87-b965-d19012bb428f}, !- Name
+  {5595fabe-b20f-4212-89f9-e6e348cbbc95}, !- Source Object
   4,                                      !- Outlet Port
-  {19090a9e-ea5c-40ff-8e55-e17c5c43cffa}, !- Target Object
+  {dea8cd68-6f4c-4491-a22f-c7e634271c43}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {6bc70111-8932-4874-afd4-df342836bc67}, !- Handle
+  {a988000d-0948-40b5-bb79-588c1610f379}, !- Handle
   Node 64,                                !- Name
-  {6fd0cfe5-1b08-4300-8c0c-f6ec9be57db6}, !- Inlet Port
-  {adcf01d5-091b-4d2a-a00a-0b4a451d4403}; !- Outlet Port
+  {ddb06416-1006-4241-bad3-6dc221a4e566}, !- Inlet Port
+  {f721df11-e178-4a84-a909-be8ab4dfa05a}; !- Outlet Port
 
 OS:Connection,
-  {f99b000a-2587-40d8-9538-c670cf71bde0}, !- Handle
-  {4e283a91-081b-4ac7-8e4f-46a396e10828}, !- Name
-  {19090a9e-ea5c-40ff-8e55-e17c5c43cffa}, !- Source Object
+  {8834f852-3fc4-4549-9538-518a9815d79e}, !- Handle
+  {b1c7fb74-34b1-4371-90bc-c55167ac5f73}, !- Name
+  {dea8cd68-6f4c-4491-a22f-c7e634271c43}, !- Source Object
   3,                                      !- Outlet Port
-  {716d5267-5edb-4409-bb3d-1f7bd011ca17}, !- Target Object
+  {cf8d1b41-7ee5-4e83-94f3-b53fa933cf4f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {6fd0cfe5-1b08-4300-8c0c-f6ec9be57db6}, !- Handle
-  {4126436a-a533-4bdd-a8a1-9a26ac82769b}, !- Name
-  {716d5267-5edb-4409-bb3d-1f7bd011ca17}, !- Source Object
+  {ddb06416-1006-4241-bad3-6dc221a4e566}, !- Handle
+  {6d2cc469-8832-44fd-b4bf-204cc88c941a}, !- Name
+  {cf8d1b41-7ee5-4e83-94f3-b53fa933cf4f}, !- Source Object
   3,                                      !- Outlet Port
-  {6bc70111-8932-4874-afd4-df342836bc67}, !- Target Object
+  {a988000d-0948-40b5-bb79-588c1610f379}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {adcf01d5-091b-4d2a-a00a-0b4a451d4403}, !- Handle
-  {c7ef9e9f-4d88-4fb6-8acf-f42d3d34c8fb}, !- Name
-  {6bc70111-8932-4874-afd4-df342836bc67}, !- Source Object
+  {f721df11-e178-4a84-a909-be8ab4dfa05a}, !- Handle
+  {a96f7ac4-b7ce-40f2-b6a5-cea9c5f0e093}, !- Name
+  {a988000d-0948-40b5-bb79-588c1610f379}, !- Source Object
   3,                                      !- Outlet Port
-  {d7d62dd2-76fa-4905-aa88-7ca21b9b2e29}, !- Target Object
+  {c5943d00-2c5d-4a94-87e7-c34b1a3d8e0f}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {6d28747b-a545-41fc-b60e-c10fb7c49cf7}, !- Handle
+  {37e350aa-fc67-4bd2-8ee1-7b449ac1445c}, !- Handle
   Pipe Adiabatic 12,                      !- Name
-  {7a092322-adf9-4307-9a33-50306f0ee7ba}, !- Inlet Node Name
-  {4d97d1c2-d10c-47b2-8ec1-cb8fba7f477f}; !- Outlet Node Name
+  {e05cd9e4-40da-4005-9475-3b0af4a4f0df}, !- Inlet Node Name
+  {224b8d93-0f4d-42c5-8a0a-4d5fe719a354}; !- Outlet Node Name
 
 OS:Node,
-  {d1e930f0-37f1-4331-a0af-b39d450e9346}, !- Handle
+  {0d649597-5279-4342-a183-994597cc6748}, !- Handle
   Node 65,                                !- Name
-  {b4665d87-3a46-4eb3-a060-3db952b71292}, !- Inlet Port
-  {7a092322-adf9-4307-9a33-50306f0ee7ba}; !- Outlet Port
+  {59c1b0f4-f8a0-4efc-b012-944be131055f}, !- Inlet Port
+  {e05cd9e4-40da-4005-9475-3b0af4a4f0df}; !- Outlet Port
 
 OS:Connection,
-  {b4665d87-3a46-4eb3-a060-3db952b71292}, !- Handle
-  {5aaeae64-0d4e-4a91-bc85-ac5c5d6390d7}, !- Name
-  {d7d62dd2-76fa-4905-aa88-7ca21b9b2e29}, !- Source Object
+  {59c1b0f4-f8a0-4efc-b012-944be131055f}, !- Handle
+  {e0efd154-d7b9-4f33-ade9-9ae6ce42dd29}, !- Name
+  {c5943d00-2c5d-4a94-87e7-c34b1a3d8e0f}, !- Source Object
   2,                                      !- Outlet Port
-  {d1e930f0-37f1-4331-a0af-b39d450e9346}, !- Target Object
+  {0d649597-5279-4342-a183-994597cc6748}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7a092322-adf9-4307-9a33-50306f0ee7ba}, !- Handle
-  {91f6938c-d284-4416-8f87-909c4198f978}, !- Name
-  {d1e930f0-37f1-4331-a0af-b39d450e9346}, !- Source Object
+  {e05cd9e4-40da-4005-9475-3b0af4a4f0df}, !- Handle
+  {f03bd40d-6e6a-41f3-8771-3d599ce7dbc3}, !- Name
+  {0d649597-5279-4342-a183-994597cc6748}, !- Source Object
   3,                                      !- Outlet Port
-  {6d28747b-a545-41fc-b60e-c10fb7c49cf7}, !- Target Object
+  {37e350aa-fc67-4bd2-8ee1-7b449ac1445c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4d97d1c2-d10c-47b2-8ec1-cb8fba7f477f}, !- Handle
-  {ac5c6cf8-0094-4c46-915e-e33a5050880c}, !- Name
-  {6d28747b-a545-41fc-b60e-c10fb7c49cf7}, !- Source Object
+  {224b8d93-0f4d-42c5-8a0a-4d5fe719a354}, !- Handle
+  {a8395f9f-7dfe-4ba9-8480-d06617af7b79}, !- Name
+  {37e350aa-fc67-4bd2-8ee1-7b449ac1445c}, !- Source Object
   3,                                      !- Outlet Port
-  {f4b4563c-deb8-4cff-8c98-1a9b81b12e7f}, !- Target Object
+  {e8ad1aea-207f-45f0-b0d9-7b604e92e375}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pump:VariableSpeed,
-  {22632b65-cc4c-4cfb-a8e0-c18726577155}, !- Handle
+  {c74d9686-9b1e-49f0-8ea5-ce1574ff9133}, !- Handle
   Pump Variable Speed 3,                  !- Name
-  {8f53e68e-7cb1-4b79-9bd9-8016d205ca25}, !- Inlet Node Name
-  {7eb45c8c-2828-43eb-9af4-742ec5c03135}, !- Outlet Node Name
+  {28b1865c-18c0-473f-b82f-e1f70bc60a68}, !- Inlet Node Name
+  {553de309-8e2b-4c9d-8930-9e823ee168b0}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -4392,433 +4400,433 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Node,
-  {bd2493b8-5b96-4b7d-ad78-e7ad916940e5}, !- Handle
+  {3f9cdc94-489a-41f5-aa7f-a903f25da1ab}, !- Handle
   Node 66,                                !- Name
-  {7eb45c8c-2828-43eb-9af4-742ec5c03135}, !- Inlet Port
-  {bdd50753-eb2f-4c76-9af7-eb0c631fc6b6}; !- Outlet Port
+  {553de309-8e2b-4c9d-8930-9e823ee168b0}, !- Inlet Port
+  {87786c62-e0a6-49e1-a1b3-5eb7310644aa}; !- Outlet Port
 
 OS:Connection,
-  {8f53e68e-7cb1-4b79-9bd9-8016d205ca25}, !- Handle
-  {ec06b6dc-1142-419f-b122-88e9e66782aa}, !- Name
-  {e67cf4de-291d-4110-86db-f104233d729c}, !- Source Object
+  {28b1865c-18c0-473f-b82f-e1f70bc60a68}, !- Handle
+  {e8042b1c-a33e-402d-b5e6-10b473cb9b6b}, !- Name
+  {1444bf8c-b0fc-4dee-bbc4-7bd09d9457a9}, !- Source Object
   3,                                      !- Outlet Port
-  {22632b65-cc4c-4cfb-a8e0-c18726577155}, !- Target Object
+  {c74d9686-9b1e-49f0-8ea5-ce1574ff9133}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7eb45c8c-2828-43eb-9af4-742ec5c03135}, !- Handle
-  {35d8db6f-1881-487a-95fa-8b8d1bdf7194}, !- Name
-  {22632b65-cc4c-4cfb-a8e0-c18726577155}, !- Source Object
+  {553de309-8e2b-4c9d-8930-9e823ee168b0}, !- Handle
+  {70c75430-2a39-4fb5-b523-aa317fec258e}, !- Name
+  {c74d9686-9b1e-49f0-8ea5-ce1574ff9133}, !- Source Object
   3,                                      !- Outlet Port
-  {bd2493b8-5b96-4b7d-ad78-e7ad916940e5}, !- Target Object
+  {3f9cdc94-489a-41f5-aa7f-a903f25da1ab}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bdd50753-eb2f-4c76-9af7-eb0c631fc6b6}, !- Handle
-  {8d826683-cdf7-4320-9e6c-fe26cfa68499}, !- Name
-  {bd2493b8-5b96-4b7d-ad78-e7ad916940e5}, !- Source Object
+  {87786c62-e0a6-49e1-a1b3-5eb7310644aa}, !- Handle
+  {ee7eb650-e25b-4713-baf5-cc6404f81a9b}, !- Name
+  {3f9cdc94-489a-41f5-aa7f-a903f25da1ab}, !- Source Object
   3,                                      !- Outlet Port
-  {0e612484-6562-48f2-94fe-dfa2bec40815}, !- Target Object
+  {5595fabe-b20f-4212-89f9-e6e348cbbc95}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {b6504f4e-8567-4d26-933c-fc267958b059}, !- Handle
+  {62ad8d0c-00a8-479b-88fb-e91fc2c3cc65}, !- Handle
   Node 67,                                !- Name
-  {f411fc52-d087-4122-8b3c-ca2006a343c0}, !- Inlet Port
-  {200795c2-33e3-4c90-9d16-eb6bbf5fea85}; !- Outlet Port
+  {fffc5d2f-214b-4178-b378-69353b745b4b}, !- Inlet Port
+  {ddc1b30a-a988-41c8-9252-9017fc140b82}; !- Outlet Port
 
 OS:Connection,
-  {1a0ba7cd-73fd-4d72-b55d-aa2fc1548481}, !- Handle
-  {2d223f42-0dc9-44a7-864e-c90e8e0e410f}, !- Name
-  {ba1d4654-6ae4-4273-a01e-94ccc7a7d744}, !- Source Object
+  {d97bcfb6-8dd7-4b24-9385-c7d26c5d7deb}, !- Handle
+  {60ed6940-4d51-4bf1-a4fd-c55fef95cb5e}, !- Name
+  {e8e2f38f-9ea1-4d70-a067-8ee799b8aa0b}, !- Source Object
   3,                                      !- Outlet Port
-  {29291873-7155-4f63-a17d-083b69b07d6f}, !- Target Object
+  {b55c11e3-32c8-4032-8edd-913f341daffa}, !- Target Object
   17;                                     !- Inlet Port
 
 OS:Connection,
-  {f411fc52-d087-4122-8b3c-ca2006a343c0}, !- Handle
-  {a6eb7d47-11d7-43fe-b306-e4a02b983ff4}, !- Name
-  {29291873-7155-4f63-a17d-083b69b07d6f}, !- Source Object
+  {fffc5d2f-214b-4178-b378-69353b745b4b}, !- Handle
+  {8c778cba-a7d5-4abf-b65d-fb346b2ab539}, !- Name
+  {b55c11e3-32c8-4032-8edd-913f341daffa}, !- Source Object
   18,                                     !- Outlet Port
-  {b6504f4e-8567-4d26-933c-fc267958b059}, !- Target Object
+  {62ad8d0c-00a8-479b-88fb-e91fc2c3cc65}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {200795c2-33e3-4c90-9d16-eb6bbf5fea85}, !- Handle
-  {4e314cba-d419-440f-9e36-a33c97f7af1e}, !- Name
-  {b6504f4e-8567-4d26-933c-fc267958b059}, !- Source Object
+  {ddc1b30a-a988-41c8-9252-9017fc140b82}, !- Handle
+  {141c9492-4e3a-49c2-ab6a-5aba726ef15b}, !- Name
+  {62ad8d0c-00a8-479b-88fb-e91fc2c3cc65}, !- Source Object
   3,                                      !- Outlet Port
-  {11ba5bdd-5306-4072-bd91-c8576487db9f}, !- Target Object
+  {47e0f0d1-68e9-47e4-9387-b5984348b316}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {2d179407-7da9-4862-b0a1-754e962c5c12}, !- Handle
+  {14b05307-52c7-4911-998d-55d944817450}, !- Handle
   Pipe Adiabatic 13,                      !- Name
-  {9826cf2c-227d-4353-90d9-be947bcdfcb2}, !- Inlet Node Name
-  {dc6fde7d-5d29-4208-bca9-c355d8f9eff9}; !- Outlet Node Name
+  {10c4bd93-6d5d-4a2f-a757-57a05a341eab}, !- Inlet Node Name
+  {48698de3-b0e8-41d7-bf7f-7f98a4ab4260}; !- Outlet Node Name
 
 OS:Node,
-  {85281b6b-907c-4534-9959-99eac830609b}, !- Handle
+  {221b6094-b06a-45d6-95ef-954c2f7e396b}, !- Handle
   Node 68,                                !- Name
-  {24677607-8567-4bd2-8dbb-115862afc5a6}, !- Inlet Port
-  {9826cf2c-227d-4353-90d9-be947bcdfcb2}; !- Outlet Port
+  {36c2802f-cfd7-4a33-a8b6-cdc0b3a47d93}, !- Inlet Port
+  {10c4bd93-6d5d-4a2f-a757-57a05a341eab}; !- Outlet Port
 
 OS:Connection,
-  {24677607-8567-4bd2-8dbb-115862afc5a6}, !- Handle
-  {5e9c1f08-cca4-4a67-9ff7-fe933ac9f7fc}, !- Name
-  {c4c39251-55bb-4831-a928-45e25490932e}, !- Source Object
+  {36c2802f-cfd7-4a33-a8b6-cdc0b3a47d93}, !- Handle
+  {4dc7fd26-450f-4e5c-81c1-69ab06c4a8b7}, !- Name
+  {d4715868-c84d-4c31-b3c7-8f48e302a1ed}, !- Source Object
   4,                                      !- Outlet Port
-  {85281b6b-907c-4534-9959-99eac830609b}, !- Target Object
+  {221b6094-b06a-45d6-95ef-954c2f7e396b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {13d15a52-93c4-44cd-80fc-265ffe621007}, !- Handle
+  {9857879f-8a2c-4088-8427-733474e5470d}, !- Handle
   Node 69,                                !- Name
-  {dc6fde7d-5d29-4208-bca9-c355d8f9eff9}, !- Inlet Port
-  {67dbb00b-6783-41ec-8620-87b80c259c61}; !- Outlet Port
+  {48698de3-b0e8-41d7-bf7f-7f98a4ab4260}, !- Inlet Port
+  {96c0c457-4496-49cb-b1f7-7243f6b05fc0}; !- Outlet Port
 
 OS:Connection,
-  {9826cf2c-227d-4353-90d9-be947bcdfcb2}, !- Handle
-  {bb176357-e1e1-43f3-9df9-627d82329585}, !- Name
-  {85281b6b-907c-4534-9959-99eac830609b}, !- Source Object
+  {10c4bd93-6d5d-4a2f-a757-57a05a341eab}, !- Handle
+  {936b1908-f550-4783-896a-4cebbd544ff8}, !- Name
+  {221b6094-b06a-45d6-95ef-954c2f7e396b}, !- Source Object
   3,                                      !- Outlet Port
-  {2d179407-7da9-4862-b0a1-754e962c5c12}, !- Target Object
+  {14b05307-52c7-4911-998d-55d944817450}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {dc6fde7d-5d29-4208-bca9-c355d8f9eff9}, !- Handle
-  {3388e986-5385-4b90-9fcb-4319759e4b17}, !- Name
-  {2d179407-7da9-4862-b0a1-754e962c5c12}, !- Source Object
+  {48698de3-b0e8-41d7-bf7f-7f98a4ab4260}, !- Handle
+  {46943176-5f7a-4ae8-ba1a-601347f675d7}, !- Name
+  {14b05307-52c7-4911-998d-55d944817450}, !- Source Object
   3,                                      !- Outlet Port
-  {13d15a52-93c4-44cd-80fc-265ffe621007}, !- Target Object
+  {9857879f-8a2c-4088-8427-733474e5470d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {67dbb00b-6783-41ec-8620-87b80c259c61}, !- Handle
-  {10c2453a-fce4-4e2b-b771-9cec356a33ef}, !- Name
-  {13d15a52-93c4-44cd-80fc-265ffe621007}, !- Source Object
+  {96c0c457-4496-49cb-b1f7-7243f6b05fc0}, !- Handle
+  {67441161-f880-453f-b40e-99fcb36275ee}, !- Name
+  {9857879f-8a2c-4088-8427-733474e5470d}, !- Source Object
   3,                                      !- Outlet Port
-  {11ba5bdd-5306-4072-bd91-c8576487db9f}, !- Target Object
+  {47e0f0d1-68e9-47e4-9387-b5984348b316}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {f0600578-d466-4494-b092-88bccbc5b9ed}, !- Handle
+  {df26cf39-313f-45e4-8cc5-3c402d842e13}, !- Handle
   Pipe Adiabatic 14,                      !- Name
-  {0f7b6ace-dbd5-4f70-b870-eae21f6c38f6}, !- Inlet Node Name
-  {4a075307-79d7-40e6-a313-724e4ff5a6c0}; !- Outlet Node Name
+  {3da4a3aa-d256-410b-bfcd-05826701d8cf}, !- Inlet Node Name
+  {803bf614-f884-499d-b41d-026c067e9fd2}; !- Outlet Node Name
 
 OS:Node,
-  {fc34500a-e249-4d05-b5ed-e041a6cf9901}, !- Handle
+  {35b2d5c4-5d00-4b00-bf12-ea316859aa03}, !- Handle
   Node 70,                                !- Name
-  {4a075307-79d7-40e6-a313-724e4ff5a6c0}, !- Inlet Port
-  {2bb45e50-881c-4480-a77a-f51d4699001c}; !- Outlet Port
+  {803bf614-f884-499d-b41d-026c067e9fd2}, !- Inlet Port
+  {db8587fe-03ba-4c03-9888-4bd3dd7b4fe0}; !- Outlet Port
 
 OS:Connection,
-  {0f7b6ace-dbd5-4f70-b870-eae21f6c38f6}, !- Handle
-  {3e932ebf-1462-49b1-bb78-9d88821041fa}, !- Name
-  {67f2f4a4-6948-4b42-b841-c3052089d462}, !- Source Object
+  {3da4a3aa-d256-410b-bfcd-05826701d8cf}, !- Handle
+  {55c3ede2-47e7-4352-8fb7-a9ced67ea863}, !- Name
+  {e67c905b-39cb-4857-9f8f-bf8f1afcbfbb}, !- Source Object
   3,                                      !- Outlet Port
-  {f0600578-d466-4494-b092-88bccbc5b9ed}, !- Target Object
+  {df26cf39-313f-45e4-8cc5-3c402d842e13}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4a075307-79d7-40e6-a313-724e4ff5a6c0}, !- Handle
-  {f78a2bbf-625b-46ad-88a9-94d0b348d32e}, !- Name
-  {f0600578-d466-4494-b092-88bccbc5b9ed}, !- Source Object
+  {803bf614-f884-499d-b41d-026c067e9fd2}, !- Handle
+  {360e1e1e-a1cd-4672-ba35-8d90cca2cc80}, !- Name
+  {df26cf39-313f-45e4-8cc5-3c402d842e13}, !- Source Object
   3,                                      !- Outlet Port
-  {fc34500a-e249-4d05-b5ed-e041a6cf9901}, !- Target Object
+  {35b2d5c4-5d00-4b00-bf12-ea316859aa03}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2bb45e50-881c-4480-a77a-f51d4699001c}, !- Handle
-  {04ac364a-a5d3-42ae-80f2-c4c3139de26b}, !- Name
-  {fc34500a-e249-4d05-b5ed-e041a6cf9901}, !- Source Object
+  {db8587fe-03ba-4c03-9888-4bd3dd7b4fe0}, !- Handle
+  {a6af63d0-ae12-44d6-8e47-5cf64e151e02}, !- Name
+  {35b2d5c4-5d00-4b00-bf12-ea316859aa03}, !- Source Object
   3,                                      !- Outlet Port
-  {c4c39251-55bb-4831-a928-45e25490932e}, !- Target Object
+  {d4715868-c84d-4c31-b3c7-8f48e302a1ed}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {3aaf1f57-e024-4868-ad47-531044fa5f91}, !- Handle
+  {1c417c66-4851-40f7-a83f-2f32e5de6389}, !- Handle
   Pipe Adiabatic 15,                      !- Name
-  {00b9cc1b-e524-437f-96cf-afc8f17f233b}, !- Inlet Node Name
-  {463e71a0-9f85-4e12-93ec-c75482805535}; !- Outlet Node Name
+  {2a994035-3da3-4a40-89e2-0aeae74c59f6}, !- Inlet Node Name
+  {e6ff1e96-b716-4dda-8baa-377f8c83f90b}; !- Outlet Node Name
 
 OS:Node,
-  {d564f9d4-c743-453d-add8-f28775f44243}, !- Handle
+  {6bada950-330b-498a-94b8-1517c9fb3beb}, !- Handle
   Node 71,                                !- Name
-  {e5b47d10-c386-4484-ad13-4f2060e27d6d}, !- Inlet Port
-  {00b9cc1b-e524-437f-96cf-afc8f17f233b}; !- Outlet Port
+  {a92ce90e-53c6-4e1c-a1cc-426778a97c66}, !- Inlet Port
+  {2a994035-3da3-4a40-89e2-0aeae74c59f6}; !- Outlet Port
 
 OS:Connection,
-  {e5b47d10-c386-4484-ad13-4f2060e27d6d}, !- Handle
-  {1681648a-d053-42fe-96f9-446154f8278e}, !- Name
-  {11ba5bdd-5306-4072-bd91-c8576487db9f}, !- Source Object
+  {a92ce90e-53c6-4e1c-a1cc-426778a97c66}, !- Handle
+  {9d1ef2de-6024-4e5c-8836-07a4ebfdeef8}, !- Name
+  {47e0f0d1-68e9-47e4-9387-b5984348b316}, !- Source Object
   2,                                      !- Outlet Port
-  {d564f9d4-c743-453d-add8-f28775f44243}, !- Target Object
+  {6bada950-330b-498a-94b8-1517c9fb3beb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {00b9cc1b-e524-437f-96cf-afc8f17f233b}, !- Handle
-  {c362b15d-99a9-4b89-a870-211091af5c8a}, !- Name
-  {d564f9d4-c743-453d-add8-f28775f44243}, !- Source Object
+  {2a994035-3da3-4a40-89e2-0aeae74c59f6}, !- Handle
+  {135b7a5f-a2da-4a5e-b52f-44555be9e1c6}, !- Name
+  {6bada950-330b-498a-94b8-1517c9fb3beb}, !- Source Object
   3,                                      !- Outlet Port
-  {3aaf1f57-e024-4868-ad47-531044fa5f91}, !- Target Object
+  {1c417c66-4851-40f7-a83f-2f32e5de6389}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {463e71a0-9f85-4e12-93ec-c75482805535}, !- Handle
-  {39d6e540-55cc-42df-bd36-a21e9ed94d90}, !- Name
-  {3aaf1f57-e024-4868-ad47-531044fa5f91}, !- Source Object
+  {e6ff1e96-b716-4dda-8baa-377f8c83f90b}, !- Handle
+  {098cdae0-71e6-42ad-ba86-5b9fe1ca22df}, !- Name
+  {1c417c66-4851-40f7-a83f-2f32e5de6389}, !- Source Object
   3,                                      !- Outlet Port
-  {975a6a07-4f83-4fc3-aae0-9b6eed1a1447}, !- Target Object
+  {b8dcd231-9cd6-4eff-a3d9-0fc18af5174c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:SetpointManager:FollowOutdoorAirTemperature,
-  {1511bd91-9eb4-470a-a33d-8fd6a4ce3e1e}, !- Handle
+  {fd03d661-6c65-4ba4-8999-c068d065850e}, !- Handle
   Setpoint Manager Follow Outdoor Air Temperature 1, !- Name
   Temperature,                            !- Control Variable
   OutdoorAirWetBulb,                      !- Reference Temperature Type
   1.5,                                    !- Offset Temperature Difference {deltaC}
   80,                                     !- Maximum Setpoint Temperature {C}
   6,                                      !- Minimum Setpoint Temperature {C}
-  {f4b4563c-deb8-4cff-8c98-1a9b81b12e7f}; !- Setpoint Node or NodeList Name
+  {e8ad1aea-207f-45f0-b0d9-7b604e92e375}; !- Setpoint Node or NodeList Name
 
 OS:Schedule:Ruleset,
-  {72e04dca-f769-4328-977a-cba9066493b4}, !- Handle
+  {097d8012-59db-4e3d-bb3c-28a7d47e7edf}, !- Handle
   Deck_Temperature 1,                     !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {6389cfe3-9416-4830-b804-1581495c8f2b}, !- Default Day Schedule Name
-  {0e1b41e3-c4f9-4b1d-9175-73bf58e8ebd5}, !- Summer Design Day Schedule Name
-  {b71fd768-bca3-4dc0-a16f-9ea8485455d4}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {2a9bd7f7-c363-46b9-a85d-21b0e0dc9974}, !- Default Day Schedule Name
+  {332c182f-8648-4ee8-887d-bee2ce707df4}, !- Summer Design Day Schedule Name
+  {80e4a54a-6eb8-4a9c-aec2-b03366688fe3}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {6389cfe3-9416-4830-b804-1581495c8f2b}, !- Handle
+  {2a9bd7f7-c363-46b9-a85d-21b0e0dc9974}, !- Handle
   Deck_Temperature_Default 1,             !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Day,
-  {0e1b41e3-c4f9-4b1d-9175-73bf58e8ebd5}, !- Handle
+  {332c182f-8648-4ee8-887d-bee2ce707df4}, !- Handle
   Deck_Temperature_Summer_Design_Day 1,   !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Day,
-  {b71fd768-bca3-4dc0-a16f-9ea8485455d4}, !- Handle
+  {80e4a54a-6eb8-4a9c-aec2-b03366688fe3}, !- Handle
   Deck_Temperature_Winter_Design_Day 1,   !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   12.8;                                   !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {d64d2ed0-629a-4d5e-b939-8370a844ade2}, !- Handle
+  {b59f427e-96f2-44e4-aab4-4b185f283e83}, !- Handle
   Hot_Water_Temperature 1,                !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {779af849-7f48-405e-a72b-70e2af1e1122}, !- Default Day Schedule Name
-  {2fb547fa-3688-4383-a771-e6ad29485d6f}, !- Summer Design Day Schedule Name
-  {422dbcf4-fd84-4058-a716-cd0e0d09f9bb}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {a062e8fc-ad5e-4707-b037-3b38452a0698}, !- Default Day Schedule Name
+  {152eb253-36ee-4859-929b-554bc8c9dd75}, !- Summer Design Day Schedule Name
+  {1fa68e23-77aa-4be7-931f-b6b6283fc8ed}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {779af849-7f48-405e-a72b-70e2af1e1122}, !- Handle
+  {a062e8fc-ad5e-4707-b037-3b38452a0698}, !- Handle
   Hot_Water_Temperature_Default 1,        !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {2fb547fa-3688-4383-a771-e6ad29485d6f}, !- Handle
+  {152eb253-36ee-4859-929b-554bc8c9dd75}, !- Handle
   Hot_Water_Temperature_Summer_Design_Day 1, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Day,
-  {422dbcf4-fd84-4058-a716-cd0e0d09f9bb}, !- Handle
+  {1fa68e23-77aa-4be7-931f-b6b6283fc8ed}, !- Handle
   Hot_Water_Temperature_Winter_Design_Day 1, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   67;                                     !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {6a34b591-5efd-44c2-a327-45a5f2f8fb0a}, !- Handle
+  {f1ca95f2-8de0-45f6-95df-8c7fc9993575}, !- Handle
   Chilled_Water_Temperature 1,            !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {9e27d044-4102-4340-b6f7-a6318aaa3e1a}, !- Default Day Schedule Name
-  {e5744ddf-d8dc-493a-a823-a11910b9971f}, !- Summer Design Day Schedule Name
-  {b05ca836-f487-406a-866b-4b5a3905491c}; !- Winter Design Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {1071b451-92cf-4913-9e36-a4ec7ee00118}, !- Default Day Schedule Name
+  {c9f671db-c7a9-4de9-8748-70809860261c}, !- Summer Design Day Schedule Name
+  {742a3c27-dbec-46f3-bf59-ffd7bfd421c3}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {9e27d044-4102-4340-b6f7-a6318aaa3e1a}, !- Handle
+  {1071b451-92cf-4913-9e36-a4ec7ee00118}, !- Handle
   Chilled_Water_Temperature_Default 1,    !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:Schedule:Day,
-  {e5744ddf-d8dc-493a-a823-a11910b9971f}, !- Handle
+  {c9f671db-c7a9-4de9-8748-70809860261c}, !- Handle
   Chilled_Water_Temperature_Summer_Design_Day 1, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:Schedule:Day,
-  {b05ca836-f487-406a-866b-4b5a3905491c}, !- Handle
+  {742a3c27-dbec-46f3-bf59-ffd7bfd421c3}, !- Handle
   Chilled_Water_Temperature_Winter_Design_Day 1, !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   6.7;                                    !- Value Until Time 1
 
 OS:AirLoopHVAC,
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- Handle
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- Handle
   VAV with Reheat 1,                      !- Name
   ,                                       !- Controller List Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule
-  {ccde1f43-1550-444e-beb6-cf9a63daa0cc}, !- Availability Manager List Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule
+  {f395976a-e5ad-4174-9a0e-631820e91e30}, !- Availability Manager List Name
   AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
   ,                                       !- Branch List Name
   ,                                       !- Connector List Name
-  {3c408e94-1a14-4105-8d4c-57e185e8d1d8}, !- Supply Side Inlet Node Name
-  {bbb91b39-4b8b-482c-88ba-781ff8c97129}, !- Demand Side Outlet Node Name
-  {308fe4bc-01e7-4c39-bb72-b45c913ee2e4}, !- Demand Side Inlet Node A
-  {efd48d61-f50b-428a-8d2f-209aefd4820a}, !- Supply Side Outlet Node A
+  {9ac876d3-708a-4bc3-aad8-ed5a97a534b9}, !- Supply Side Inlet Node Name
+  {b3d699a3-575b-4e72-b7bc-22b14dbd2784}, !- Demand Side Outlet Node Name
+  {770abbb7-5307-4738-8c33-c6af8167db89}, !- Demand Side Inlet Node A
+  {395a2d07-3476-43e4-acdf-9b2381a1b358}, !- Supply Side Outlet Node A
   ,                                       !- Demand Side Inlet Node B
   ,                                       !- Supply Side Outlet Node B
   ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Demand Mixer Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Demand Splitter A Name
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Demand Mixer Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Demand Splitter A Name
   ,                                       !- Demand Splitter B Name
   ;                                       !- Supply Splitter Name
 
 OS:Node,
-  {234bf79c-4b65-438d-8c0e-13f06c694f72}, !- Handle
+  {a82ae679-3a88-46e5-a556-de26b905a321}, !- Handle
   Node 72,                                !- Name
-  {3c408e94-1a14-4105-8d4c-57e185e8d1d8}, !- Inlet Port
-  {bdc323ac-6f57-43c8-a213-76869b13f8e8}; !- Outlet Port
+  {9ac876d3-708a-4bc3-aad8-ed5a97a534b9}, !- Inlet Port
+  {9b00acf6-dcc0-4c5c-b617-e4cd778ffd38}; !- Outlet Port
 
 OS:Node,
-  {26b9b1f6-3a77-4388-8281-379bba4a306a}, !- Handle
+  {b01e7e68-e673-4b6a-85bc-9bb71c36ced1}, !- Handle
   Node 73,                                !- Name
-  {d4098cbf-d6e7-4a6e-a74d-228744072d40}, !- Inlet Port
-  {efd48d61-f50b-428a-8d2f-209aefd4820a}; !- Outlet Port
+  {64d026c7-2e25-4e4c-abfd-7d5847dfab78}, !- Inlet Port
+  {395a2d07-3476-43e4-acdf-9b2381a1b358}; !- Outlet Port
 
 OS:Connection,
-  {3c408e94-1a14-4105-8d4c-57e185e8d1d8}, !- Handle
-  {d3c0f56d-d937-4fce-8752-99cc7024dd20}, !- Name
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- Source Object
+  {9ac876d3-708a-4bc3-aad8-ed5a97a534b9}, !- Handle
+  {85febb8a-81f6-430a-8f9f-06841a889dfb}, !- Name
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- Source Object
   8,                                      !- Outlet Port
-  {234bf79c-4b65-438d-8c0e-13f06c694f72}, !- Target Object
+  {a82ae679-3a88-46e5-a556-de26b905a321}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {efd48d61-f50b-428a-8d2f-209aefd4820a}, !- Handle
-  {06842cf2-b7d4-4fca-8a76-13beb3a18a53}, !- Name
-  {26b9b1f6-3a77-4388-8281-379bba4a306a}, !- Source Object
+  {395a2d07-3476-43e4-acdf-9b2381a1b358}, !- Handle
+  {43f93ecf-6db5-4239-a1ad-ec26a38607d8}, !- Name
+  {b01e7e68-e673-4b6a-85bc-9bb71c36ced1}, !- Source Object
   3,                                      !- Outlet Port
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- Target Object
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- Target Object
   11;                                     !- Inlet Port
 
 OS:Node,
-  {dacb5919-7637-4b28-9ac3-624a309d93f2}, !- Handle
+  {3b20b242-81bc-4656-8392-f9ee455febc8}, !- Handle
   Node 74,                                !- Name
-  {308fe4bc-01e7-4c39-bb72-b45c913ee2e4}, !- Inlet Port
-  {4fbbab4c-24f1-4e5c-be4a-87dc8ded81c3}; !- Outlet Port
+  {770abbb7-5307-4738-8c33-c6af8167db89}, !- Inlet Port
+  {deffc94d-d1e3-4d47-8426-629eb20c71ca}; !- Outlet Port
 
 OS:Node,
-  {d8182cfc-d9fc-4959-979d-22fb8e0e1bc4}, !- Handle
+  {00e0b3f9-5140-421f-bd6c-52181641c2cb}, !- Handle
   Node 75,                                !- Name
-  {193b2ae5-0214-4217-b076-adf2662c42f9}, !- Inlet Port
-  {bbb91b39-4b8b-482c-88ba-781ff8c97129}; !- Outlet Port
+  {936fe0bd-a524-4ed0-b76b-c5eb546fb018}, !- Inlet Port
+  {b3d699a3-575b-4e72-b7bc-22b14dbd2784}; !- Outlet Port
 
 OS:Node,
-  {10a1998b-f4c9-499d-a6fd-34f777bd7415}, !- Handle
+  {fac4a905-d12a-4f7a-b68c-d03e472bea0a}, !- Handle
   Node 76,                                !- Name
-  {0d4b0082-6de2-4797-a6c4-9526609f1152}, !- Inlet Port
-  {e49afaea-6321-4fb6-8e07-a6f176fae502}; !- Outlet Port
+  {4d7ce014-8858-4315-b9d2-c1ef70f5e7f8}, !- Inlet Port
+  {3d864097-09b9-4449-8c9a-f66f619f2c85}; !- Outlet Port
 
 OS:Connection,
-  {308fe4bc-01e7-4c39-bb72-b45c913ee2e4}, !- Handle
-  {34314141-b546-4846-b951-d53502356d76}, !- Name
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- Source Object
+  {770abbb7-5307-4738-8c33-c6af8167db89}, !- Handle
+  {f5a74ad7-48e9-4d9c-992b-a08fc8635f57}, !- Name
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- Source Object
   10,                                     !- Outlet Port
-  {dacb5919-7637-4b28-9ac3-624a309d93f2}, !- Target Object
+  {3b20b242-81bc-4656-8392-f9ee455febc8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bbb91b39-4b8b-482c-88ba-781ff8c97129}, !- Handle
-  {41778399-ce31-4a8d-94c1-bf09cb038aa3}, !- Name
-  {d8182cfc-d9fc-4959-979d-22fb8e0e1bc4}, !- Source Object
+  {b3d699a3-575b-4e72-b7bc-22b14dbd2784}, !- Handle
+  {e0e0f850-22b0-46c9-8e8c-920290b0a674}, !- Name
+  {00e0b3f9-5140-421f-bd6c-52181641c2cb}, !- Source Object
   3,                                      !- Outlet Port
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- Target Object
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- Target Object
   9;                                      !- Inlet Port
 
 OS:AirLoopHVAC:ZoneSplitter,
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Handle
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Handle
   Air Loop HVAC Zone Splitter 2,          !- Name
-  {4fbbab4c-24f1-4e5c-be4a-87dc8ded81c3}, !- Inlet Node Name
-  {a9b00334-025d-4da8-9527-d6bf078e2038}, !- Outlet Node Name 1
-  {ca6c49ed-57c9-45b8-a039-1808ed247715}, !- Outlet Node Name 2
-  {1206cff6-3cae-4a80-8184-f077c5be8d8c}, !- Outlet Node Name 3
-  {edf49465-954d-4eae-abd1-b3001bcf82fa}, !- Outlet Node Name 4
-  {62d56964-2496-4825-b9ae-b26ae1b0398d}, !- Outlet Node Name 5
-  {9be4cd62-c3d8-4259-a94c-efd53ce23877}, !- Outlet Node Name 6
-  {6c04e586-8cea-478c-a677-3f8cbb5f4f3d}, !- Outlet Node Name 7
-  {ce00a0a3-c2b7-450f-8658-ac303b832efc}; !- Outlet Node Name 8
+  {deffc94d-d1e3-4d47-8426-629eb20c71ca}, !- Inlet Node Name
+  {1caa182a-46ff-4261-99db-fdfd6ee3f739}, !- Outlet Node Name 1
+  {33a38d02-2200-4d84-a2dd-c1ccd42f07c1}, !- Outlet Node Name 2
+  {74ae7993-7c54-4ff0-b6af-ef2cbd159222}, !- Outlet Node Name 3
+  {f22400f7-5bfc-48f8-b9b2-5cb2ab706456}, !- Outlet Node Name 4
+  {219465cc-5c09-40ec-9f2d-b581f387cac0}, !- Outlet Node Name 5
+  {2ca091e6-baad-453e-bac5-a7d9fe0ac5e9}, !- Outlet Node Name 6
+  {963e0a81-7f03-4534-9b04-de1275e0e43c}, !- Outlet Node Name 7
+  {0dc5cf0e-8c79-4282-8617-6c1eae974a93}; !- Outlet Node Name 8
 
 OS:AirLoopHVAC:ZoneMixer,
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Handle
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Handle
   Air Loop HVAC Zone Mixer 2,             !- Name
-  {193b2ae5-0214-4217-b076-adf2662c42f9}, !- Outlet Node Name
-  {90990327-befa-48cb-9bfd-59cdf0459fda}, !- Inlet Node Name 1
-  {8292e3f5-316e-4277-b97a-cfc59c3581e8}, !- Inlet Node Name 2
-  {aa41c35f-549f-4718-8578-50a190020456}, !- Inlet Node Name 3
-  {9df485fc-6d70-41d3-9a74-0a875583aa1b}, !- Inlet Node Name 4
-  {745f97e3-6f7e-481a-8c65-30658aec43b1}, !- Inlet Node Name 5
+  {936fe0bd-a524-4ed0-b76b-c5eb546fb018}, !- Outlet Node Name
+  {dfd84259-b857-4daf-b3ac-a4a1748268a0}, !- Inlet Node Name 1
+  {1a89a622-f0f7-432e-9b71-c48220ea5501}, !- Inlet Node Name 2
+  {071c698a-631d-4958-9559-387ae9c4126d}, !- Inlet Node Name 3
+  {30379c3f-32d8-4b61-bb6d-507010487fb3}, !- Inlet Node Name 4
+  {31db07bb-e62f-4398-ae0b-c012fc57b548}, !- Inlet Node Name 5
   ,                                       !- Inlet Node Name 6
   ,                                       !- Inlet Node Name 7
   ;                                       !- Inlet Node Name 8
 
 OS:Connection,
-  {4fbbab4c-24f1-4e5c-be4a-87dc8ded81c3}, !- Handle
-  {450b8ab3-2b6c-4911-a150-ea51524efed3}, !- Name
-  {dacb5919-7637-4b28-9ac3-624a309d93f2}, !- Source Object
+  {deffc94d-d1e3-4d47-8426-629eb20c71ca}, !- Handle
+  {375e80c1-4129-4cc6-a117-0e0935ed55f1}, !- Name
+  {3b20b242-81bc-4656-8392-f9ee455febc8}, !- Source Object
   3,                                      !- Outlet Port
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Target Object
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {193b2ae5-0214-4217-b076-adf2662c42f9}, !- Handle
-  {ee7d51e5-c89c-4716-9790-3d63106d9c2f}, !- Name
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Source Object
+  {936fe0bd-a524-4ed0-b76b-c5eb546fb018}, !- Handle
+  {4108fc62-3c1d-4f27-bf77-7c1c3565b3ea}, !- Name
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Source Object
   2,                                      !- Outlet Port
-  {d8182cfc-d9fc-4959-979d-22fb8e0e1bc4}, !- Target Object
+  {00e0b3f9-5140-421f-bd6c-52181641c2cb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Sizing:System,
-  {b46ff9c9-5e19-476d-82ee-4c10e2d36230}, !- Handle
-  {f924b720-1be0-4aab-a792-f3ebffe70c87}, !- AirLoop Name
+  {95466907-1193-40e5-8e3f-e5c1a1dc0a98}, !- Handle
+  {409753bc-a34e-406e-a9ea-703dba0d96f6}, !- AirLoop Name
   Sensible,                               !- Type of Load to Size On
   Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
-  0.3,                                    !- Minimum System Air Flow Ratio
+  0.3,                                    !- Central Heating Maximum System Air Flow Ratio
   7,                                      !- Preheat Design Temperature {C}
   0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
   12.8,                                   !- Precool Design Temperature {C}
@@ -4854,13 +4862,13 @@ OS:Sizing:System,
   OnOff;                                  !- Central Cooling Capacity Control Method
 
 OS:AvailabilityManagerAssignmentList,
-  {ccde1f43-1550-444e-beb6-cf9a63daa0cc}, !- Handle
+  {f395976a-e5ad-4174-9a0e-631820e91e30}, !- Handle
   Air Loop HVAC 1 AvailabilityManagerAssignmentList 1; !- Name
 
 OS:Fan:VariableVolume,
-  {b21ed246-333f-4f9e-b4ee-ecc62becd93f}, !- Handle
+  {47a69932-308c-46a9-b7f2-8c644a46824f}, !- Handle
   Fan Variable Volume 2,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   0.6045,                                 !- Fan Total Efficiency
   500,                                    !- Pressure Rise {Pa}
   Autosize,                               !- Maximum Flow Rate {m3/s}
@@ -4874,20 +4882,20 @@ OS:Fan:VariableVolume,
   -0.07292612,                            !- Fan Power Coefficient 3
   0.943739823,                            !- Fan Power Coefficient 4
   0,                                      !- Fan Power Coefficient 5
-  {c0681c48-5db5-4a52-a83e-c83a4a56de42}, !- Air Inlet Node Name
-  {d4098cbf-d6e7-4a6e-a74d-228744072d40}, !- Air Outlet Node Name
+  {d25ef28d-b605-4d64-952c-09c8eb8fdab9}, !- Air Inlet Node Name
+  {64d026c7-2e25-4e4c-abfd-7d5847dfab78}, !- Air Outlet Node Name
   ;                                       !- End-Use Subcategory
 
 OS:Coil:Heating:Water,
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Handle
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Handle
   Coil Heating Water 3,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {f066e3b4-9228-4a27-9362-8da07b58ef3f}, !- Water Inlet Node Name
-  {2a489dae-bc79-428f-bc16-6a44df1c3499}, !- Water Outlet Node Name
-  {33aebc9e-4d65-4c4c-add6-9c2a7e9b7c78}, !- Air Inlet Node Name
-  {58c1e61f-da30-469b-843d-874407ceedfe}, !- Air Outlet Node Name
+  {40e4cc8a-958f-45cc-8a0a-b34ddb03456d}, !- Water Inlet Node Name
+  {0a0789c5-6a97-4ce3-9aaa-6aaabf0e5d57}, !- Water Outlet Node Name
+  {df1dde00-4378-49a7-be8e-e1d924a496ab}, !- Air Inlet Node Name
+  {bb9303c7-5d5d-4908-bd7d-60c4d4d61eab}, !- Air Outlet Node Name
   ,                                       !- Performance Input Method
   ,                                       !- Rated Capacity {W}
   ,                                       !- Rated Inlet Water Temperature {C}
@@ -4897,9 +4905,9 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Coil:Cooling:Water,
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Handle
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Handle
   Coil Cooling Water 2,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- Design Water Flow Rate {m3/s}
   ,                                       !- Design Air Flow Rate {m3/s}
   ,                                       !- Design Inlet Water Temperature {C}
@@ -4907,22 +4915,22 @@ OS:Coil:Cooling:Water,
   ,                                       !- Design Outlet Air Temperature {C}
   ,                                       !- Design Inlet Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Design Outlet Air Humidity Ratio {kg-H2O/kg-air}
-  {43ec0ff6-a36b-4f50-ad19-8509601e69cb}, !- Water Inlet Node Name
-  {f21202f0-890a-4d65-9705-3837e34312d9}, !- Water Outlet Node Name
-  {8c4571ae-9ae7-4892-85ed-9c031e6b7e6f}, !- Air Inlet Node Name
-  {a32289ae-18ef-4e2b-b4a6-7609ff9fca9d}, !- Air Outlet Node Name
+  {3417ffe2-e225-4a50-b39d-ddf06edee7c0}, !- Water Inlet Node Name
+  {43d61dff-7a9f-4193-9d3b-8deac3fb7ea8}, !- Water Outlet Node Name
+  {fa824996-f130-4cab-ad3a-5baa37641009}, !- Air Inlet Node Name
+  {915fd242-eae1-474b-8093-8ad79fc517c9}, !- Air Outlet Node Name
   ,                                       !- Type of Analysis
   ;                                       !- Heat Exchanger Configuration
 
 OS:SetpointManager:Scheduled,
-  {dc810173-311b-4ada-8e5d-339e21c25e18}, !- Handle
+  {6f0a120b-c427-4359-8c69-4168b1510ee2}, !- Handle
   Setpoint Manager Scheduled 4,           !- Name
   Temperature,                            !- Control Variable
-  {72e04dca-f769-4328-977a-cba9066493b4}, !- Schedule Name
-  {26b9b1f6-3a77-4388-8281-379bba4a306a}; !- Setpoint Node or NodeList Name
+  {097d8012-59db-4e3d-bb3c-28a7d47e7edf}, !- Schedule Name
+  {b01e7e68-e673-4b6a-85bc-9bb71c36ced1}; !- Setpoint Node or NodeList Name
 
 OS:Controller:OutdoorAir,
-  {196f7ddb-ce4f-4257-90f8-e1eb8147a8a4}, !- Handle
+  {4a35b652-e946-420f-a640-9db7b5fca1f8}, !- Handle
   Controller Outdoor Air 2,               !- Name
   ,                                       !- Relief Air Outlet Node Name
   ,                                       !- Return Air Node Name
@@ -4942,7 +4950,7 @@ OS:Controller:OutdoorAir,
   ,                                       !- Minimum Outdoor Air Schedule Name
   ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
   ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
-  {a09a2c58-428a-4bf5-8eca-3c31285e8b3c}, !- Controller Mechanical Ventilation
+  {98743659-dff0-4649-a23e-ef8b0b4e751f}, !- Controller Mechanical Ventilation
   ,                                       !- Time of Day Economizer Control Schedule Name
   No,                                     !- High Humidity Control
   ,                                       !- Humidistat Control Zone Name
@@ -4951,135 +4959,135 @@ OS:Controller:OutdoorAir,
   BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
 
 OS:Controller:MechanicalVentilation,
-  {a09a2c58-428a-4bf5-8eca-3c31285e8b3c}, !- Handle
+  {98743659-dff0-4649-a23e-ef8b0b4e751f}, !- Handle
   Controller Mechanical Ventilation 2,    !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule
   ,                                       !- Demand Controlled Ventilation
   ZoneSum;                                !- System Outdoor Air Method
 
 OS:AirLoopHVAC:OutdoorAirSystem,
-  {86556706-6adc-4f53-bbdc-bb897c349f07}, !- Handle
+  {bdc88a72-537a-4639-adc6-6d6fbb5d8a18}, !- Handle
   Air Loop HVAC Outdoor Air System 2,     !- Name
-  {196f7ddb-ce4f-4257-90f8-e1eb8147a8a4}, !- Controller Name
+  {4a35b652-e946-420f-a640-9db7b5fca1f8}, !- Controller Name
   ,                                       !- Outdoor Air Equipment List Name
   ,                                       !- Availability Manager List Name
-  {00de4d90-b4a8-4b78-b687-e3b50c43c5c4}, !- Mixed Air Node Name
-  {02603500-57ba-4f7b-946e-acf897b5b64b}, !- Outdoor Air Stream Node Name
-  {8edf4f74-2a0f-4c81-8686-08cb6b06ee64}, !- Relief Air Stream Node Name
-  {bdc323ac-6f57-43c8-a213-76869b13f8e8}; !- Return Air Stream Node Name
+  {fb1f5a64-ea96-40ea-ae7f-c4b4d400c597}, !- Mixed Air Node Name
+  {b7840d3d-12a8-4a27-a9cf-8f5bc3b8ed65}, !- Outdoor Air Stream Node Name
+  {6071cd8d-3feb-434f-9375-2707943ea0b5}, !- Relief Air Stream Node Name
+  {9b00acf6-dcc0-4c5c-b617-e4cd778ffd38}; !- Return Air Stream Node Name
 
 OS:Node,
-  {bbab8f04-f7aa-4594-8d69-ee9e1a010077}, !- Handle
+  {4a49d0dd-8baa-437f-89e3-e04bc1afc14f}, !- Handle
   Node 77,                                !- Name
   ,                                       !- Inlet Port
-  {02603500-57ba-4f7b-946e-acf897b5b64b}; !- Outlet Port
+  {b7840d3d-12a8-4a27-a9cf-8f5bc3b8ed65}; !- Outlet Port
 
 OS:Connection,
-  {02603500-57ba-4f7b-946e-acf897b5b64b}, !- Handle
-  {4d45557e-7666-4ebe-80aa-72a16094e733}, !- Name
-  {bbab8f04-f7aa-4594-8d69-ee9e1a010077}, !- Source Object
+  {b7840d3d-12a8-4a27-a9cf-8f5bc3b8ed65}, !- Handle
+  {500195a7-6ae1-4501-a8d3-7ec6592986f6}, !- Name
+  {4a49d0dd-8baa-437f-89e3-e04bc1afc14f}, !- Source Object
   3,                                      !- Outlet Port
-  {86556706-6adc-4f53-bbdc-bb897c349f07}, !- Target Object
+  {bdc88a72-537a-4639-adc6-6d6fbb5d8a18}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Node,
-  {264eca53-f95a-4dfe-885a-d87edae09e93}, !- Handle
+  {985f8e9e-62d0-4fea-ad41-21ad2f725dfd}, !- Handle
   Node 78,                                !- Name
-  {8edf4f74-2a0f-4c81-8686-08cb6b06ee64}, !- Inlet Port
+  {6071cd8d-3feb-434f-9375-2707943ea0b5}, !- Inlet Port
   ;                                       !- Outlet Port
 
 OS:Connection,
-  {8edf4f74-2a0f-4c81-8686-08cb6b06ee64}, !- Handle
-  {ad93d812-00d7-4bca-bdf8-aa0b558d84db}, !- Name
-  {86556706-6adc-4f53-bbdc-bb897c349f07}, !- Source Object
+  {6071cd8d-3feb-434f-9375-2707943ea0b5}, !- Handle
+  {a5176485-5e34-4dc6-ae59-883a616565b0}, !- Name
+  {bdc88a72-537a-4639-adc6-6d6fbb5d8a18}, !- Source Object
   7,                                      !- Outlet Port
-  {264eca53-f95a-4dfe-885a-d87edae09e93}, !- Target Object
+  {985f8e9e-62d0-4fea-ad41-21ad2f725dfd}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bdc323ac-6f57-43c8-a213-76869b13f8e8}, !- Handle
-  {54a33a93-63d5-47c4-9a91-e767c49cb26e}, !- Name
-  {234bf79c-4b65-438d-8c0e-13f06c694f72}, !- Source Object
+  {9b00acf6-dcc0-4c5c-b617-e4cd778ffd38}, !- Handle
+  {5013f5ec-cafb-4bb6-a224-33bb20601f17}, !- Name
+  {a82ae679-3a88-46e5-a556-de26b905a321}, !- Source Object
   3,                                      !- Outlet Port
-  {86556706-6adc-4f53-bbdc-bb897c349f07}, !- Target Object
+  {bdc88a72-537a-4639-adc6-6d6fbb5d8a18}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Node,
-  {fe3ca1ba-045f-4c80-b42d-e4fdbf60be81}, !- Handle
+  {765e3c3e-8112-4d70-bf80-b20bdbe64481}, !- Handle
   Node 79,                                !- Name
-  {00de4d90-b4a8-4b78-b687-e3b50c43c5c4}, !- Inlet Port
-  {8c4571ae-9ae7-4892-85ed-9c031e6b7e6f}; !- Outlet Port
+  {fb1f5a64-ea96-40ea-ae7f-c4b4d400c597}, !- Inlet Port
+  {fa824996-f130-4cab-ad3a-5baa37641009}; !- Outlet Port
 
 OS:Connection,
-  {00de4d90-b4a8-4b78-b687-e3b50c43c5c4}, !- Handle
-  {33d9cd6f-6452-4a35-9e5d-89573249874c}, !- Name
-  {86556706-6adc-4f53-bbdc-bb897c349f07}, !- Source Object
+  {fb1f5a64-ea96-40ea-ae7f-c4b4d400c597}, !- Handle
+  {b7717677-eabf-431d-8df8-cc8126f4bb5c}, !- Name
+  {bdc88a72-537a-4639-adc6-6d6fbb5d8a18}, !- Source Object
   5,                                      !- Outlet Port
-  {fe3ca1ba-045f-4c80-b42d-e4fdbf60be81}, !- Target Object
+  {765e3c3e-8112-4d70-bf80-b20bdbe64481}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8c4571ae-9ae7-4892-85ed-9c031e6b7e6f}, !- Handle
-  {96b35f0a-d1fe-4046-a3c7-a330a0fe3e52}, !- Name
-  {fe3ca1ba-045f-4c80-b42d-e4fdbf60be81}, !- Source Object
+  {fa824996-f130-4cab-ad3a-5baa37641009}, !- Handle
+  {32e175a7-7fae-4c6a-887c-a0ed16a91fd8}, !- Name
+  {765e3c3e-8112-4d70-bf80-b20bdbe64481}, !- Source Object
   3,                                      !- Outlet Port
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Target Object
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Node,
-  {cf232603-4255-4884-be76-6314c707a230}, !- Handle
+  {f7b04d23-057c-4fe6-a537-889a1f06e5ee}, !- Handle
   Node 80,                                !- Name
-  {a32289ae-18ef-4e2b-b4a6-7609ff9fca9d}, !- Inlet Port
-  {33aebc9e-4d65-4c4c-add6-9c2a7e9b7c78}; !- Outlet Port
+  {915fd242-eae1-474b-8093-8ad79fc517c9}, !- Inlet Port
+  {df1dde00-4378-49a7-be8e-e1d924a496ab}; !- Outlet Port
 
 OS:Connection,
-  {a32289ae-18ef-4e2b-b4a6-7609ff9fca9d}, !- Handle
-  {ee251e5c-83c9-4311-8984-4e49e712162d}, !- Name
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Source Object
+  {915fd242-eae1-474b-8093-8ad79fc517c9}, !- Handle
+  {56fd5350-aa70-490f-9eba-2be4685f9583}, !- Name
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Source Object
   13,                                     !- Outlet Port
-  {cf232603-4255-4884-be76-6314c707a230}, !- Target Object
+  {f7b04d23-057c-4fe6-a537-889a1f06e5ee}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {33aebc9e-4d65-4c4c-add6-9c2a7e9b7c78}, !- Handle
-  {ecb45e5c-5e65-4760-b9b3-da76031708e6}, !- Name
-  {cf232603-4255-4884-be76-6314c707a230}, !- Source Object
+  {df1dde00-4378-49a7-be8e-e1d924a496ab}, !- Handle
+  {9c5fb9ab-6ee8-43b9-aea4-1057b46a737f}, !- Name
+  {f7b04d23-057c-4fe6-a537-889a1f06e5ee}, !- Source Object
   3,                                      !- Outlet Port
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Target Object
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Node,
-  {00520bde-a8b1-4242-8a00-f5904dad8cba}, !- Handle
+  {91f178d5-3acc-45c5-8f9b-a6cbcdede659}, !- Handle
   Node 81,                                !- Name
-  {58c1e61f-da30-469b-843d-874407ceedfe}, !- Inlet Port
-  {c0681c48-5db5-4a52-a83e-c83a4a56de42}; !- Outlet Port
+  {bb9303c7-5d5d-4908-bd7d-60c4d4d61eab}, !- Inlet Port
+  {d25ef28d-b605-4d64-952c-09c8eb8fdab9}; !- Outlet Port
 
 OS:Connection,
-  {58c1e61f-da30-469b-843d-874407ceedfe}, !- Handle
-  {0a44e4fc-ffd0-46b4-af97-de9eeb298416}, !- Name
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Source Object
+  {bb9303c7-5d5d-4908-bd7d-60c4d4d61eab}, !- Handle
+  {bccd928c-87a0-4b33-8b67-821117a372a9}, !- Name
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Source Object
   8,                                      !- Outlet Port
-  {00520bde-a8b1-4242-8a00-f5904dad8cba}, !- Target Object
+  {91f178d5-3acc-45c5-8f9b-a6cbcdede659}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c0681c48-5db5-4a52-a83e-c83a4a56de42}, !- Handle
-  {4bea2775-107e-458e-a70d-8131364a92e9}, !- Name
-  {00520bde-a8b1-4242-8a00-f5904dad8cba}, !- Source Object
+  {d25ef28d-b605-4d64-952c-09c8eb8fdab9}, !- Handle
+  {7b15892b-ad25-4a47-a9f7-e2cb582f002d}, !- Name
+  {91f178d5-3acc-45c5-8f9b-a6cbcdede659}, !- Source Object
   3,                                      !- Outlet Port
-  {b21ed246-333f-4f9e-b4ee-ecc62becd93f}, !- Target Object
+  {47a69932-308c-46a9-b7f2-8c644a46824f}, !- Target Object
   16;                                     !- Inlet Port
 
 OS:Connection,
-  {d4098cbf-d6e7-4a6e-a74d-228744072d40}, !- Handle
-  {d749a6df-515e-4140-a955-220c38fd6569}, !- Name
-  {b21ed246-333f-4f9e-b4ee-ecc62becd93f}, !- Source Object
+  {64d026c7-2e25-4e4c-abfd-7d5847dfab78}, !- Handle
+  {ffc84eb9-275f-4d14-bf44-07c6a5a5735c}, !- Name
+  {47a69932-308c-46a9-b7f2-8c644a46824f}, !- Source Object
   17,                                     !- Outlet Port
-  {26b9b1f6-3a77-4388-8281-379bba4a306a}, !- Target Object
+  {b01e7e68-e673-4b6a-85bc-9bb71c36ced1}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PlantLoop,
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Handle
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Handle
   Hot Water Loop 1,                       !- Name
   Water,                                  !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -5087,21 +5095,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {55580731-e630-497a-95c9-92b5369b7120}, !- Loop Temperature Setpoint Node Name
+  {b018037a-6900-4cbb-80c9-4cd4580a4d4a}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {ac1b655f-3b19-49ba-9a5a-47d4890d0fb6}, !- Plant Side Inlet Node Name
-  {e1d0e338-9b25-4f01-be9d-7be9d6b06cf2}, !- Plant Side Outlet Node Name
+  {26a9b846-b713-46d1-bc63-496034e92ab2}, !- Plant Side Inlet Node Name
+  {5432ad9f-ea6f-4605-b16f-e0c9c3eadff2}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {784f2ce3-f21a-418d-b821-6af5090b2f83}, !- Demand Side Inlet Node Name
-  {91815eba-2f11-4d17-8a22-d279dab99c4a}, !- Demand Side Outlet Node Name
+  {5a7902a6-5c75-432c-8277-03a6d52bac19}, !- Demand Side Inlet Node Name
+  {3dcc6e24-815b-43c8-b495-ba8722f5be9f}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {74e6eafc-fe4d-476d-a158-1510b32a3c67}, !- Availability Manager List Name
+  {facfd21c-6bd4-4c9e-ab8c-8fcffa7682d6}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -5109,14 +5117,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Demand Mixer Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Demand Splitter Name
-  {6aedec3b-894c-4c58-b200-13399111a4d2}, !- Supply Mixer Name
-  {36fc620b-b362-4555-9901-90d907570c5d}; !- Supply Splitter Name
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Demand Mixer Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Demand Splitter Name
+  {879221b3-c288-46b9-b053-e20e219cd2bc}, !- Supply Mixer Name
+  {a52ca5a2-500c-4384-b2e9-62b2c8d09a00}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {6f63513d-475a-4b88-9b9c-5125ff7ea3e8}, !- Handle
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Plant or Condenser Loop Name
+  {a70f4e30-093e-4a73-a84a-a6c61fff5b75}, !- Handle
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Plant or Condenser Loop Name
   Heating,                                !- Loop Type
   82,                                     !- Design Loop Exit Temperature {C}
   11,                                     !- Loop Design Temperature Difference {deltaC}
@@ -5125,142 +5133,142 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {324804a7-7c94-45ce-8273-4c412f9ab2c0}, !- Handle
+  {1c45366f-e0e7-4b27-acbb-fe6c76384d83}, !- Handle
   Node 82,                                !- Name
-  {ac1b655f-3b19-49ba-9a5a-47d4890d0fb6}, !- Inlet Port
-  {36124561-b715-404f-9d56-0ad280c20928}; !- Outlet Port
+  {26a9b846-b713-46d1-bc63-496034e92ab2}, !- Inlet Port
+  {cbcc1e85-6165-466e-88f5-ab76bbf6cdf3}; !- Outlet Port
 
 OS:Node,
-  {55580731-e630-497a-95c9-92b5369b7120}, !- Handle
+  {b018037a-6900-4cbb-80c9-4cd4580a4d4a}, !- Handle
   Node 83,                                !- Name
-  {4e632b3b-039d-4b14-ab45-c75913ca7a4e}, !- Inlet Port
-  {e1d0e338-9b25-4f01-be9d-7be9d6b06cf2}; !- Outlet Port
+  {83bfd4d9-c49b-406b-868b-5074bf00ef16}, !- Inlet Port
+  {5432ad9f-ea6f-4605-b16f-e0c9c3eadff2}; !- Outlet Port
 
 OS:Node,
-  {cee177cf-6d98-477e-95d6-5897ee1c95ef}, !- Handle
+  {94a5afdb-14e4-4ff4-8ef4-7e76e9521a97}, !- Handle
   Node 84,                                !- Name
-  {1f28f534-23ef-42f0-a802-c85ee341394e}, !- Inlet Port
-  {36d940ef-d6dd-40a4-8627-8c38b3bc6f1e}; !- Outlet Port
+  {0e3f30b3-76cf-40e2-ad35-5fb19f83f240}, !- Inlet Port
+  {e6e0dd76-68ae-407d-9621-9b20b2f1b37f}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {6aedec3b-894c-4c58-b200-13399111a4d2}, !- Handle
+  {879221b3-c288-46b9-b053-e20e219cd2bc}, !- Handle
   Connector Mixer 7,                      !- Name
-  {e19a9a3b-3eb6-4253-9583-b5afdfd27eb9}, !- Outlet Branch Name
-  {fe140ede-3a9f-4796-a2ef-4b6bd21ad7cf}, !- Inlet Branch Name 1
-  {7064def6-efa4-4f07-a81f-9b2631dd6a38}; !- Inlet Branch Name 2
+  {f0a85b29-92bc-4177-8f2d-603496b85d47}, !- Outlet Branch Name
+  {01ae1476-8471-477e-8efe-f4fd1962f333}, !- Inlet Branch Name 1
+  {852bad5d-cac8-4c5a-a91f-b955f004f8ad}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {36fc620b-b362-4555-9901-90d907570c5d}, !- Handle
+  {a52ca5a2-500c-4384-b2e9-62b2c8d09a00}, !- Handle
   Connector Splitter 7,                   !- Name
-  {9bad8539-c95f-4e5b-ab61-24c596cd1b17}, !- Inlet Branch Name
-  {1f28f534-23ef-42f0-a802-c85ee341394e}, !- Outlet Branch Name 1
-  {d3d8def0-5d85-40ed-aa10-4fb3b3bf7b22}; !- Outlet Branch Name 2
+  {d9176ded-2e5e-465b-8330-cac40f044877}, !- Inlet Branch Name
+  {0e3f30b3-76cf-40e2-ad35-5fb19f83f240}, !- Outlet Branch Name 1
+  {31813162-5321-48af-8289-de6e66ed54a9}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {ac1b655f-3b19-49ba-9a5a-47d4890d0fb6}, !- Handle
-  {7ba61653-73b7-4f44-8aee-0c5921e6b330}, !- Name
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Source Object
+  {26a9b846-b713-46d1-bc63-496034e92ab2}, !- Handle
+  {451e2b4c-caae-4942-ab23-3261aaf28c40}, !- Name
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Source Object
   14,                                     !- Outlet Port
-  {324804a7-7c94-45ce-8273-4c412f9ab2c0}, !- Target Object
+  {1c45366f-e0e7-4b27-acbb-fe6c76384d83}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {1f28f534-23ef-42f0-a802-c85ee341394e}, !- Handle
-  {97430e7c-0e2e-4326-a89d-a89cee796877}, !- Name
-  {36fc620b-b362-4555-9901-90d907570c5d}, !- Source Object
+  {0e3f30b3-76cf-40e2-ad35-5fb19f83f240}, !- Handle
+  {0e999b49-670d-4154-8ccb-1ed27b7ecf6b}, !- Name
+  {a52ca5a2-500c-4384-b2e9-62b2c8d09a00}, !- Source Object
   3,                                      !- Outlet Port
-  {cee177cf-6d98-477e-95d6-5897ee1c95ef}, !- Target Object
+  {94a5afdb-14e4-4ff4-8ef4-7e76e9521a97}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {e1d0e338-9b25-4f01-be9d-7be9d6b06cf2}, !- Handle
-  {deafba05-15ae-44ed-aecb-71a4980f4f1a}, !- Name
-  {55580731-e630-497a-95c9-92b5369b7120}, !- Source Object
+  {5432ad9f-ea6f-4605-b16f-e0c9c3eadff2}, !- Handle
+  {526ae6ae-e22a-4985-acdd-1ee790c75576}, !- Name
+  {b018037a-6900-4cbb-80c9-4cd4580a4d4a}, !- Source Object
   3,                                      !- Outlet Port
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Target Object
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {7c09dead-052b-42de-a986-2655d3bd13ca}, !- Handle
+  {438a06db-66c7-42c2-a04e-5b3af9f570c2}, !- Handle
   Node 85,                                !- Name
-  {784f2ce3-f21a-418d-b821-6af5090b2f83}, !- Inlet Port
-  {2269deb4-2d43-499c-9dd7-ff5bf359ff32}; !- Outlet Port
+  {5a7902a6-5c75-432c-8277-03a6d52bac19}, !- Inlet Port
+  {68f5289d-e133-4f83-b611-75030d55970f}; !- Outlet Port
 
 OS:Node,
-  {5c3b9d46-560c-4aed-af05-906102523a36}, !- Handle
+  {86ba865f-6a3a-4aa7-8a19-b88ec0643acb}, !- Handle
   Node 86,                                !- Name
-  {a20e65a6-051f-4faa-bdb7-e8829a279d19}, !- Inlet Port
-  {91815eba-2f11-4d17-8a22-d279dab99c4a}; !- Outlet Port
+  {fb1bbf5f-f0a7-40c8-bade-4259a35be505}, !- Inlet Port
+  {3dcc6e24-815b-43c8-b495-ba8722f5be9f}; !- Outlet Port
 
 OS:Node,
-  {ad08a98d-f471-4428-a923-4e3d33103204}, !- Handle
+  {d249fbb1-a320-4b96-88e6-84988f215c6d}, !- Handle
   Node 87,                                !- Name
-  {d1c9a8aa-33a6-4d4d-b58a-bbcbbb3daa1d}, !- Inlet Port
-  {cc666ba6-d50a-4324-ad8b-270cc70534ba}; !- Outlet Port
+  {8b5699d4-a451-4d42-af5c-83db11b99e9c}, !- Inlet Port
+  {3573ba55-b06e-42c0-9b49-abb838a02443}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Handle
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Handle
   Connector Mixer 8,                      !- Name
-  {f084e99f-8c3d-433d-9483-74b23686f566}, !- Outlet Branch Name
-  {cc3bdef4-40cb-462b-8eb5-1240868255ed}, !- Inlet Branch Name 1
-  {0dc6d3fc-a4e3-431d-83e6-c4612337587e}, !- Inlet Branch Name 2
-  {11279a12-ece7-42b2-8cbe-c74c868f527d}, !- Inlet Branch Name 3
-  {51051964-0414-408a-ad40-92188ffc4931}, !- Inlet Branch Name 4
-  {41386c16-6d4d-4321-8594-156b58d7b75d}, !- Inlet Branch Name 5
-  {19c67d46-f739-422b-933e-fab090eb0b57}, !- Inlet Branch Name 6
-  {b6207458-cd8c-4ccc-af5e-7d7a3ace66ac}, !- Inlet Branch Name 7
-  {46511e3b-8748-4dec-904f-dbc9084d16d6}, !- Inlet Branch Name 8
-  {978dd3ff-d7f4-4102-ab67-fbe26637e62f}, !- Inlet Branch Name 9
-  {8bbafbc2-6ec1-4da8-bbc8-0cb45c7d547b}; !- Inlet Branch Name 10
+  {8c3eec38-2c3d-449e-a8be-1003c0c5cf09}, !- Outlet Branch Name
+  {8e6cd72d-e519-4448-9494-ead51d5f17e7}, !- Inlet Branch Name 1
+  {585219ea-0957-4d97-ba1f-f8aa6ff6fe73}, !- Inlet Branch Name 2
+  {ecc18424-615e-444c-bfb2-816d9e396818}, !- Inlet Branch Name 3
+  {a491e700-0d90-4a8d-93dd-42ac6f76242b}, !- Inlet Branch Name 4
+  {1b9b96cf-dd6d-46fe-96fa-d200085ffd90}, !- Inlet Branch Name 5
+  {5fe15c42-d441-4be3-9bac-c4c6212707e5}, !- Inlet Branch Name 6
+  {bb11889f-1edb-4d65-b774-75ae18cb8c59}, !- Inlet Branch Name 7
+  {15c34fd4-fb56-46ac-9dcf-2835806f715e}, !- Inlet Branch Name 8
+  {594597e3-b455-408d-81fd-a1013d6c3988}, !- Inlet Branch Name 9
+  {a722af56-46d6-4ba7-8161-dfa02ec565c6}; !- Inlet Branch Name 10
 
 OS:Connector:Splitter,
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Handle
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Handle
   Connector Splitter 8,                   !- Name
-  {e722291e-ece4-4993-b07b-6d7ceb0a3f82}, !- Inlet Branch Name
-  {d1c9a8aa-33a6-4d4d-b58a-bbcbbb3daa1d}, !- Outlet Branch Name 1
-  {f182e312-62ab-43ec-bc5e-9cafd3b5d21d}, !- Outlet Branch Name 2
-  {37aa0af5-2509-4ada-adcd-6b82a719ee2c}, !- Outlet Branch Name 3
-  {e15734dd-822f-4fec-a6a8-a3396f91ba31}, !- Outlet Branch Name 4
-  {ef97fedc-1df9-47a3-8dee-50e1347e01dd}, !- Outlet Branch Name 5
-  {03e640fa-6b04-487a-9203-af11f621534a}, !- Outlet Branch Name 6
-  {87e898cb-2722-4c18-a167-5f32fd837b9d}, !- Outlet Branch Name 7
-  {e663dc16-03f3-4577-bb31-9fd53061b3cf}, !- Outlet Branch Name 8
-  {45b5b821-1f5f-49b8-94e4-b4bec62ace52}, !- Outlet Branch Name 9
-  {1540095d-b2cf-4b4d-ad03-27188c3bf055}; !- Outlet Branch Name 10
+  {2be786f9-a1c4-4a41-bad1-928ad1c11261}, !- Inlet Branch Name
+  {8b5699d4-a451-4d42-af5c-83db11b99e9c}, !- Outlet Branch Name 1
+  {1d425c84-d4b3-4708-8d2e-1d484433ff8d}, !- Outlet Branch Name 2
+  {e5498cd0-8d2f-4817-b0c9-ec8d79dd6f28}, !- Outlet Branch Name 3
+  {1a51ba8b-cbf2-42ca-b052-475cd810a946}, !- Outlet Branch Name 4
+  {51ae1093-0806-453c-8a82-7f35a81f5f2d}, !- Outlet Branch Name 5
+  {48c66872-d7b1-4662-bb82-4c74386f7e88}, !- Outlet Branch Name 6
+  {2aa13d57-c038-4a54-b5be-e4266cee36ed}, !- Outlet Branch Name 7
+  {75ff64a1-0646-41fc-8eca-7a372c33432c}, !- Outlet Branch Name 8
+  {ae7e397d-199a-42bd-bea0-283cf5a6a8ff}, !- Outlet Branch Name 9
+  {79a38c81-9ae9-443b-b24a-dc410870a41d}; !- Outlet Branch Name 10
 
 OS:Connection,
-  {784f2ce3-f21a-418d-b821-6af5090b2f83}, !- Handle
-  {df266539-e22f-426c-b17d-7ea36b79ab20}, !- Name
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Source Object
+  {5a7902a6-5c75-432c-8277-03a6d52bac19}, !- Handle
+  {279aaa1f-ff27-4859-b43b-81a5ab3b95ef}, !- Name
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Source Object
   17,                                     !- Outlet Port
-  {7c09dead-052b-42de-a986-2655d3bd13ca}, !- Target Object
+  {438a06db-66c7-42c2-a04e-5b3af9f570c2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {d1c9a8aa-33a6-4d4d-b58a-bbcbbb3daa1d}, !- Handle
-  {44ada818-a9ed-40c7-8c36-c1a175caaa59}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {8b5699d4-a451-4d42-af5c-83db11b99e9c}, !- Handle
+  {64801935-0cee-4c4e-8c80-9a381dd2c797}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   3,                                      !- Outlet Port
-  {ad08a98d-f471-4428-a923-4e3d33103204}, !- Target Object
+  {d249fbb1-a320-4b96-88e6-84988f215c6d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {91815eba-2f11-4d17-8a22-d279dab99c4a}, !- Handle
-  {0f6822de-0a02-49ba-afd4-b9c3d2d512f9}, !- Name
-  {5c3b9d46-560c-4aed-af05-906102523a36}, !- Source Object
+  {3dcc6e24-815b-43c8-b495-ba8722f5be9f}, !- Handle
+  {0e0067da-e6b3-47a6-bbb8-82defaea58db}, !- Name
+  {86ba865f-6a3a-4aa7-8a19-b88ec0643acb}, !- Source Object
   3,                                      !- Outlet Port
-  {0cbac993-95f6-4f92-8604-0bca154b7951}, !- Target Object
+  {f856023c-3160-4706-a328-bbca5066f141}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {74e6eafc-fe4d-476d-a158-1510b32a3c67}, !- Handle
+  {facfd21c-6bd4-4c9e-ab8c-8fcffa7682d6}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList 3; !- Name
 
 OS:Pump:VariableSpeed,
-  {dbb5959a-7393-4acf-ab45-9baea02d75fa}, !- Handle
+  {fa83f8db-a9be-47fd-bb52-24a2703cfe64}, !- Handle
   Pump Variable Speed 4,                  !- Name
-  {36124561-b715-404f-9d56-0ad280c20928}, !- Inlet Node Name
-  {ec24daa4-8104-4937-be69-e6b421b63e30}, !- Outlet Node Name
+  {cbcc1e85-6165-466e-88f5-ab76bbf6cdf3}, !- Inlet Node Name
+  {b32b7b8b-7db4-4bdb-94bf-f83a4b9db818}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -5289,20 +5297,20 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Boiler:HotWater,
-  {700bad59-a62a-40ec-8476-8142bfb9790a}, !- Handle
+  {35b1c5a7-3fad-4ccf-b588-f2b706e0e083}, !- Handle
   Boiler Hot Water 2,                     !- Name
   ,                                       !- Fuel Type
   ,                                       !- Nominal Capacity {W}
   ,                                       !- Nominal Thermal Efficiency
   LeavingBoiler,                          !- Efficiency Curve Temperature Evaluation Variable
-  {6a1a48fc-819b-4348-9c33-5c6f9cfada17}, !- Normalized Boiler Efficiency Curve Name
+  {6b073d54-5b64-40b9-851e-49d303dc7d0a}, !- Normalized Boiler Efficiency Curve Name
   ,                                       !- Design Water Outlet Temperature {C}
   ,                                       !- Design Water Flow Rate {m3/s}
   ,                                       !- Minimum Part Load Ratio
   ,                                       !- Maximum Part Load Ratio
   ,                                       !- Optimum Part Load Ratio
-  {36d940ef-d6dd-40a4-8627-8c38b3bc6f1e}, !- Boiler Water Inlet Node Name
-  {c59624ac-fcae-489d-a54a-bac5f00876a2}, !- Boiler Water Outlet Node Name
+  {e6e0dd76-68ae-407d-9621-9b20b2f1b37f}, !- Boiler Water Inlet Node Name
+  {d6d317d3-7c57-447a-85bb-f076ed51e597}, !- Boiler Water Outlet Node Name
   99,                                     !- Water Outlet Upper Temperature Limit {C}
   ConstantFlow,                           !- Boiler Flow Mode
   0,                                      !- Parasitic Electric Load {W}
@@ -5310,7 +5318,7 @@ OS:Boiler:HotWater,
   General;                                !- End-Use Subcategory
 
 OS:Curve:Biquadratic,
-  {6a1a48fc-819b-4348-9c33-5c6f9cfada17}, !- Handle
+  {6b073d54-5b64-40b9-851e-49d303dc7d0a}, !- Handle
   Boiler Efficiency 1,                    !- Name
   1,                                      !- Coefficient1 Constant
   0,                                      !- Coefficient2 x
@@ -5329,199 +5337,199 @@ OS:Curve:Biquadratic,
   Dimensionless;                          !- Output Unit Type
 
 OS:Node,
-  {ad4ca220-884e-4d57-b5d6-0b0eca8a57c2}, !- Handle
+  {9d17a723-de76-4754-9a3e-f8814d323843}, !- Handle
   Node 88,                                !- Name
-  {ec24daa4-8104-4937-be69-e6b421b63e30}, !- Inlet Port
-  {9bad8539-c95f-4e5b-ab61-24c596cd1b17}; !- Outlet Port
+  {b32b7b8b-7db4-4bdb-94bf-f83a4b9db818}, !- Inlet Port
+  {d9176ded-2e5e-465b-8330-cac40f044877}; !- Outlet Port
 
 OS:Connection,
-  {36124561-b715-404f-9d56-0ad280c20928}, !- Handle
-  {d48d7846-bb3d-414f-bdeb-d411871b1ebe}, !- Name
-  {324804a7-7c94-45ce-8273-4c412f9ab2c0}, !- Source Object
+  {cbcc1e85-6165-466e-88f5-ab76bbf6cdf3}, !- Handle
+  {6d83cd85-904e-4c18-8648-f4a197f4c8ce}, !- Name
+  {1c45366f-e0e7-4b27-acbb-fe6c76384d83}, !- Source Object
   3,                                      !- Outlet Port
-  {dbb5959a-7393-4acf-ab45-9baea02d75fa}, !- Target Object
+  {fa83f8db-a9be-47fd-bb52-24a2703cfe64}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {ec24daa4-8104-4937-be69-e6b421b63e30}, !- Handle
-  {a61a1031-9c57-4435-9d66-88004de0efaa}, !- Name
-  {dbb5959a-7393-4acf-ab45-9baea02d75fa}, !- Source Object
+  {b32b7b8b-7db4-4bdb-94bf-f83a4b9db818}, !- Handle
+  {31e6d4c8-0e26-404e-b086-e0ebf7c79422}, !- Name
+  {fa83f8db-a9be-47fd-bb52-24a2703cfe64}, !- Source Object
   3,                                      !- Outlet Port
-  {ad4ca220-884e-4d57-b5d6-0b0eca8a57c2}, !- Target Object
+  {9d17a723-de76-4754-9a3e-f8814d323843}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {9bad8539-c95f-4e5b-ab61-24c596cd1b17}, !- Handle
-  {2a17a2a1-cc2c-42d6-89c6-8370cd112a5d}, !- Name
-  {ad4ca220-884e-4d57-b5d6-0b0eca8a57c2}, !- Source Object
+  {d9176ded-2e5e-465b-8330-cac40f044877}, !- Handle
+  {8131b349-fb3d-4556-b63f-f6b404861c3e}, !- Name
+  {9d17a723-de76-4754-9a3e-f8814d323843}, !- Source Object
   3,                                      !- Outlet Port
-  {36fc620b-b362-4555-9901-90d907570c5d}, !- Target Object
+  {a52ca5a2-500c-4384-b2e9-62b2c8d09a00}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {66774887-bbd2-4c2d-8248-a75921b28d07}, !- Handle
+  {8e9596a4-2ae7-4e8d-8e47-6188e11b6d45}, !- Handle
   Node 89,                                !- Name
-  {c59624ac-fcae-489d-a54a-bac5f00876a2}, !- Inlet Port
-  {fe140ede-3a9f-4796-a2ef-4b6bd21ad7cf}; !- Outlet Port
+  {d6d317d3-7c57-447a-85bb-f076ed51e597}, !- Inlet Port
+  {01ae1476-8471-477e-8efe-f4fd1962f333}; !- Outlet Port
 
 OS:Connection,
-  {36d940ef-d6dd-40a4-8627-8c38b3bc6f1e}, !- Handle
-  {f10f66ee-2c17-46d7-8fc1-9b84b5ff4d63}, !- Name
-  {cee177cf-6d98-477e-95d6-5897ee1c95ef}, !- Source Object
+  {e6e0dd76-68ae-407d-9621-9b20b2f1b37f}, !- Handle
+  {7e179e12-f3a7-481a-a258-b9503e42cf80}, !- Name
+  {94a5afdb-14e4-4ff4-8ef4-7e76e9521a97}, !- Source Object
   3,                                      !- Outlet Port
-  {700bad59-a62a-40ec-8476-8142bfb9790a}, !- Target Object
+  {35b1c5a7-3fad-4ccf-b588-f2b706e0e083}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Connection,
-  {c59624ac-fcae-489d-a54a-bac5f00876a2}, !- Handle
-  {a02dbd33-8640-4234-aea1-b07fe8f61aea}, !- Name
-  {700bad59-a62a-40ec-8476-8142bfb9790a}, !- Source Object
+  {d6d317d3-7c57-447a-85bb-f076ed51e597}, !- Handle
+  {a76cf23c-5a46-4be6-b8bf-4a3d7afe3896}, !- Name
+  {35b1c5a7-3fad-4ccf-b588-f2b706e0e083}, !- Source Object
   13,                                     !- Outlet Port
-  {66774887-bbd2-4c2d-8248-a75921b28d07}, !- Target Object
+  {8e9596a4-2ae7-4e8d-8e47-6188e11b6d45}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {fe140ede-3a9f-4796-a2ef-4b6bd21ad7cf}, !- Handle
-  {e758fa25-5535-430d-b844-9f66b3c503be}, !- Name
-  {66774887-bbd2-4c2d-8248-a75921b28d07}, !- Source Object
+  {01ae1476-8471-477e-8efe-f4fd1962f333}, !- Handle
+  {a883ce42-52b7-438f-8266-0e3437faffaa}, !- Name
+  {8e9596a4-2ae7-4e8d-8e47-6188e11b6d45}, !- Source Object
   3,                                      !- Outlet Port
-  {6aedec3b-894c-4c58-b200-13399111a4d2}, !- Target Object
+  {879221b3-c288-46b9-b053-e20e219cd2bc}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {1aa1c965-b434-4c1c-9fdc-674900d1f8f0}, !- Handle
+  {5d1d73c9-bd54-47b8-8d55-14e0a8c4b5ba}, !- Handle
   Pipe Adiabatic 16,                      !- Name
-  {61a601d5-5c7f-4652-8142-c2b96379f61c}, !- Inlet Node Name
-  {b28f3ae4-3e88-4fb1-a011-3cf8f6dae519}; !- Outlet Node Name
+  {ede65005-b3af-469a-930b-f3e97e96a8e4}, !- Inlet Node Name
+  {a52dd39d-3eb7-4059-bd7d-57ad3c1505ad}; !- Outlet Node Name
 
 OS:Node,
-  {a8c9fab0-e0cc-4270-8149-3b16064b0b9b}, !- Handle
+  {1211fbe0-0274-43cd-981d-e9b61f5d2a83}, !- Handle
   Node 90,                                !- Name
-  {d3d8def0-5d85-40ed-aa10-4fb3b3bf7b22}, !- Inlet Port
-  {61a601d5-5c7f-4652-8142-c2b96379f61c}; !- Outlet Port
+  {31813162-5321-48af-8289-de6e66ed54a9}, !- Inlet Port
+  {ede65005-b3af-469a-930b-f3e97e96a8e4}; !- Outlet Port
 
 OS:Connection,
-  {d3d8def0-5d85-40ed-aa10-4fb3b3bf7b22}, !- Handle
-  {3fde31a8-b743-42fd-b9a2-ea1db5cac885}, !- Name
-  {36fc620b-b362-4555-9901-90d907570c5d}, !- Source Object
+  {31813162-5321-48af-8289-de6e66ed54a9}, !- Handle
+  {6f5289c4-1750-4800-b39b-d340d82c2a51}, !- Name
+  {a52ca5a2-500c-4384-b2e9-62b2c8d09a00}, !- Source Object
   4,                                      !- Outlet Port
-  {a8c9fab0-e0cc-4270-8149-3b16064b0b9b}, !- Target Object
+  {1211fbe0-0274-43cd-981d-e9b61f5d2a83}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {38259880-4b6e-426d-8b3c-187a39887273}, !- Handle
+  {6fc1cd87-6102-4ea9-b693-d0b38d1a729e}, !- Handle
   Node 91,                                !- Name
-  {b28f3ae4-3e88-4fb1-a011-3cf8f6dae519}, !- Inlet Port
-  {7064def6-efa4-4f07-a81f-9b2631dd6a38}; !- Outlet Port
+  {a52dd39d-3eb7-4059-bd7d-57ad3c1505ad}, !- Inlet Port
+  {852bad5d-cac8-4c5a-a91f-b955f004f8ad}; !- Outlet Port
 
 OS:Connection,
-  {61a601d5-5c7f-4652-8142-c2b96379f61c}, !- Handle
-  {4cd94565-ebc9-47ec-a5eb-bf2c80aea5e0}, !- Name
-  {a8c9fab0-e0cc-4270-8149-3b16064b0b9b}, !- Source Object
+  {ede65005-b3af-469a-930b-f3e97e96a8e4}, !- Handle
+  {12059fba-b052-44bd-8d55-ced51b885678}, !- Name
+  {1211fbe0-0274-43cd-981d-e9b61f5d2a83}, !- Source Object
   3,                                      !- Outlet Port
-  {1aa1c965-b434-4c1c-9fdc-674900d1f8f0}, !- Target Object
+  {5d1d73c9-bd54-47b8-8d55-14e0a8c4b5ba}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b28f3ae4-3e88-4fb1-a011-3cf8f6dae519}, !- Handle
-  {96c92396-dadb-437e-b22b-81a4af0830ad}, !- Name
-  {1aa1c965-b434-4c1c-9fdc-674900d1f8f0}, !- Source Object
+  {a52dd39d-3eb7-4059-bd7d-57ad3c1505ad}, !- Handle
+  {90f1d2ce-c7c9-4c45-836b-ab83bfc98407}, !- Name
+  {5d1d73c9-bd54-47b8-8d55-14e0a8c4b5ba}, !- Source Object
   3,                                      !- Outlet Port
-  {38259880-4b6e-426d-8b3c-187a39887273}, !- Target Object
+  {6fc1cd87-6102-4ea9-b693-d0b38d1a729e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7064def6-efa4-4f07-a81f-9b2631dd6a38}, !- Handle
-  {319f88bf-cc31-477e-adb2-501e6ea83109}, !- Name
-  {38259880-4b6e-426d-8b3c-187a39887273}, !- Source Object
+  {852bad5d-cac8-4c5a-a91f-b955f004f8ad}, !- Handle
+  {9967face-dc00-4d77-87cb-40377f6bd1f2}, !- Name
+  {6fc1cd87-6102-4ea9-b693-d0b38d1a729e}, !- Source Object
   3,                                      !- Outlet Port
-  {6aedec3b-894c-4c58-b200-13399111a4d2}, !- Target Object
+  {879221b3-c288-46b9-b053-e20e219cd2bc}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {47811fbc-18c2-4c7c-afb9-bf96aa10902e}, !- Handle
+  {bb87a8ec-805d-4677-b278-7c281c18cd16}, !- Handle
   Pipe Adiabatic 17,                      !- Name
-  {cc666ba6-d50a-4324-ad8b-270cc70534ba}, !- Inlet Node Name
-  {2e313d38-9b52-47c7-9ecd-7408c97b8be4}; !- Outlet Node Name
+  {3573ba55-b06e-42c0-9b49-abb838a02443}, !- Inlet Node Name
+  {e77c6642-b8ee-4aa6-ae4b-6341d8942f9b}; !- Outlet Node Name
 
 OS:Node,
-  {0db9fecb-4aa8-4196-85da-e734c64832e0}, !- Handle
+  {8715d4ed-6b46-4c35-bb38-40cd5136e09a}, !- Handle
   Node 92,                                !- Name
-  {2e313d38-9b52-47c7-9ecd-7408c97b8be4}, !- Inlet Port
-  {cc3bdef4-40cb-462b-8eb5-1240868255ed}; !- Outlet Port
+  {e77c6642-b8ee-4aa6-ae4b-6341d8942f9b}, !- Inlet Port
+  {8e6cd72d-e519-4448-9494-ead51d5f17e7}; !- Outlet Port
 
 OS:Connection,
-  {cc666ba6-d50a-4324-ad8b-270cc70534ba}, !- Handle
-  {d3bc0a5a-639e-4872-8cf1-65062c7ea065}, !- Name
-  {ad08a98d-f471-4428-a923-4e3d33103204}, !- Source Object
+  {3573ba55-b06e-42c0-9b49-abb838a02443}, !- Handle
+  {85688ad7-480e-4d50-8b53-c480f5ff5571}, !- Name
+  {d249fbb1-a320-4b96-88e6-84988f215c6d}, !- Source Object
   3,                                      !- Outlet Port
-  {47811fbc-18c2-4c7c-afb9-bf96aa10902e}, !- Target Object
+  {bb87a8ec-805d-4677-b278-7c281c18cd16}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2e313d38-9b52-47c7-9ecd-7408c97b8be4}, !- Handle
-  {3964a7b2-fa28-408e-b269-aaac9418856f}, !- Name
-  {47811fbc-18c2-4c7c-afb9-bf96aa10902e}, !- Source Object
+  {e77c6642-b8ee-4aa6-ae4b-6341d8942f9b}, !- Handle
+  {f718c63c-2605-4bc1-abce-e1e63fe66c39}, !- Name
+  {bb87a8ec-805d-4677-b278-7c281c18cd16}, !- Source Object
   3,                                      !- Outlet Port
-  {0db9fecb-4aa8-4196-85da-e734c64832e0}, !- Target Object
+  {8715d4ed-6b46-4c35-bb38-40cd5136e09a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {cc3bdef4-40cb-462b-8eb5-1240868255ed}, !- Handle
-  {205167fe-6329-43b4-bea3-d5c0e50ab51d}, !- Name
-  {0db9fecb-4aa8-4196-85da-e734c64832e0}, !- Source Object
+  {8e6cd72d-e519-4448-9494-ead51d5f17e7}, !- Handle
+  {ce18988a-86b6-4f5c-8611-4f4e3cb3e01a}, !- Name
+  {8715d4ed-6b46-4c35-bb38-40cd5136e09a}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Node,
-  {63a4d404-22f3-479f-b15e-2ba4f6a74cc8}, !- Handle
+  {ffcf2a73-02dd-4a96-bf0a-31f23016c69f}, !- Handle
   Node 93,                                !- Name
-  {f182e312-62ab-43ec-bc5e-9cafd3b5d21d}, !- Inlet Port
-  {f066e3b4-9228-4a27-9362-8da07b58ef3f}; !- Outlet Port
+  {1d425c84-d4b3-4708-8d2e-1d484433ff8d}, !- Inlet Port
+  {40e4cc8a-958f-45cc-8a0a-b34ddb03456d}; !- Outlet Port
 
 OS:Connection,
-  {f182e312-62ab-43ec-bc5e-9cafd3b5d21d}, !- Handle
-  {2b1bff5a-2919-474e-941a-aada379d81ca}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {1d425c84-d4b3-4708-8d2e-1d484433ff8d}, !- Handle
+  {fe177f16-80e6-4052-9083-e4706936ee62}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   4,                                      !- Outlet Port
-  {63a4d404-22f3-479f-b15e-2ba4f6a74cc8}, !- Target Object
+  {ffcf2a73-02dd-4a96-bf0a-31f23016c69f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {c720a33c-d6db-4264-9f64-0548aa5c0b67}, !- Handle
+  {29f49614-074a-41dc-8b69-50692e0d5c45}, !- Handle
   Node 94,                                !- Name
-  {2a489dae-bc79-428f-bc16-6a44df1c3499}, !- Inlet Port
-  {0dc6d3fc-a4e3-431d-83e6-c4612337587e}; !- Outlet Port
+  {0a0789c5-6a97-4ce3-9aaa-6aaabf0e5d57}, !- Inlet Port
+  {585219ea-0957-4d97-ba1f-f8aa6ff6fe73}; !- Outlet Port
 
 OS:Connection,
-  {f066e3b4-9228-4a27-9362-8da07b58ef3f}, !- Handle
-  {c393c8a2-0e70-4b55-a373-36cbfcb9e6d2}, !- Name
-  {63a4d404-22f3-479f-b15e-2ba4f6a74cc8}, !- Source Object
+  {40e4cc8a-958f-45cc-8a0a-b34ddb03456d}, !- Handle
+  {385bce33-2b75-47b5-b02e-de566587d46b}, !- Name
+  {ffcf2a73-02dd-4a96-bf0a-31f23016c69f}, !- Source Object
   3,                                      !- Outlet Port
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Target Object
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {2a489dae-bc79-428f-bc16-6a44df1c3499}, !- Handle
-  {0755e3e7-78c0-4a9f-af37-fd51ce568673}, !- Name
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Source Object
+  {0a0789c5-6a97-4ce3-9aaa-6aaabf0e5d57}, !- Handle
+  {0b655464-1888-4fb0-8c78-494ae16bf65f}, !- Name
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Source Object
   6,                                      !- Outlet Port
-  {c720a33c-d6db-4264-9f64-0548aa5c0b67}, !- Target Object
+  {29f49614-074a-41dc-8b69-50692e0d5c45}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {0dc6d3fc-a4e3-431d-83e6-c4612337587e}, !- Handle
-  {d521943e-26be-474d-9180-1b32285d7e80}, !- Name
-  {c720a33c-d6db-4264-9f64-0548aa5c0b67}, !- Source Object
+  {585219ea-0957-4d97-ba1f-f8aa6ff6fe73}, !- Handle
+  {fd4e49e7-7646-41e5-927f-106f2464f89c}, !- Name
+  {29f49614-074a-41dc-8b69-50692e0d5c45}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Controller:WaterCoil,
-  {27f49248-f1d9-40a9-9cca-fecd99ae7f32}, !- Handle
+  {4f64a7d3-3854-4eb2-9f24-48ebf37f4662}, !- Handle
   Controller Water Coil 3,                !- Name
-  {2142bcbd-b46a-4dea-9927-32b86c537ab0}, !- Water Coil Name
+  {177ea20e-d39e-48db-99e6-4407667c008f}, !- Water Coil Name
   ,                                       !- Control Variable
   Normal,                                 !- Action
   ,                                       !- Actuator Variable
@@ -5532,122 +5540,122 @@ OS:Controller:WaterCoil,
   0;                                      !- Minimum Actuated Flow {m3/s}
 
 OS:Pipe:Adiabatic,
-  {c49d8edf-b055-4c7e-8cd0-5750c1af792c}, !- Handle
+  {ef3c4807-ddf4-4422-b09c-18df937b3403}, !- Handle
   Pipe Adiabatic 18,                      !- Name
-  {2269deb4-2d43-499c-9dd7-ff5bf359ff32}, !- Inlet Node Name
-  {738392aa-0e94-4de3-ba92-347dfe842d7f}; !- Outlet Node Name
+  {68f5289d-e133-4f83-b611-75030d55970f}, !- Inlet Node Name
+  {b448cd74-d902-4801-8d20-24cfdb69a18b}; !- Outlet Node Name
 
 OS:Pipe:Adiabatic,
-  {97f33b48-2d6c-4bee-8b3f-67045d2c17f6}, !- Handle
+  {3f5ef24a-1404-4543-b321-69a8d6e7c813}, !- Handle
   Pipe Adiabatic 19,                      !- Name
-  {8f91fbbf-bf6c-4182-b286-c60d12ba13bc}, !- Inlet Node Name
-  {a20e65a6-051f-4faa-bdb7-e8829a279d19}; !- Outlet Node Name
+  {a1471e27-4bd5-4bc1-b337-83074a75d9c6}, !- Inlet Node Name
+  {fb1bbf5f-f0a7-40c8-bade-4259a35be505}; !- Outlet Node Name
 
 OS:Node,
-  {dd5f9a28-0f31-49de-b500-39a3f6ae8458}, !- Handle
+  {b0bc1671-b3ee-4383-a5db-f9de0f4aa4ce}, !- Handle
   Node 95,                                !- Name
-  {f084e99f-8c3d-433d-9483-74b23686f566}, !- Inlet Port
-  {8f91fbbf-bf6c-4182-b286-c60d12ba13bc}; !- Outlet Port
+  {8c3eec38-2c3d-449e-a8be-1003c0c5cf09}, !- Inlet Port
+  {a1471e27-4bd5-4bc1-b337-83074a75d9c6}; !- Outlet Port
 
 OS:Connection,
-  {f084e99f-8c3d-433d-9483-74b23686f566}, !- Handle
-  {45a3d80b-90b8-4ac7-9310-8d406a7930ca}, !- Name
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Source Object
+  {8c3eec38-2c3d-449e-a8be-1003c0c5cf09}, !- Handle
+  {86e37cf6-ee39-4863-a2de-dd9a58e3265d}, !- Name
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Source Object
   2,                                      !- Outlet Port
-  {dd5f9a28-0f31-49de-b500-39a3f6ae8458}, !- Target Object
+  {b0bc1671-b3ee-4383-a5db-f9de0f4aa4ce}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8f91fbbf-bf6c-4182-b286-c60d12ba13bc}, !- Handle
-  {2bfb5e9e-ca60-4184-b6af-6cc231f7b95d}, !- Name
-  {dd5f9a28-0f31-49de-b500-39a3f6ae8458}, !- Source Object
+  {a1471e27-4bd5-4bc1-b337-83074a75d9c6}, !- Handle
+  {c67d9e0a-393f-4469-bf86-35caa0c3ed83}, !- Name
+  {b0bc1671-b3ee-4383-a5db-f9de0f4aa4ce}, !- Source Object
   3,                                      !- Outlet Port
-  {97f33b48-2d6c-4bee-8b3f-67045d2c17f6}, !- Target Object
+  {3f5ef24a-1404-4543-b321-69a8d6e7c813}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a20e65a6-051f-4faa-bdb7-e8829a279d19}, !- Handle
-  {208c5f35-f790-4d5b-a66a-96f731dcbe1e}, !- Name
-  {97f33b48-2d6c-4bee-8b3f-67045d2c17f6}, !- Source Object
+  {fb1bbf5f-f0a7-40c8-bade-4259a35be505}, !- Handle
+  {538dcdb4-a127-4337-a7c7-7adf78561a12}, !- Name
+  {3f5ef24a-1404-4543-b321-69a8d6e7c813}, !- Source Object
   3,                                      !- Outlet Port
-  {5c3b9d46-560c-4aed-af05-906102523a36}, !- Target Object
+  {86ba865f-6a3a-4aa7-8a19-b88ec0643acb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {e3ec4802-c1ca-471a-8827-5db12b7ef973}, !- Handle
+  {11b8476b-1a56-400e-8f13-25e702ab9828}, !- Handle
   Node 96,                                !- Name
-  {738392aa-0e94-4de3-ba92-347dfe842d7f}, !- Inlet Port
-  {e722291e-ece4-4993-b07b-6d7ceb0a3f82}; !- Outlet Port
+  {b448cd74-d902-4801-8d20-24cfdb69a18b}, !- Inlet Port
+  {2be786f9-a1c4-4a41-bad1-928ad1c11261}; !- Outlet Port
 
 OS:Connection,
-  {2269deb4-2d43-499c-9dd7-ff5bf359ff32}, !- Handle
-  {c7a972ff-bd51-4cb6-826b-f7727125332b}, !- Name
-  {7c09dead-052b-42de-a986-2655d3bd13ca}, !- Source Object
+  {68f5289d-e133-4f83-b611-75030d55970f}, !- Handle
+  {2fc60181-d6e0-4cd1-8b7e-c0ab8fc5f325}, !- Name
+  {438a06db-66c7-42c2-a04e-5b3af9f570c2}, !- Source Object
   3,                                      !- Outlet Port
-  {c49d8edf-b055-4c7e-8cd0-5750c1af792c}, !- Target Object
+  {ef3c4807-ddf4-4422-b09c-18df937b3403}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {738392aa-0e94-4de3-ba92-347dfe842d7f}, !- Handle
-  {4f7dc383-7aa8-4927-b89c-bc742e92a3ac}, !- Name
-  {c49d8edf-b055-4c7e-8cd0-5750c1af792c}, !- Source Object
+  {b448cd74-d902-4801-8d20-24cfdb69a18b}, !- Handle
+  {73ae7671-2b26-4175-8354-2c0698e346c6}, !- Name
+  {ef3c4807-ddf4-4422-b09c-18df937b3403}, !- Source Object
   3,                                      !- Outlet Port
-  {e3ec4802-c1ca-471a-8827-5db12b7ef973}, !- Target Object
+  {11b8476b-1a56-400e-8f13-25e702ab9828}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {e722291e-ece4-4993-b07b-6d7ceb0a3f82}, !- Handle
-  {b6fd6cce-a8f9-4a8d-ad0c-079bcb16cfff}, !- Name
-  {e3ec4802-c1ca-471a-8827-5db12b7ef973}, !- Source Object
+  {2be786f9-a1c4-4a41-bad1-928ad1c11261}, !- Handle
+  {8a978d45-d994-4224-a4a0-d6e7b259b768}, !- Name
+  {11b8476b-1a56-400e-8f13-25e702ab9828}, !- Source Object
   3,                                      !- Outlet Port
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Target Object
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {be65b338-2e01-4ef5-ab10-bc7b5ec5f6ba}, !- Handle
+  {0d756a5d-2712-44de-9baa-8be150bd0e51}, !- Handle
   Pipe Adiabatic 20,                      !- Name
-  {113fcf73-3ca7-46b3-b4d5-e80475d9f1b5}, !- Inlet Node Name
-  {4e632b3b-039d-4b14-ab45-c75913ca7a4e}; !- Outlet Node Name
+  {635a3488-bdd4-4954-82e1-aa125ce4143a}, !- Inlet Node Name
+  {83bfd4d9-c49b-406b-868b-5074bf00ef16}; !- Outlet Node Name
 
 OS:Node,
-  {d97ae90b-7668-4e59-ab83-eb16a7acc840}, !- Handle
+  {65da3047-9661-4d23-9bf7-a95dfeede084}, !- Handle
   Node 97,                                !- Name
-  {e19a9a3b-3eb6-4253-9583-b5afdfd27eb9}, !- Inlet Port
-  {113fcf73-3ca7-46b3-b4d5-e80475d9f1b5}; !- Outlet Port
+  {f0a85b29-92bc-4177-8f2d-603496b85d47}, !- Inlet Port
+  {635a3488-bdd4-4954-82e1-aa125ce4143a}; !- Outlet Port
 
 OS:Connection,
-  {e19a9a3b-3eb6-4253-9583-b5afdfd27eb9}, !- Handle
-  {99fc8b78-02f5-4afe-80fa-6dbf4c159d84}, !- Name
-  {6aedec3b-894c-4c58-b200-13399111a4d2}, !- Source Object
+  {f0a85b29-92bc-4177-8f2d-603496b85d47}, !- Handle
+  {eca202e0-4077-4666-b802-187aa6289630}, !- Name
+  {879221b3-c288-46b9-b053-e20e219cd2bc}, !- Source Object
   2,                                      !- Outlet Port
-  {d97ae90b-7668-4e59-ab83-eb16a7acc840}, !- Target Object
+  {65da3047-9661-4d23-9bf7-a95dfeede084}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {113fcf73-3ca7-46b3-b4d5-e80475d9f1b5}, !- Handle
-  {100c9994-b7ce-4d89-a361-c529ad11f3d1}, !- Name
-  {d97ae90b-7668-4e59-ab83-eb16a7acc840}, !- Source Object
+  {635a3488-bdd4-4954-82e1-aa125ce4143a}, !- Handle
+  {14158d52-3a26-4cda-b9f8-55b8711d7127}, !- Name
+  {65da3047-9661-4d23-9bf7-a95dfeede084}, !- Source Object
   3,                                      !- Outlet Port
-  {be65b338-2e01-4ef5-ab10-bc7b5ec5f6ba}, !- Target Object
+  {0d756a5d-2712-44de-9baa-8be150bd0e51}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4e632b3b-039d-4b14-ab45-c75913ca7a4e}, !- Handle
-  {faa49c17-4976-4864-a1e6-4ce662ddc1a2}, !- Name
-  {be65b338-2e01-4ef5-ab10-bc7b5ec5f6ba}, !- Source Object
+  {83bfd4d9-c49b-406b-868b-5074bf00ef16}, !- Handle
+  {63a454f4-689c-4cb2-8f12-ac271bbbc550}, !- Name
+  {0d756a5d-2712-44de-9baa-8be150bd0e51}, !- Source Object
   3,                                      !- Outlet Port
-  {55580731-e630-497a-95c9-92b5369b7120}, !- Target Object
+  {b018037a-6900-4cbb-80c9-4cd4580a4d4a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:SetpointManager:Scheduled,
-  {ac947c0e-eb87-42bc-9c83-96cf5c5f1482}, !- Handle
+  {25b4a2fb-e262-4b51-8514-7350ce50a6e5}, !- Handle
   Setpoint Manager Scheduled 5,           !- Name
   Temperature,                            !- Control Variable
-  {d64d2ed0-629a-4d5e-b939-8370a844ade2}, !- Schedule Name
-  {55580731-e630-497a-95c9-92b5369b7120}; !- Setpoint Node or NodeList Name
+  {b59f427e-96f2-44e4-aab4-4b185f283e83}, !- Schedule Name
+  {b018037a-6900-4cbb-80c9-4cd4580a4d4a}; !- Setpoint Node or NodeList Name
 
 OS:PlantLoop,
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Handle
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Handle
   Chilled Water Loop 1,                   !- Name
   ,                                       !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -5655,21 +5663,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {89962828-d478-44a1-bbde-b4e42e9aebb5}, !- Loop Temperature Setpoint Node Name
+  {ccad579b-ca70-4107-bddc-4ae28ac5dfbc}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {6bf661bb-ff92-4f46-a2c3-8ff3181e316a}, !- Plant Side Inlet Node Name
-  {a93ee175-99e3-41dd-bdb6-6c347fc775e8}, !- Plant Side Outlet Node Name
+  {73cf8d5d-e010-4041-b46c-b298f59b4e8e}, !- Plant Side Inlet Node Name
+  {cd23736e-2c62-4595-aa69-7f5406fe7c2c}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {24668735-37fa-431d-8ecb-b563fcfded8b}, !- Demand Side Inlet Node Name
-  {0335b912-c4b2-47d9-80f3-94207f8881a1}, !- Demand Side Outlet Node Name
+  {9e209ffa-6131-4d43-8108-869d34e38900}, !- Demand Side Inlet Node Name
+  {3621b794-0ea6-446e-850e-781c2409e4f2}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {67b1ed4c-be63-4956-a623-7075802d55c9}, !- Availability Manager List Name
+  {d419be5b-d5ff-409b-8743-63b5cbbbecaf}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -5677,14 +5685,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {00de061f-a1c1-4c0d-b407-b11d465c25c0}, !- Demand Mixer Name
-  {e456cff4-8275-4599-8a35-b814791b54e0}, !- Demand Splitter Name
-  {64643956-bc08-4f66-ba59-27e27779565f}, !- Supply Mixer Name
-  {05138c05-e362-4da8-982d-1260c6b7500b}; !- Supply Splitter Name
+  {167f8265-20ac-4fa2-951f-0fc6a8e79dde}, !- Demand Mixer Name
+  {18358474-2815-4b3c-90ea-5fe6ef4fd105}, !- Demand Splitter Name
+  {eee47fb7-f745-43cd-bfc8-88ae8bf9b770}, !- Supply Mixer Name
+  {7f3e3c44-83a6-457c-a869-7d482d03f81d}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {74e66142-9cb2-40b2-bdfb-24f79dcd41bd}, !- Handle
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Plant or Condenser Loop Name
+  {9084247b-69ce-4d00-b826-0a18c87059e0}, !- Handle
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Plant or Condenser Loop Name
   Cooling,                                !- Loop Type
   7.22,                                   !- Design Loop Exit Temperature {C}
   6.67,                                   !- Loop Design Temperature Difference {deltaC}
@@ -5693,126 +5701,126 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {7fa2aaa8-caf3-4287-a787-61eab1c417c9}, !- Handle
+  {06b3fbab-7172-4c61-bee7-a4d25dfa0c1f}, !- Handle
   Node 98,                                !- Name
-  {6bf661bb-ff92-4f46-a2c3-8ff3181e316a}, !- Inlet Port
-  {3fa3c50b-6aa3-492e-b038-4c38d488a67a}; !- Outlet Port
+  {73cf8d5d-e010-4041-b46c-b298f59b4e8e}, !- Inlet Port
+  {4eebe556-52e4-429b-a15a-20df1f89e82a}; !- Outlet Port
 
 OS:Node,
-  {89962828-d478-44a1-bbde-b4e42e9aebb5}, !- Handle
+  {ccad579b-ca70-4107-bddc-4ae28ac5dfbc}, !- Handle
   Node 99,                                !- Name
-  {89c5419f-1d31-4720-b793-5a3a34cf7a42}, !- Inlet Port
-  {a93ee175-99e3-41dd-bdb6-6c347fc775e8}; !- Outlet Port
+  {880e71c8-9c46-4212-a27d-0a658cfc3f8b}, !- Inlet Port
+  {cd23736e-2c62-4595-aa69-7f5406fe7c2c}; !- Outlet Port
 
 OS:Node,
-  {3ab6bc58-f10c-4967-9318-f274d7ec51f6}, !- Handle
+  {6a8ad578-fafa-4cc3-a984-996edfd6ad5c}, !- Handle
   Node 100,                               !- Name
-  {3215d0fd-792c-4556-a2b9-7b80e6267f03}, !- Inlet Port
-  {f594877e-c057-47e2-8e4f-3c85278ec38c}; !- Outlet Port
+  {8db3fa44-15ac-4b69-96bc-c7a412161f87}, !- Inlet Port
+  {0a740d68-0d7f-47c0-bfaf-0cf7b296366e}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {64643956-bc08-4f66-ba59-27e27779565f}, !- Handle
+  {eee47fb7-f745-43cd-bfc8-88ae8bf9b770}, !- Handle
   Connector Mixer 9,                      !- Name
-  {1aad137e-9ed5-4ca6-b5c1-c140cb6a04a7}, !- Outlet Branch Name
-  {de3f0b68-1321-491a-8777-90e65e8c9eab}, !- Inlet Branch Name 1
-  {b20e1b4d-d58a-42ff-89ad-1cf778a295e3}; !- Inlet Branch Name 2
+  {eb37b4be-3fd5-40d6-bd0c-169b1126b874}, !- Outlet Branch Name
+  {86a1e074-2de1-4194-8f56-d99beb57fddb}, !- Inlet Branch Name 1
+  {718fb00f-971f-4d61-914d-eb4b3562d63f}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {05138c05-e362-4da8-982d-1260c6b7500b}, !- Handle
+  {7f3e3c44-83a6-457c-a869-7d482d03f81d}, !- Handle
   Connector Splitter 9,                   !- Name
-  {5fee6c51-7970-4007-a1b0-2089d8c9368e}, !- Inlet Branch Name
-  {3215d0fd-792c-4556-a2b9-7b80e6267f03}, !- Outlet Branch Name 1
-  {e4156081-b1ec-4806-8a7b-5de4ab93beef}; !- Outlet Branch Name 2
+  {654c178c-b4be-4a68-a0d0-ae8761b6e92d}, !- Inlet Branch Name
+  {8db3fa44-15ac-4b69-96bc-c7a412161f87}, !- Outlet Branch Name 1
+  {40dd0d49-ce96-42af-9cf0-fcc6151ca992}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {6bf661bb-ff92-4f46-a2c3-8ff3181e316a}, !- Handle
-  {eb400fd6-322b-4453-a096-82d7c085c3d5}, !- Name
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Source Object
+  {73cf8d5d-e010-4041-b46c-b298f59b4e8e}, !- Handle
+  {d4b2405f-483b-4ede-8189-dd84f1ede9ec}, !- Name
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Source Object
   14,                                     !- Outlet Port
-  {7fa2aaa8-caf3-4287-a787-61eab1c417c9}, !- Target Object
+  {06b3fbab-7172-4c61-bee7-a4d25dfa0c1f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {3215d0fd-792c-4556-a2b9-7b80e6267f03}, !- Handle
-  {00690709-9678-4a58-97ec-0592ac96725d}, !- Name
-  {05138c05-e362-4da8-982d-1260c6b7500b}, !- Source Object
+  {8db3fa44-15ac-4b69-96bc-c7a412161f87}, !- Handle
+  {544ca808-76a4-4535-94f0-02ec3afeda5b}, !- Name
+  {7f3e3c44-83a6-457c-a869-7d482d03f81d}, !- Source Object
   3,                                      !- Outlet Port
-  {3ab6bc58-f10c-4967-9318-f274d7ec51f6}, !- Target Object
+  {6a8ad578-fafa-4cc3-a984-996edfd6ad5c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a93ee175-99e3-41dd-bdb6-6c347fc775e8}, !- Handle
-  {e514039e-59a1-48bf-b0af-cfb691def383}, !- Name
-  {89962828-d478-44a1-bbde-b4e42e9aebb5}, !- Source Object
+  {cd23736e-2c62-4595-aa69-7f5406fe7c2c}, !- Handle
+  {492c887c-7b67-4a08-8d9f-26fe62c79a45}, !- Name
+  {ccad579b-ca70-4107-bddc-4ae28ac5dfbc}, !- Source Object
   3,                                      !- Outlet Port
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Target Object
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {b984dda5-6309-494e-8eb3-1250ad92e0d6}, !- Handle
+  {37530c05-e86d-4229-a713-f1f7e062d5c5}, !- Handle
   Node 101,                               !- Name
-  {24668735-37fa-431d-8ecb-b563fcfded8b}, !- Inlet Port
-  {43e68be6-e44f-466f-bae7-bcfaa8ab5a4e}; !- Outlet Port
+  {9e209ffa-6131-4d43-8108-869d34e38900}, !- Inlet Port
+  {da2ae81b-356f-423e-b477-19cea77909b7}; !- Outlet Port
 
 OS:Node,
-  {4cc80e65-398c-410a-8c29-66722d8970df}, !- Handle
+  {f9466fba-621b-44e1-9f1f-22534e10821b}, !- Handle
   Node 102,                               !- Name
-  {c678e770-d779-4e08-a362-5773d58a62e8}, !- Inlet Port
-  {0335b912-c4b2-47d9-80f3-94207f8881a1}; !- Outlet Port
+  {852b2b29-97e3-457a-8240-a39d8156d8ed}, !- Inlet Port
+  {3621b794-0ea6-446e-850e-781c2409e4f2}; !- Outlet Port
 
 OS:Node,
-  {590896a5-eeb4-40c4-9e8e-b441d9a2237e}, !- Handle
+  {951d46b8-f8dd-4f62-b4e6-e8aeece13e61}, !- Handle
   Node 103,                               !- Name
-  {29d8b5b0-3035-4bf2-856f-f2d9f192a775}, !- Inlet Port
-  {43ec0ff6-a36b-4f50-ad19-8509601e69cb}; !- Outlet Port
+  {c472f7d0-6520-4886-b057-26fc01814494}, !- Inlet Port
+  {3417ffe2-e225-4a50-b39d-ddf06edee7c0}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {00de061f-a1c1-4c0d-b407-b11d465c25c0}, !- Handle
+  {167f8265-20ac-4fa2-951f-0fc6a8e79dde}, !- Handle
   Connector Mixer 10,                     !- Name
-  {1664913c-8d05-4288-b83d-c67721ea084d}, !- Outlet Branch Name
-  {df07c751-a4fa-4080-895d-6856949d252b}, !- Inlet Branch Name 1
-  {80c09a10-cd5d-4b34-9fe2-27788fa5a448}; !- Inlet Branch Name 2
+  {c969774e-36d5-4c9b-9f72-66c20ff1dd90}, !- Outlet Branch Name
+  {a469dfa7-f753-46dc-9db7-c257eb4b19e9}, !- Inlet Branch Name 1
+  {e6cde65f-6a84-4474-b3f4-9a0472e5406d}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {e456cff4-8275-4599-8a35-b814791b54e0}, !- Handle
+  {18358474-2815-4b3c-90ea-5fe6ef4fd105}, !- Handle
   Connector Splitter 10,                  !- Name
-  {2287bdd8-bd4b-4f45-bc76-129103a7f75e}, !- Inlet Branch Name
-  {29d8b5b0-3035-4bf2-856f-f2d9f192a775}, !- Outlet Branch Name 1
-  {302bde1c-c358-4a6f-8380-cd04a81f1959}; !- Outlet Branch Name 2
+  {2e2bdc70-8b78-4b82-aaa3-9de48bdcaf49}, !- Inlet Branch Name
+  {c472f7d0-6520-4886-b057-26fc01814494}, !- Outlet Branch Name 1
+  {986d36bb-c042-4478-97e6-bd40206bee0a}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {24668735-37fa-431d-8ecb-b563fcfded8b}, !- Handle
-  {365634d9-5c61-41fa-b7f5-08de39712c6c}, !- Name
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Source Object
+  {9e209ffa-6131-4d43-8108-869d34e38900}, !- Handle
+  {7d48c8c2-738a-49a8-808c-b9d86c88d5e3}, !- Name
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Source Object
   17,                                     !- Outlet Port
-  {b984dda5-6309-494e-8eb3-1250ad92e0d6}, !- Target Object
+  {37530c05-e86d-4229-a713-f1f7e062d5c5}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {29d8b5b0-3035-4bf2-856f-f2d9f192a775}, !- Handle
-  {04dfa4d9-9ca3-4458-804c-4ffeaa2f1803}, !- Name
-  {e456cff4-8275-4599-8a35-b814791b54e0}, !- Source Object
+  {c472f7d0-6520-4886-b057-26fc01814494}, !- Handle
+  {4213597b-5a5f-45ee-b4dc-0b7c8fbb93e7}, !- Name
+  {18358474-2815-4b3c-90ea-5fe6ef4fd105}, !- Source Object
   3,                                      !- Outlet Port
-  {590896a5-eeb4-40c4-9e8e-b441d9a2237e}, !- Target Object
+  {951d46b8-f8dd-4f62-b4e6-e8aeece13e61}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {0335b912-c4b2-47d9-80f3-94207f8881a1}, !- Handle
-  {b1010bb1-3206-4e0a-bd15-e09e01ce9d45}, !- Name
-  {4cc80e65-398c-410a-8c29-66722d8970df}, !- Source Object
+  {3621b794-0ea6-446e-850e-781c2409e4f2}, !- Handle
+  {3aa542d2-dea4-43fa-b0c9-644054b2ff67}, !- Name
+  {f9466fba-621b-44e1-9f1f-22534e10821b}, !- Source Object
   3,                                      !- Outlet Port
-  {23188bd0-bf8d-4b68-bf03-71e41dcd0798}, !- Target Object
+  {19d11c74-e77e-4316-9d17-69b489119301}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {67b1ed4c-be63-4956-a623-7075802d55c9}, !- Handle
+  {d419be5b-d5ff-409b-8743-63b5cbbbecaf}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList 4; !- Name
 
 OS:Pump:VariableSpeed,
-  {12ccff9a-7d6b-44ff-b9a9-e5d1a3632e2d}, !- Handle
+  {0afbffb8-d049-47d9-8d8e-2db7d77cfff2}, !- Handle
   Pump Variable Speed 5,                  !- Name
-  {3fa3c50b-6aa3-492e-b038-4c38d488a67a}, !- Inlet Node Name
-  {196b2027-db23-4fa5-aae0-f129e14317a5}, !- Outlet Node Name
+  {4eebe556-52e4-429b-a15a-20df1f89e82a}, !- Inlet Node Name
+  {83cde63a-7b1e-416b-b23b-348d5a4914bc}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -5841,37 +5849,37 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Node,
-  {d6a633b2-a9ad-4810-aa37-8b6f33d752f1}, !- Handle
+  {b5983ff6-f359-41b2-9f90-a9abdff05dc1}, !- Handle
   Node 104,                               !- Name
-  {196b2027-db23-4fa5-aae0-f129e14317a5}, !- Inlet Port
-  {5fee6c51-7970-4007-a1b0-2089d8c9368e}; !- Outlet Port
+  {83cde63a-7b1e-416b-b23b-348d5a4914bc}, !- Inlet Port
+  {654c178c-b4be-4a68-a0d0-ae8761b6e92d}; !- Outlet Port
 
 OS:Connection,
-  {3fa3c50b-6aa3-492e-b038-4c38d488a67a}, !- Handle
-  {caa40331-43e9-44e9-8731-2d7a6802d880}, !- Name
-  {7fa2aaa8-caf3-4287-a787-61eab1c417c9}, !- Source Object
+  {4eebe556-52e4-429b-a15a-20df1f89e82a}, !- Handle
+  {6db9da9c-ca23-4fe6-adcf-b33cf10fa3d1}, !- Name
+  {06b3fbab-7172-4c61-bee7-a4d25dfa0c1f}, !- Source Object
   3,                                      !- Outlet Port
-  {12ccff9a-7d6b-44ff-b9a9-e5d1a3632e2d}, !- Target Object
+  {0afbffb8-d049-47d9-8d8e-2db7d77cfff2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {196b2027-db23-4fa5-aae0-f129e14317a5}, !- Handle
-  {1e73334c-1a2b-4ffc-b8c7-9b5b79a6069d}, !- Name
-  {12ccff9a-7d6b-44ff-b9a9-e5d1a3632e2d}, !- Source Object
+  {83cde63a-7b1e-416b-b23b-348d5a4914bc}, !- Handle
+  {2ec235a1-c6ff-4b5f-a8a8-ea9d76432d02}, !- Name
+  {0afbffb8-d049-47d9-8d8e-2db7d77cfff2}, !- Source Object
   3,                                      !- Outlet Port
-  {d6a633b2-a9ad-4810-aa37-8b6f33d752f1}, !- Target Object
+  {b5983ff6-f359-41b2-9f90-a9abdff05dc1}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5fee6c51-7970-4007-a1b0-2089d8c9368e}, !- Handle
-  {f9571961-ecdf-4795-9ae5-6b8aa2230211}, !- Name
-  {d6a633b2-a9ad-4810-aa37-8b6f33d752f1}, !- Source Object
+  {654c178c-b4be-4a68-a0d0-ae8761b6e92d}, !- Handle
+  {9b8742c7-2b6d-40e8-ae11-1bdab2fee7b8}, !- Name
+  {b5983ff6-f359-41b2-9f90-a9abdff05dc1}, !- Source Object
   3,                                      !- Outlet Port
-  {05138c05-e362-4da8-982d-1260c6b7500b}, !- Target Object
+  {7f3e3c44-83a6-457c-a869-7d482d03f81d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Curve:Biquadratic,
-  {3e5a2465-96d9-4118-9771-33d86d18d2b1}, !- Handle
+  {8dea916d-7bba-4559-a226-1acd23c77820}, !- Handle
   Curve Biquadratic 3,                    !- Name
   0.258,                                  !- Coefficient1 Constant
   0.0389,                                 !- Coefficient2 x
@@ -5885,7 +5893,7 @@ OS:Curve:Biquadratic,
   35;                                     !- Maximum Value of y
 
 OS:Curve:Biquadratic,
-  {aeb67054-d79e-4888-9fde-2c72fb6b5034}, !- Handle
+  {afee23f1-0aaa-4091-8aed-a5fa33b94e61}, !- Handle
   Curve Biquadratic 4,                    !- Name
   0.934,                                  !- Coefficient1 Constant
   -0.0582,                                !- Coefficient2 x
@@ -5899,7 +5907,7 @@ OS:Curve:Biquadratic,
   35;                                     !- Maximum Value of y
 
 OS:Curve:Quadratic,
-  {925722ec-2cbe-4143-b4ae-e638969ab537}, !- Handle
+  {afbc2ac7-e5ef-4b1c-b6d6-f21a79d065e9}, !- Handle
   Curve Quadratic 2,                      !- Name
   0.222903,                               !- Coefficient1 Constant
   0.313387,                               !- Coefficient2 x
@@ -5908,7 +5916,7 @@ OS:Curve:Quadratic,
   1;                                      !- Maximum Value of x
 
 OS:Chiller:Electric:EIR,
-  {ab01a737-8119-4bd6-97a6-cd847b52d340}, !- Handle
+  {6ebfdf57-c0f7-46d0-b1fc-fb78811ee76e}, !- Handle
   Chiller Electric EIR 2,                 !- Name
   Autosize,                               !- Reference Capacity {W}
   5.5,                                    !- Reference COP {W/W}
@@ -5916,17 +5924,17 @@ OS:Chiller:Electric:EIR,
   ,                                       !- Reference Entering Condenser Fluid Temperature {C}
   ,                                       !- Reference Chilled Water Flow Rate {m3/s}
   ,                                       !- Reference Condenser Fluid Flow Rate {m3/s}
-  {3e5a2465-96d9-4118-9771-33d86d18d2b1}, !- Cooling Capacity Function of Temperature Curve Name
-  {aeb67054-d79e-4888-9fde-2c72fb6b5034}, !- Electric Input to Cooling Output Ratio Function of Temperature Curve Name
-  {925722ec-2cbe-4143-b4ae-e638969ab537}, !- Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
+  {8dea916d-7bba-4559-a226-1acd23c77820}, !- Cooling Capacity Function of Temperature Curve Name
+  {afee23f1-0aaa-4091-8aed-a5fa33b94e61}, !- Electric Input to Cooling Output Ratio Function of Temperature Curve Name
+  {afbc2ac7-e5ef-4b1c-b6d6-f21a79d065e9}, !- Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name
   ,                                       !- Minimum Part Load Ratio
   ,                                       !- Maximum Part Load Ratio
   ,                                       !- Optimum Part Load Ratio
   ,                                       !- Minimum Unloading Ratio
-  {f594877e-c057-47e2-8e4f-3c85278ec38c}, !- Chilled Water Inlet Node Name
-  {76136df7-7567-4d4a-b705-5d6d28e27326}, !- Chilled Water Outlet Node Name
-  {db119f20-167c-4d08-8c5c-ecd631dae498}, !- Condenser Inlet Node Name
-  {534d9792-6d2a-4d59-a798-e9c471410f08}, !- Condenser Outlet Node Name
+  {0a740d68-0d7f-47c0-bfaf-0cf7b296366e}, !- Chilled Water Inlet Node Name
+  {09434a0a-67e3-4fb4-9f74-293d6ab18052}, !- Chilled Water Outlet Node Name
+  {1ac82f54-903e-4369-9993-424bca9ff0f2}, !- Condenser Inlet Node Name
+  {71dc6505-11ed-4fb8-97b2-b1f90d17df6e}, !- Condenser Outlet Node Name
   WaterCooled,                            !- Condenser Type
   ,                                       !- Condenser Fan Power Ratio {W/W}
   ,                                       !- Compressor Motor Efficiency
@@ -5945,155 +5953,155 @@ OS:Chiller:Electric:EIR,
   General;                                !- End-Use Subcategory
 
 OS:Node,
-  {c8208503-68f0-4180-9943-6502ac3feeb3}, !- Handle
+  {0d21e19c-c29a-47d9-9785-807000209eef}, !- Handle
   Node 105,                               !- Name
-  {76136df7-7567-4d4a-b705-5d6d28e27326}, !- Inlet Port
-  {de3f0b68-1321-491a-8777-90e65e8c9eab}; !- Outlet Port
+  {09434a0a-67e3-4fb4-9f74-293d6ab18052}, !- Inlet Port
+  {86a1e074-2de1-4194-8f56-d99beb57fddb}; !- Outlet Port
 
 OS:Connection,
-  {f594877e-c057-47e2-8e4f-3c85278ec38c}, !- Handle
-  {2c2fe93c-1cf6-4ff4-8ae2-c6d976e8e1a4}, !- Name
-  {3ab6bc58-f10c-4967-9318-f274d7ec51f6}, !- Source Object
+  {0a740d68-0d7f-47c0-bfaf-0cf7b296366e}, !- Handle
+  {b9115aff-d188-4549-afc9-05788cdf0ef9}, !- Name
+  {6a8ad578-fafa-4cc3-a984-996edfd6ad5c}, !- Source Object
   3,                                      !- Outlet Port
-  {ab01a737-8119-4bd6-97a6-cd847b52d340}, !- Target Object
+  {6ebfdf57-c0f7-46d0-b1fc-fb78811ee76e}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Connection,
-  {76136df7-7567-4d4a-b705-5d6d28e27326}, !- Handle
-  {59abb4d6-9f50-4bb5-8690-1f5fe84fd957}, !- Name
-  {ab01a737-8119-4bd6-97a6-cd847b52d340}, !- Source Object
+  {09434a0a-67e3-4fb4-9f74-293d6ab18052}, !- Handle
+  {42e09d08-0faf-4283-a833-980cb371e021}, !- Name
+  {6ebfdf57-c0f7-46d0-b1fc-fb78811ee76e}, !- Source Object
   16,                                     !- Outlet Port
-  {c8208503-68f0-4180-9943-6502ac3feeb3}, !- Target Object
+  {0d21e19c-c29a-47d9-9785-807000209eef}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {de3f0b68-1321-491a-8777-90e65e8c9eab}, !- Handle
-  {bd0badcb-0d49-43c2-9141-906497b11a46}, !- Name
-  {c8208503-68f0-4180-9943-6502ac3feeb3}, !- Source Object
+  {86a1e074-2de1-4194-8f56-d99beb57fddb}, !- Handle
+  {6e5d40de-9948-474b-9403-e3b8031c99b0}, !- Name
+  {0d21e19c-c29a-47d9-9785-807000209eef}, !- Source Object
   3,                                      !- Outlet Port
-  {64643956-bc08-4f66-ba59-27e27779565f}, !- Target Object
+  {eee47fb7-f745-43cd-bfc8-88ae8bf9b770}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {db484ca1-0651-4dca-b130-60c4fb1c4873}, !- Handle
+  {46d3babd-fc72-4bae-8085-197ea3f1d255}, !- Handle
   Pipe Adiabatic 21,                      !- Name
-  {56b9ed42-8fbe-4596-a6be-59376ffa89c5}, !- Inlet Node Name
-  {efc20df4-67df-4b9e-898c-a681581fe597}; !- Outlet Node Name
+  {ca9cf92a-51d6-4b62-adc1-67b178bf606e}, !- Inlet Node Name
+  {aee8d014-9e71-4837-84ec-686d96d8988c}; !- Outlet Node Name
 
 OS:Node,
-  {196fdbba-bc18-4aed-b13d-ef05b2900620}, !- Handle
+  {81d1b929-5a00-477f-8f0b-8c96eca465a2}, !- Handle
   Node 106,                               !- Name
-  {e4156081-b1ec-4806-8a7b-5de4ab93beef}, !- Inlet Port
-  {56b9ed42-8fbe-4596-a6be-59376ffa89c5}; !- Outlet Port
+  {40dd0d49-ce96-42af-9cf0-fcc6151ca992}, !- Inlet Port
+  {ca9cf92a-51d6-4b62-adc1-67b178bf606e}; !- Outlet Port
 
 OS:Connection,
-  {e4156081-b1ec-4806-8a7b-5de4ab93beef}, !- Handle
-  {9bf3b3c6-4106-44e1-9455-089ccc2003da}, !- Name
-  {05138c05-e362-4da8-982d-1260c6b7500b}, !- Source Object
+  {40dd0d49-ce96-42af-9cf0-fcc6151ca992}, !- Handle
+  {25e06715-4c6b-4399-a21f-0b6b44720214}, !- Name
+  {7f3e3c44-83a6-457c-a869-7d482d03f81d}, !- Source Object
   4,                                      !- Outlet Port
-  {196fdbba-bc18-4aed-b13d-ef05b2900620}, !- Target Object
+  {81d1b929-5a00-477f-8f0b-8c96eca465a2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {b8a0d16d-5081-48c6-8eeb-0a18bac9e881}, !- Handle
+  {a9ebbc3e-988a-42d9-8246-702e9991f4db}, !- Handle
   Node 107,                               !- Name
-  {efc20df4-67df-4b9e-898c-a681581fe597}, !- Inlet Port
-  {b20e1b4d-d58a-42ff-89ad-1cf778a295e3}; !- Outlet Port
+  {aee8d014-9e71-4837-84ec-686d96d8988c}, !- Inlet Port
+  {718fb00f-971f-4d61-914d-eb4b3562d63f}; !- Outlet Port
 
 OS:Connection,
-  {56b9ed42-8fbe-4596-a6be-59376ffa89c5}, !- Handle
-  {768e4b0e-888b-47a0-9977-6c5826958da0}, !- Name
-  {196fdbba-bc18-4aed-b13d-ef05b2900620}, !- Source Object
+  {ca9cf92a-51d6-4b62-adc1-67b178bf606e}, !- Handle
+  {816fc63a-a25a-4128-b0dc-4cb7b444eeef}, !- Name
+  {81d1b929-5a00-477f-8f0b-8c96eca465a2}, !- Source Object
   3,                                      !- Outlet Port
-  {db484ca1-0651-4dca-b130-60c4fb1c4873}, !- Target Object
+  {46d3babd-fc72-4bae-8085-197ea3f1d255}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {efc20df4-67df-4b9e-898c-a681581fe597}, !- Handle
-  {6cb1022e-f4c2-4ecc-bc8c-7e03c0ac2997}, !- Name
-  {db484ca1-0651-4dca-b130-60c4fb1c4873}, !- Source Object
+  {aee8d014-9e71-4837-84ec-686d96d8988c}, !- Handle
+  {8f2ac570-9add-4bd0-bb50-6b407343f76a}, !- Name
+  {46d3babd-fc72-4bae-8085-197ea3f1d255}, !- Source Object
   3,                                      !- Outlet Port
-  {b8a0d16d-5081-48c6-8eeb-0a18bac9e881}, !- Target Object
+  {a9ebbc3e-988a-42d9-8246-702e9991f4db}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b20e1b4d-d58a-42ff-89ad-1cf778a295e3}, !- Handle
-  {c9270404-264b-4583-be75-e372844dbef9}, !- Name
-  {b8a0d16d-5081-48c6-8eeb-0a18bac9e881}, !- Source Object
+  {718fb00f-971f-4d61-914d-eb4b3562d63f}, !- Handle
+  {96f7eea2-24f2-4a5c-b149-2de4d269b63d}, !- Name
+  {a9ebbc3e-988a-42d9-8246-702e9991f4db}, !- Source Object
   3,                                      !- Outlet Port
-  {64643956-bc08-4f66-ba59-27e27779565f}, !- Target Object
+  {eee47fb7-f745-43cd-bfc8-88ae8bf9b770}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {606ba4dd-ad3e-430e-a0b0-67082f0c7244}, !- Handle
+  {6ec5147b-aaee-4cea-9486-be3815d6449c}, !- Handle
   Pipe Adiabatic 22,                      !- Name
-  {f5992609-7b55-40e3-bc5b-7ded271cfaaf}, !- Inlet Node Name
-  {89c5419f-1d31-4720-b793-5a3a34cf7a42}; !- Outlet Node Name
+  {b9ebc639-3b9f-4ed7-b88b-09ee4d9128a1}, !- Inlet Node Name
+  {880e71c8-9c46-4212-a27d-0a658cfc3f8b}; !- Outlet Node Name
 
 OS:Node,
-  {d4b40487-1273-42cd-af3b-7d345fc8437f}, !- Handle
+  {964e6722-b64c-426b-8270-a63418f4984c}, !- Handle
   Node 108,                               !- Name
-  {1aad137e-9ed5-4ca6-b5c1-c140cb6a04a7}, !- Inlet Port
-  {f5992609-7b55-40e3-bc5b-7ded271cfaaf}; !- Outlet Port
+  {eb37b4be-3fd5-40d6-bd0c-169b1126b874}, !- Inlet Port
+  {b9ebc639-3b9f-4ed7-b88b-09ee4d9128a1}; !- Outlet Port
 
 OS:Connection,
-  {1aad137e-9ed5-4ca6-b5c1-c140cb6a04a7}, !- Handle
-  {9d241aad-96fb-48ec-a7ff-b42fe4ff00e0}, !- Name
-  {64643956-bc08-4f66-ba59-27e27779565f}, !- Source Object
+  {eb37b4be-3fd5-40d6-bd0c-169b1126b874}, !- Handle
+  {1f7f822c-4861-4fc0-8a2b-c6f90fe22f21}, !- Name
+  {eee47fb7-f745-43cd-bfc8-88ae8bf9b770}, !- Source Object
   2,                                      !- Outlet Port
-  {d4b40487-1273-42cd-af3b-7d345fc8437f}, !- Target Object
+  {964e6722-b64c-426b-8270-a63418f4984c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f5992609-7b55-40e3-bc5b-7ded271cfaaf}, !- Handle
-  {e42cae79-285e-45a8-9e61-b66ad5d2ca8e}, !- Name
-  {d4b40487-1273-42cd-af3b-7d345fc8437f}, !- Source Object
+  {b9ebc639-3b9f-4ed7-b88b-09ee4d9128a1}, !- Handle
+  {f8f84748-e5a7-483c-8cf2-d03cc0222b52}, !- Name
+  {964e6722-b64c-426b-8270-a63418f4984c}, !- Source Object
   3,                                      !- Outlet Port
-  {606ba4dd-ad3e-430e-a0b0-67082f0c7244}, !- Target Object
+  {6ec5147b-aaee-4cea-9486-be3815d6449c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {89c5419f-1d31-4720-b793-5a3a34cf7a42}, !- Handle
-  {91f698a5-7ec6-474f-8ba6-fc7f9df8d61b}, !- Name
-  {606ba4dd-ad3e-430e-a0b0-67082f0c7244}, !- Source Object
+  {880e71c8-9c46-4212-a27d-0a658cfc3f8b}, !- Handle
+  {b297e8e1-c6f5-4dec-9154-59ec0b93b2cb}, !- Name
+  {6ec5147b-aaee-4cea-9486-be3815d6449c}, !- Source Object
   3,                                      !- Outlet Port
-  {89962828-d478-44a1-bbde-b4e42e9aebb5}, !- Target Object
+  {ccad579b-ca70-4107-bddc-4ae28ac5dfbc}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {5cb3eeb9-108f-45b2-82fc-05b1810548b9}, !- Handle
+  {fc998ceb-ae6c-4e0f-99a0-f9e52eeae62b}, !- Handle
   Node 109,                               !- Name
-  {f21202f0-890a-4d65-9705-3837e34312d9}, !- Inlet Port
-  {df07c751-a4fa-4080-895d-6856949d252b}; !- Outlet Port
+  {43d61dff-7a9f-4193-9d3b-8deac3fb7ea8}, !- Inlet Port
+  {a469dfa7-f753-46dc-9db7-c257eb4b19e9}; !- Outlet Port
 
 OS:Connection,
-  {43ec0ff6-a36b-4f50-ad19-8509601e69cb}, !- Handle
-  {34ba45c6-1e4f-4174-ac8c-685db2c0250e}, !- Name
-  {590896a5-eeb4-40c4-9e8e-b441d9a2237e}, !- Source Object
+  {3417ffe2-e225-4a50-b39d-ddf06edee7c0}, !- Handle
+  {a3d99bd9-59b2-404a-aa91-8cd5d6191640}, !- Name
+  {951d46b8-f8dd-4f62-b4e6-e8aeece13e61}, !- Source Object
   3,                                      !- Outlet Port
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Target Object
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Target Object
   10;                                     !- Inlet Port
 
 OS:Connection,
-  {f21202f0-890a-4d65-9705-3837e34312d9}, !- Handle
-  {5e3be627-fe98-4fe6-8aed-bec1c93cd3c6}, !- Name
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Source Object
+  {43d61dff-7a9f-4193-9d3b-8deac3fb7ea8}, !- Handle
+  {fe5617a8-bd33-4d2a-aeb9-2f2afc48fe03}, !- Name
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Source Object
   11,                                     !- Outlet Port
-  {5cb3eeb9-108f-45b2-82fc-05b1810548b9}, !- Target Object
+  {fc998ceb-ae6c-4e0f-99a0-f9e52eeae62b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {df07c751-a4fa-4080-895d-6856949d252b}, !- Handle
-  {ea59c0f0-b44d-4ccc-a42c-146ca3a4e742}, !- Name
-  {5cb3eeb9-108f-45b2-82fc-05b1810548b9}, !- Source Object
+  {a469dfa7-f753-46dc-9db7-c257eb4b19e9}, !- Handle
+  {3d04f8e0-708d-4116-8525-f319d8422339}, !- Name
+  {fc998ceb-ae6c-4e0f-99a0-f9e52eeae62b}, !- Source Object
   3,                                      !- Outlet Port
-  {00de061f-a1c1-4c0d-b407-b11d465c25c0}, !- Target Object
+  {167f8265-20ac-4fa2-951f-0fc6a8e79dde}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Controller:WaterCoil,
-  {1d0b57f9-0cff-41b2-8bd5-577ede2d7374}, !- Handle
+  {aceb7aac-2690-4c00-b1e0-bad6d5351ffd}, !- Handle
   Controller Water Coil 4,                !- Name
-  {1e2629de-bcda-4319-a974-86b2f7ceca6e}, !- Water Coil Name
+  {357da444-c970-4b1a-ae99-2beadf98d327}, !- Water Coil Name
   ,                                       !- Control Variable
   Reverse,                                !- Action
   ,                                       !- Actuator Variable
@@ -6104,20 +6112,20 @@ OS:Controller:WaterCoil,
   0;                                      !- Minimum Actuated Flow {m3/s}
 
 OS:SetpointManager:Scheduled,
-  {12dae7c0-66bb-46c1-9fb1-8776fa08816d}, !- Handle
+  {336d28b9-e198-40b9-abb2-e33c4fbb249b}, !- Handle
   Setpoint Manager Scheduled 6,           !- Name
   Temperature,                            !- Control Variable
-  {6a34b591-5efd-44c2-a327-45a5f2f8fb0a}, !- Schedule Name
-  {89962828-d478-44a1-bbde-b4e42e9aebb5}; !- Setpoint Node or NodeList Name
+  {f1ca95f2-8de0-45f6-95df-8c7fc9993575}, !- Schedule Name
+  {ccad579b-ca70-4107-bddc-4ae28ac5dfbc}; !- Setpoint Node or NodeList Name
 
 OS:Coil:Heating:Water,
-  {18600f54-5451-42b4-b7cf-a8e73b6b94c9}, !- Handle
+  {6864b4cb-5597-4371-b12d-928b53c12a75}, !- Handle
   Coil Heating Water 4,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {4dbc760d-eb4e-4727-9e74-6dea01c5214a}, !- Water Inlet Node Name
-  {6a52ab77-c52f-46c6-8398-43acd7d8418a}, !- Water Outlet Node Name
+  {b497b10e-34fb-49a0-8b86-59e5ec780380}, !- Water Inlet Node Name
+  {1823b5b9-0106-480a-8364-b79f986ec301}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -6129,19 +6137,19 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {53e94f22-5fdf-4a8c-b627-50291494ce10}, !- Handle
+  {ad473cc8-4b29-4ba9-9a73-4360c7bd3e12}, !- Handle
   Air Terminal Single Duct VAV Reheat 2,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {c6aeade6-6a10-457c-af00-6c0f2d6ba47d}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {05a10ec9-74b6-440b-ae56-e1e6d0d1227d}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {18600f54-5451-42b4-b7cf-a8e73b6b94c9}, !- Reheat Coil Name
+  {6864b4cb-5597-4371-b12d-928b53c12a75}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {0d4b0082-6de2-4797-a6c4-9526609f1152}, !- Air Outlet Node Name
+  {4d7ce014-8858-4315-b9d2-c1ef70f5e7f8}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -6150,203 +6158,203 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Node,
-  {a090a395-1f19-45b5-b5dc-8a18080031d4}, !- Handle
+  {a5460d91-5eb3-4ddd-9ebd-c205fd876380}, !- Handle
   Node 110,                               !- Name
-  {a9b00334-025d-4da8-9527-d6bf078e2038}, !- Inlet Port
-  {c6aeade6-6a10-457c-af00-6c0f2d6ba47d}; !- Outlet Port
+  {1caa182a-46ff-4261-99db-fdfd6ee3f739}, !- Inlet Port
+  {05a10ec9-74b6-440b-ae56-e1e6d0d1227d}; !- Outlet Port
 
 OS:Connection,
-  {a9b00334-025d-4da8-9527-d6bf078e2038}, !- Handle
-  {40dbe3c0-cf39-4df1-ae72-4e3ac0b86672}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {1caa182a-46ff-4261-99db-fdfd6ee3f739}, !- Handle
+  {49b5a230-6051-446f-aeeb-7efb459789c0}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   3,                                      !- Outlet Port
-  {a090a395-1f19-45b5-b5dc-8a18080031d4}, !- Target Object
+  {a5460d91-5eb3-4ddd-9ebd-c205fd876380}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c6aeade6-6a10-457c-af00-6c0f2d6ba47d}, !- Handle
-  {9843692a-c39b-4e7a-8a61-6bbaeec8bc4d}, !- Name
-  {a090a395-1f19-45b5-b5dc-8a18080031d4}, !- Source Object
+  {05a10ec9-74b6-440b-ae56-e1e6d0d1227d}, !- Handle
+  {3bacf18f-1961-4b09-a3e7-1b2724b1b566}, !- Name
+  {a5460d91-5eb3-4ddd-9ebd-c205fd876380}, !- Source Object
   3,                                      !- Outlet Port
-  {53e94f22-5fdf-4a8c-b627-50291494ce10}, !- Target Object
+  {ad473cc8-4b29-4ba9-9a73-4360c7bd3e12}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {0d4b0082-6de2-4797-a6c4-9526609f1152}, !- Handle
-  {0a8317dd-eec8-44c2-91e0-f0d253abbfa2}, !- Name
-  {53e94f22-5fdf-4a8c-b627-50291494ce10}, !- Source Object
+  {4d7ce014-8858-4315-b9d2-c1ef70f5e7f8}, !- Handle
+  {f3f1416e-2cba-4060-922e-6f16fd4ee3dc}, !- Name
+  {ad473cc8-4b29-4ba9-9a73-4360c7bd3e12}, !- Source Object
   12,                                     !- Outlet Port
-  {10a1998b-f4c9-499d-a6fd-34f777bd7415}, !- Target Object
+  {fac4a905-d12a-4f7a-b68c-d03e472bea0a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {0b567155-04e7-4a36-8807-669966405fff}, !- Handle
+  {82e82d0a-f8d6-4b8d-83a2-4174d0c0abe5}, !- Handle
   Pipe Adiabatic 23,                      !- Name
-  {2778d8f2-0b5e-4fc7-b014-37ac4547e16d}, !- Inlet Node Name
-  {a228791e-b196-48a0-8056-e879f09f97e4}; !- Outlet Node Name
+  {10b0c7f5-c023-4c79-a8f7-5f40a9ffb5b2}, !- Inlet Node Name
+  {ff630ceb-68eb-4c1e-a507-cf7790320088}; !- Outlet Node Name
 
 OS:Node,
-  {47634371-7bcc-4fda-97f8-f53538819574}, !- Handle
+  {318f2984-7cf2-459f-891a-65fb00fb5295}, !- Handle
   Node 111,                               !- Name
-  {302bde1c-c358-4a6f-8380-cd04a81f1959}, !- Inlet Port
-  {2778d8f2-0b5e-4fc7-b014-37ac4547e16d}; !- Outlet Port
+  {986d36bb-c042-4478-97e6-bd40206bee0a}, !- Inlet Port
+  {10b0c7f5-c023-4c79-a8f7-5f40a9ffb5b2}; !- Outlet Port
 
 OS:Connection,
-  {302bde1c-c358-4a6f-8380-cd04a81f1959}, !- Handle
-  {a8e5d478-1f24-470e-b0f4-34fa3104a7d6}, !- Name
-  {e456cff4-8275-4599-8a35-b814791b54e0}, !- Source Object
+  {986d36bb-c042-4478-97e6-bd40206bee0a}, !- Handle
+  {91d7b596-947b-47ba-beb5-336684569861}, !- Name
+  {18358474-2815-4b3c-90ea-5fe6ef4fd105}, !- Source Object
   4,                                      !- Outlet Port
-  {47634371-7bcc-4fda-97f8-f53538819574}, !- Target Object
+  {318f2984-7cf2-459f-891a-65fb00fb5295}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {5bd33059-ffdf-4a86-9e2c-ef8c87297553}, !- Handle
+  {bc975b1c-4a56-427e-ad2b-ad822a405e37}, !- Handle
   Node 112,                               !- Name
-  {a228791e-b196-48a0-8056-e879f09f97e4}, !- Inlet Port
-  {80c09a10-cd5d-4b34-9fe2-27788fa5a448}; !- Outlet Port
+  {ff630ceb-68eb-4c1e-a507-cf7790320088}, !- Inlet Port
+  {e6cde65f-6a84-4474-b3f4-9a0472e5406d}; !- Outlet Port
 
 OS:Connection,
-  {2778d8f2-0b5e-4fc7-b014-37ac4547e16d}, !- Handle
-  {793c315c-3372-421a-bf6f-e807d328042a}, !- Name
-  {47634371-7bcc-4fda-97f8-f53538819574}, !- Source Object
+  {10b0c7f5-c023-4c79-a8f7-5f40a9ffb5b2}, !- Handle
+  {ca245cc6-e86c-457d-b558-656e38f13f73}, !- Name
+  {318f2984-7cf2-459f-891a-65fb00fb5295}, !- Source Object
   3,                                      !- Outlet Port
-  {0b567155-04e7-4a36-8807-669966405fff}, !- Target Object
+  {82e82d0a-f8d6-4b8d-83a2-4174d0c0abe5}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a228791e-b196-48a0-8056-e879f09f97e4}, !- Handle
-  {5a0c417d-145f-4ee1-bc7f-59e557d92c57}, !- Name
-  {0b567155-04e7-4a36-8807-669966405fff}, !- Source Object
+  {ff630ceb-68eb-4c1e-a507-cf7790320088}, !- Handle
+  {c1158b1d-ed0e-42a9-92ea-147144792c13}, !- Name
+  {82e82d0a-f8d6-4b8d-83a2-4174d0c0abe5}, !- Source Object
   3,                                      !- Outlet Port
-  {5bd33059-ffdf-4a86-9e2c-ef8c87297553}, !- Target Object
+  {bc975b1c-4a56-427e-ad2b-ad822a405e37}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {80c09a10-cd5d-4b34-9fe2-27788fa5a448}, !- Handle
-  {db0b9825-df3f-4968-95f2-25265182b0d1}, !- Name
-  {5bd33059-ffdf-4a86-9e2c-ef8c87297553}, !- Source Object
+  {e6cde65f-6a84-4474-b3f4-9a0472e5406d}, !- Handle
+  {c30e49de-43f1-4f46-9e63-d664b0ba9aa8}, !- Name
+  {bc975b1c-4a56-427e-ad2b-ad822a405e37}, !- Source Object
   3,                                      !- Outlet Port
-  {00de061f-a1c1-4c0d-b407-b11d465c25c0}, !- Target Object
+  {167f8265-20ac-4fa2-951f-0fc6a8e79dde}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Node,
-  {0a92bcd7-5577-45a0-9acd-c1596791d363}, !- Handle
+  {b1482289-651c-4928-bf3b-4fe15d49197a}, !- Handle
   Node 113,                               !- Name
-  {37aa0af5-2509-4ada-adcd-6b82a719ee2c}, !- Inlet Port
-  {4dbc760d-eb4e-4727-9e74-6dea01c5214a}; !- Outlet Port
+  {e5498cd0-8d2f-4817-b0c9-ec8d79dd6f28}, !- Inlet Port
+  {b497b10e-34fb-49a0-8b86-59e5ec780380}; !- Outlet Port
 
 OS:Connection,
-  {37aa0af5-2509-4ada-adcd-6b82a719ee2c}, !- Handle
-  {6a2b7a63-ca4c-4a32-a31c-5edc4962f5c8}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {e5498cd0-8d2f-4817-b0c9-ec8d79dd6f28}, !- Handle
+  {41535a5a-e825-4034-9c0e-2146efbc4586}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   5,                                      !- Outlet Port
-  {0a92bcd7-5577-45a0-9acd-c1596791d363}, !- Target Object
+  {b1482289-651c-4928-bf3b-4fe15d49197a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {4d1280a0-e6ff-474d-98e4-cf27a7ac253d}, !- Handle
+  {080f8d9d-c79e-4f5a-a0da-3701ea146c3d}, !- Handle
   Node 114,                               !- Name
-  {6a52ab77-c52f-46c6-8398-43acd7d8418a}, !- Inlet Port
-  {11279a12-ece7-42b2-8cbe-c74c868f527d}; !- Outlet Port
+  {1823b5b9-0106-480a-8364-b79f986ec301}, !- Inlet Port
+  {ecc18424-615e-444c-bfb2-816d9e396818}; !- Outlet Port
 
 OS:Connection,
-  {4dbc760d-eb4e-4727-9e74-6dea01c5214a}, !- Handle
-  {3abef9e6-aeb6-423b-bb45-bb366cc8179b}, !- Name
-  {0a92bcd7-5577-45a0-9acd-c1596791d363}, !- Source Object
+  {b497b10e-34fb-49a0-8b86-59e5ec780380}, !- Handle
+  {a62f0780-37e9-4ad8-9b8b-22ee36edf2f5}, !- Name
+  {b1482289-651c-4928-bf3b-4fe15d49197a}, !- Source Object
   3,                                      !- Outlet Port
-  {18600f54-5451-42b4-b7cf-a8e73b6b94c9}, !- Target Object
+  {6864b4cb-5597-4371-b12d-928b53c12a75}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {6a52ab77-c52f-46c6-8398-43acd7d8418a}, !- Handle
-  {cae4c251-600b-4ceb-b509-946e65f4e086}, !- Name
-  {18600f54-5451-42b4-b7cf-a8e73b6b94c9}, !- Source Object
+  {1823b5b9-0106-480a-8364-b79f986ec301}, !- Handle
+  {5c19a674-db40-4db0-ab47-7056177bbde0}, !- Name
+  {6864b4cb-5597-4371-b12d-928b53c12a75}, !- Source Object
   6,                                      !- Outlet Port
-  {4d1280a0-e6ff-474d-98e4-cf27a7ac253d}, !- Target Object
+  {080f8d9d-c79e-4f5a-a0da-3701ea146c3d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {11279a12-ece7-42b2-8cbe-c74c868f527d}, !- Handle
-  {18735659-fade-409f-9b15-5bc692f8c7b7}, !- Name
-  {4d1280a0-e6ff-474d-98e4-cf27a7ac253d}, !- Source Object
+  {ecc18424-615e-444c-bfb2-816d9e396818}, !- Handle
+  {3765b1fb-63fb-4791-a546-015b27de269b}, !- Name
+  {080f8d9d-c79e-4f5a-a0da-3701ea146c3d}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {acbef2f8-030a-49bd-9dc1-5efb30c90135}, !- Handle
+  {16691cff-3da6-4328-94b2-5d98611c2d41}, !- Handle
   Pipe Adiabatic 24,                      !- Name
-  {43e68be6-e44f-466f-bae7-bcfaa8ab5a4e}, !- Inlet Node Name
-  {1a4fa3ae-f56a-442c-89f1-2adbc9d096c1}; !- Outlet Node Name
+  {da2ae81b-356f-423e-b477-19cea77909b7}, !- Inlet Node Name
+  {a28052d4-1158-4ae6-8792-53de23126804}; !- Outlet Node Name
 
 OS:Node,
-  {76406dc3-9134-47b3-afc4-29945395de1f}, !- Handle
+  {7a6e9411-5905-4dba-9542-c40258b96678}, !- Handle
   Node 115,                               !- Name
-  {1a4fa3ae-f56a-442c-89f1-2adbc9d096c1}, !- Inlet Port
-  {2287bdd8-bd4b-4f45-bc76-129103a7f75e}; !- Outlet Port
+  {a28052d4-1158-4ae6-8792-53de23126804}, !- Inlet Port
+  {2e2bdc70-8b78-4b82-aaa3-9de48bdcaf49}; !- Outlet Port
 
 OS:Connection,
-  {43e68be6-e44f-466f-bae7-bcfaa8ab5a4e}, !- Handle
-  {f7a1202e-50ba-48d2-855c-ed5b7d654f35}, !- Name
-  {b984dda5-6309-494e-8eb3-1250ad92e0d6}, !- Source Object
+  {da2ae81b-356f-423e-b477-19cea77909b7}, !- Handle
+  {0e5299f6-ed2b-4eff-ad9c-cb301b5b3d15}, !- Name
+  {37530c05-e86d-4229-a713-f1f7e062d5c5}, !- Source Object
   3,                                      !- Outlet Port
-  {acbef2f8-030a-49bd-9dc1-5efb30c90135}, !- Target Object
+  {16691cff-3da6-4328-94b2-5d98611c2d41}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {1a4fa3ae-f56a-442c-89f1-2adbc9d096c1}, !- Handle
-  {5d8c7d35-69cb-4720-b761-59397faa4dce}, !- Name
-  {acbef2f8-030a-49bd-9dc1-5efb30c90135}, !- Source Object
+  {a28052d4-1158-4ae6-8792-53de23126804}, !- Handle
+  {e285adcf-e671-423f-aac2-af34ffc5dcee}, !- Name
+  {16691cff-3da6-4328-94b2-5d98611c2d41}, !- Source Object
   3,                                      !- Outlet Port
-  {76406dc3-9134-47b3-afc4-29945395de1f}, !- Target Object
+  {7a6e9411-5905-4dba-9542-c40258b96678}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2287bdd8-bd4b-4f45-bc76-129103a7f75e}, !- Handle
-  {7633bfb4-0b43-44e6-b24a-4fa0cb39d09e}, !- Name
-  {76406dc3-9134-47b3-afc4-29945395de1f}, !- Source Object
+  {2e2bdc70-8b78-4b82-aaa3-9de48bdcaf49}, !- Handle
+  {dcb6fdc7-57c7-4852-b28b-1f10b85de91a}, !- Name
+  {7a6e9411-5905-4dba-9542-c40258b96678}, !- Source Object
   3,                                      !- Outlet Port
-  {e456cff4-8275-4599-8a35-b814791b54e0}, !- Target Object
+  {18358474-2815-4b3c-90ea-5fe6ef4fd105}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {9d7a670f-3a65-4239-a253-3cbb7c712c48}, !- Handle
+  {ccdba752-723b-4893-bf20-1bbf8985c62b}, !- Handle
   Pipe Adiabatic 25,                      !- Name
-  {2af1c33a-c2c5-4236-8f45-8eb68e04b6b1}, !- Inlet Node Name
-  {c678e770-d779-4e08-a362-5773d58a62e8}; !- Outlet Node Name
+  {c3f6e3a7-220f-4a25-b9da-5db4f9d6c52e}, !- Inlet Node Name
+  {852b2b29-97e3-457a-8240-a39d8156d8ed}; !- Outlet Node Name
 
 OS:Node,
-  {b0031e69-bc24-43d1-92c5-33b459e3faff}, !- Handle
+  {ddbc69f6-27e2-49be-a87f-d2a6dae78c88}, !- Handle
   Node 116,                               !- Name
-  {1664913c-8d05-4288-b83d-c67721ea084d}, !- Inlet Port
-  {2af1c33a-c2c5-4236-8f45-8eb68e04b6b1}; !- Outlet Port
+  {c969774e-36d5-4c9b-9f72-66c20ff1dd90}, !- Inlet Port
+  {c3f6e3a7-220f-4a25-b9da-5db4f9d6c52e}; !- Outlet Port
 
 OS:Connection,
-  {1664913c-8d05-4288-b83d-c67721ea084d}, !- Handle
-  {272c2814-d7f5-451d-8ae0-ede72fe6e179}, !- Name
-  {00de061f-a1c1-4c0d-b407-b11d465c25c0}, !- Source Object
+  {c969774e-36d5-4c9b-9f72-66c20ff1dd90}, !- Handle
+  {d521154a-906b-47ce-ba37-63ac32c77019}, !- Name
+  {167f8265-20ac-4fa2-951f-0fc6a8e79dde}, !- Source Object
   2,                                      !- Outlet Port
-  {b0031e69-bc24-43d1-92c5-33b459e3faff}, !- Target Object
+  {ddbc69f6-27e2-49be-a87f-d2a6dae78c88}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2af1c33a-c2c5-4236-8f45-8eb68e04b6b1}, !- Handle
-  {0b32b761-9216-48c5-9a85-a3edfda766fb}, !- Name
-  {b0031e69-bc24-43d1-92c5-33b459e3faff}, !- Source Object
+  {c3f6e3a7-220f-4a25-b9da-5db4f9d6c52e}, !- Handle
+  {1b1df673-c383-4fd9-9190-6b5f74dc9a76}, !- Name
+  {ddbc69f6-27e2-49be-a87f-d2a6dae78c88}, !- Source Object
   3,                                      !- Outlet Port
-  {9d7a670f-3a65-4239-a253-3cbb7c712c48}, !- Target Object
+  {ccdba752-723b-4893-bf20-1bbf8985c62b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c678e770-d779-4e08-a362-5773d58a62e8}, !- Handle
-  {6259709a-ef75-411d-a381-86e24c6d1965}, !- Name
-  {9d7a670f-3a65-4239-a253-3cbb7c712c48}, !- Source Object
+  {852b2b29-97e3-457a-8240-a39d8156d8ed}, !- Handle
+  {d02141ff-2426-4691-8222-9a436c4ded7c}, !- Name
+  {ccdba752-723b-4893-bf20-1bbf8985c62b}, !- Source Object
   3,                                      !- Outlet Port
-  {4cc80e65-398c-410a-8c29-66722d8970df}, !- Target Object
+  {f9466fba-621b-44e1-9f1f-22534e10821b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:PlantLoop,
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Handle
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Handle
   Condenser Water Loop 1,                 !- Name
   ,                                       !- Fluid Type
   0,                                      !- Glycol Concentration
@@ -6354,21 +6362,21 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
   ,                                       !- Primary Plant Equipment Operation Scheme
-  {29daa881-3c34-42c4-8633-c112c2bc316b}, !- Loop Temperature Setpoint Node Name
+  {54eefe27-5eb8-473b-8021-ad60bdc6d4fc}, !- Loop Temperature Setpoint Node Name
   ,                                       !- Maximum Loop Temperature {C}
   ,                                       !- Minimum Loop Temperature {C}
   ,                                       !- Maximum Loop Flow Rate {m3/s}
   ,                                       !- Minimum Loop Flow Rate {m3/s}
   Autocalculate,                          !- Plant Loop Volume {m3}
-  {5dee5a87-6930-4972-864c-c48a22450023}, !- Plant Side Inlet Node Name
-  {a160507f-87e1-4a2c-b2b0-2e6491d27f97}, !- Plant Side Outlet Node Name
+  {9dc424f5-0611-4cbc-ad51-d41fd82837c8}, !- Plant Side Inlet Node Name
+  {c6e68784-dc67-41cd-9509-a734eecbf869}, !- Plant Side Outlet Node Name
   ,                                       !- Plant Side Branch List Name
-  {2b127a8d-fe66-483f-b6bb-a40f9996c267}, !- Demand Side Inlet Node Name
-  {b170673c-8b24-450f-a5f6-fe167bec9130}, !- Demand Side Outlet Node Name
+  {1062ba54-039d-4dc7-891e-babc433ae49a}, !- Demand Side Inlet Node Name
+  {a93f622d-4b5a-47d0-b183-40c22034c48a}, !- Demand Side Outlet Node Name
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  {f9dc345f-0d53-45bd-b322-7663f88da9e7}, !- Availability Manager List Name
+  {5cab9f53-235b-49e6-af49-277d332a7888}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
   ,                                       !- Pressure Simulation Type
@@ -6376,14 +6384,14 @@ OS:PlantLoop,
   ,                                       !- Plant Equipment Operation Cooling Load Schedule
   ,                                       !- Primary Plant Equipment Operation Scheme Schedule
   ,                                       !- Component Setpoint Operation Scheme Schedule
-  {2092e766-a134-472e-a00a-38b2b1c2d6ae}, !- Demand Mixer Name
-  {9fa609d7-f7d1-4075-a9ee-8882e4762d33}, !- Demand Splitter Name
-  {eb0f6596-2925-4b0c-a9c6-62905af1ab03}, !- Supply Mixer Name
-  {00992a26-af4c-420c-8e5d-3c8b5bbdacc7}; !- Supply Splitter Name
+  {0316a5d6-6afc-49cc-b965-7f02229e9ca3}, !- Demand Mixer Name
+  {9e075730-8f1c-4f8c-b928-030b840de2f1}, !- Demand Splitter Name
+  {c5227386-386c-4331-998b-cf87c55d0e50}, !- Supply Mixer Name
+  {f270bdfd-de63-4882-83a3-8990a9b83e33}; !- Supply Splitter Name
 
 OS:Sizing:Plant,
-  {fdaad415-5c72-4eac-bb40-a48cad5eefd8}, !- Handle
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Plant or Condenser Loop Name
+  {1502fe76-f9ba-4f7a-afac-7ed482e29a7f}, !- Handle
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Plant or Condenser Loop Name
   Condenser,                              !- Loop Type
   29.4,                                   !- Design Loop Exit Temperature {C}
   5.6,                                    !- Loop Design Temperature Difference {deltaC}
@@ -6392,126 +6400,126 @@ OS:Sizing:Plant,
   None;                                   !- Coincident Sizing Factor Mode
 
 OS:Node,
-  {b7589078-5daa-425b-84c8-07a939468be0}, !- Handle
+  {eb836a85-3fc3-452a-aacf-89863139ec5a}, !- Handle
   Node 117,                               !- Name
-  {5dee5a87-6930-4972-864c-c48a22450023}, !- Inlet Port
-  {ffd0cbae-c076-41b9-8a6a-a91db7c6d68c}; !- Outlet Port
+  {9dc424f5-0611-4cbc-ad51-d41fd82837c8}, !- Inlet Port
+  {f7f3dc7d-68d8-4072-8dab-d149da556a4b}; !- Outlet Port
 
 OS:Node,
-  {29daa881-3c34-42c4-8633-c112c2bc316b}, !- Handle
+  {54eefe27-5eb8-473b-8021-ad60bdc6d4fc}, !- Handle
   Node 118,                               !- Name
-  {8b62114e-0e6e-4e02-9466-2c0d52b19f0a}, !- Inlet Port
-  {a160507f-87e1-4a2c-b2b0-2e6491d27f97}; !- Outlet Port
+  {90074bbf-dd24-4ce0-a00a-f70571a2829d}, !- Inlet Port
+  {c6e68784-dc67-41cd-9509-a734eecbf869}; !- Outlet Port
 
 OS:Node,
-  {7b0e526b-0cc1-4afb-b295-17ce1b27fc63}, !- Handle
+  {2064161e-6443-425f-9bd7-dcdc62f201ee}, !- Handle
   Node 119,                               !- Name
-  {3019c5fa-606c-4710-9e80-eb2e3125e99e}, !- Inlet Port
-  {26808513-76d5-430c-8632-288fdd54bbd1}; !- Outlet Port
+  {e8c386d9-510c-4c0c-a9cd-d7463cd76ac7}, !- Inlet Port
+  {fd97dee6-6bf1-49be-96ab-391cf7362b6f}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {eb0f6596-2925-4b0c-a9c6-62905af1ab03}, !- Handle
+  {c5227386-386c-4331-998b-cf87c55d0e50}, !- Handle
   Connector Mixer 11,                     !- Name
-  {256d2afe-4bce-4889-92e2-cb1dc9050a75}, !- Outlet Branch Name
-  {8738bf9d-1739-4e0f-b986-ee5e05d759d7}, !- Inlet Branch Name 1
-  {dc959968-7742-42bb-b7d0-2c48207bcc48}; !- Inlet Branch Name 2
+  {9bf5bf88-3d03-4a8a-8d71-57c5496fa79c}, !- Outlet Branch Name
+  {0c5e3211-2d90-4dc7-a3ea-cc484b788f42}, !- Inlet Branch Name 1
+  {9088bcd1-4059-4377-b12e-63b88080248a}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {00992a26-af4c-420c-8e5d-3c8b5bbdacc7}, !- Handle
+  {f270bdfd-de63-4882-83a3-8990a9b83e33}, !- Handle
   Connector Splitter 11,                  !- Name
-  {7ab44c93-1334-43e7-a816-0eb442234436}, !- Inlet Branch Name
-  {3019c5fa-606c-4710-9e80-eb2e3125e99e}, !- Outlet Branch Name 1
-  {39be84f7-ee5a-4b26-b467-d89e764a7232}; !- Outlet Branch Name 2
+  {5161877d-6e97-4e8b-b6f1-2a7c157eab9b}, !- Inlet Branch Name
+  {e8c386d9-510c-4c0c-a9cd-d7463cd76ac7}, !- Outlet Branch Name 1
+  {586db999-5cae-4af4-b3ce-ac568c50a772}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {5dee5a87-6930-4972-864c-c48a22450023}, !- Handle
-  {99232b34-1f3c-414e-bd7f-6e3f7bda4f80}, !- Name
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Source Object
+  {9dc424f5-0611-4cbc-ad51-d41fd82837c8}, !- Handle
+  {4ed57540-adfc-49bb-8b57-6fac26f1e98a}, !- Name
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Source Object
   14,                                     !- Outlet Port
-  {b7589078-5daa-425b-84c8-07a939468be0}, !- Target Object
+  {eb836a85-3fc3-452a-aacf-89863139ec5a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {3019c5fa-606c-4710-9e80-eb2e3125e99e}, !- Handle
-  {ead07a0a-798f-4f51-861e-9e5445816ba2}, !- Name
-  {00992a26-af4c-420c-8e5d-3c8b5bbdacc7}, !- Source Object
+  {e8c386d9-510c-4c0c-a9cd-d7463cd76ac7}, !- Handle
+  {33b638b5-a43d-4d6c-ad60-e65f68fa11b4}, !- Name
+  {f270bdfd-de63-4882-83a3-8990a9b83e33}, !- Source Object
   3,                                      !- Outlet Port
-  {7b0e526b-0cc1-4afb-b295-17ce1b27fc63}, !- Target Object
+  {2064161e-6443-425f-9bd7-dcdc62f201ee}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a160507f-87e1-4a2c-b2b0-2e6491d27f97}, !- Handle
-  {9bfb0dbe-7e61-43ca-9f0f-7cb6ffbfccac}, !- Name
-  {29daa881-3c34-42c4-8633-c112c2bc316b}, !- Source Object
+  {c6e68784-dc67-41cd-9509-a734eecbf869}, !- Handle
+  {e8f26399-def5-4be1-ad5b-8358e6c65f2b}, !- Name
+  {54eefe27-5eb8-473b-8021-ad60bdc6d4fc}, !- Source Object
   3,                                      !- Outlet Port
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Target Object
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Target Object
   15;                                     !- Inlet Port
 
 OS:Node,
-  {4fe4af14-ada5-4ee4-9069-23a019900026}, !- Handle
+  {09eb4ebf-fb2c-4a6e-be3a-d506d2cd5e86}, !- Handle
   Node 120,                               !- Name
-  {2b127a8d-fe66-483f-b6bb-a40f9996c267}, !- Inlet Port
-  {b3c05703-1fff-4f19-86fa-44c4b2ab3038}; !- Outlet Port
+  {1062ba54-039d-4dc7-891e-babc433ae49a}, !- Inlet Port
+  {bb24aa0b-cd3e-4202-a995-622637e715f7}; !- Outlet Port
 
 OS:Node,
-  {6ecee92a-39b8-482c-bf5f-fec1483b4e93}, !- Handle
+  {89be91ef-ead5-4a21-9a73-bbb5b27b094b}, !- Handle
   Node 121,                               !- Name
-  {7bdf6ca8-446b-468a-92a1-4af3ab9aa60d}, !- Inlet Port
-  {b170673c-8b24-450f-a5f6-fe167bec9130}; !- Outlet Port
+  {0d2335bc-9e9f-46ce-b479-579bde4ae244}, !- Inlet Port
+  {a93f622d-4b5a-47d0-b183-40c22034c48a}; !- Outlet Port
 
 OS:Node,
-  {37cd20a6-3f17-45b2-9b49-33832cc37e97}, !- Handle
+  {31d00f2a-e2e4-4999-8fae-4597980e42cb}, !- Handle
   Node 122,                               !- Name
-  {710e1775-6272-4b02-94b8-e7fba60968d4}, !- Inlet Port
-  {db119f20-167c-4d08-8c5c-ecd631dae498}; !- Outlet Port
+  {b72a3ade-6ce1-4843-9ed8-e4cd49811f15}, !- Inlet Port
+  {1ac82f54-903e-4369-9993-424bca9ff0f2}; !- Outlet Port
 
 OS:Connector:Mixer,
-  {2092e766-a134-472e-a00a-38b2b1c2d6ae}, !- Handle
+  {0316a5d6-6afc-49cc-b965-7f02229e9ca3}, !- Handle
   Connector Mixer 12,                     !- Name
-  {f42643b0-82ec-4d88-8045-9527c50fbde0}, !- Outlet Branch Name
-  {71527dc2-01f2-4fcb-abfa-36197f75b242}, !- Inlet Branch Name 1
-  {ef59ddbc-4b6f-4a99-a09b-49040551193a}; !- Inlet Branch Name 2
+  {68bb0c10-de47-4191-b2b4-68bb0cad3a5d}, !- Outlet Branch Name
+  {1773bc50-0787-414d-b5c7-43d5439e21c7}, !- Inlet Branch Name 1
+  {0c030d40-bbde-4265-af15-52aa80b8f5ec}; !- Inlet Branch Name 2
 
 OS:Connector:Splitter,
-  {9fa609d7-f7d1-4075-a9ee-8882e4762d33}, !- Handle
+  {9e075730-8f1c-4f8c-b928-030b840de2f1}, !- Handle
   Connector Splitter 12,                  !- Name
-  {85e93d36-a425-4b92-b06d-411eae37f598}, !- Inlet Branch Name
-  {710e1775-6272-4b02-94b8-e7fba60968d4}, !- Outlet Branch Name 1
-  {49400498-cfac-4858-a365-94da3888d382}; !- Outlet Branch Name 2
+  {fd7e6381-efd1-4c87-b56e-355364eb5a67}, !- Inlet Branch Name
+  {b72a3ade-6ce1-4843-9ed8-e4cd49811f15}, !- Outlet Branch Name 1
+  {11288021-cd15-42dd-bf90-7dbbb1e0d071}; !- Outlet Branch Name 2
 
 OS:Connection,
-  {2b127a8d-fe66-483f-b6bb-a40f9996c267}, !- Handle
-  {299c559f-3cd2-446d-a712-27dd01d941e4}, !- Name
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Source Object
+  {1062ba54-039d-4dc7-891e-babc433ae49a}, !- Handle
+  {edb26676-5b72-434f-81d6-e5264a7df059}, !- Name
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Source Object
   17,                                     !- Outlet Port
-  {4fe4af14-ada5-4ee4-9069-23a019900026}, !- Target Object
+  {09eb4ebf-fb2c-4a6e-be3a-d506d2cd5e86}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {710e1775-6272-4b02-94b8-e7fba60968d4}, !- Handle
-  {118f06da-bce6-4d54-a4f2-6fd69d99b120}, !- Name
-  {9fa609d7-f7d1-4075-a9ee-8882e4762d33}, !- Source Object
+  {b72a3ade-6ce1-4843-9ed8-e4cd49811f15}, !- Handle
+  {39ec2c89-0803-4492-9615-94b370ee8d5b}, !- Name
+  {9e075730-8f1c-4f8c-b928-030b840de2f1}, !- Source Object
   3,                                      !- Outlet Port
-  {37cd20a6-3f17-45b2-9b49-33832cc37e97}, !- Target Object
+  {31d00f2a-e2e4-4999-8fae-4597980e42cb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b170673c-8b24-450f-a5f6-fe167bec9130}, !- Handle
-  {624c9c60-9493-49eb-811c-ac297642630d}, !- Name
-  {6ecee92a-39b8-482c-bf5f-fec1483b4e93}, !- Source Object
+  {a93f622d-4b5a-47d0-b183-40c22034c48a}, !- Handle
+  {23be2fb6-083e-489c-8666-bbc9e1fc818c}, !- Name
+  {89be91ef-ead5-4a21-9a73-bbb5b27b094b}, !- Source Object
   3,                                      !- Outlet Port
-  {8ad36959-2adb-4ba5-9881-c0a4e358f5a5}, !- Target Object
+  {64259998-456f-471f-9c16-4073f14bab5a}, !- Target Object
   18;                                     !- Inlet Port
 
 OS:AvailabilityManagerAssignmentList,
-  {f9dc345f-0d53-45bd-b322-7663f88da9e7}, !- Handle
+  {5cab9f53-235b-49e6-af49-277d332a7888}, !- Handle
   Plant Loop 1 AvailabilityManagerAssignmentList 5; !- Name
 
 OS:CoolingTower:SingleSpeed,
-  {8f80e286-b6e6-4ca2-8468-108786bdb029}, !- Handle
+  {a1ae9292-f7b1-46a3-9972-5c19f61e63b9}, !- Handle
   Cooling Tower Single Speed 2,           !- Name
-  {26808513-76d5-430c-8632-288fdd54bbd1}, !- Water Inlet Node Name
-  {47823719-2cd7-4de1-b3f7-470f5b0197c0}, !- Water Outlet Node Name
+  {fd97dee6-6bf1-49be-96ab-391cf7362b6f}, !- Water Inlet Node Name
+  {ec053b46-9f70-492c-8297-a9ababa88484}, !- Water Outlet Node Name
   autosize,                               !- Design Water Flow Rate {m3/s}
   autosize,                               !- Design Air Flow Rate {m3/s}
   autosize,                               !- Fan Power at Design Air Flow Rate {W}
@@ -6548,126 +6556,126 @@ OS:CoolingTower:SingleSpeed,
   General;                                !- End-Use Subcategory
 
 OS:Node,
-  {d9a421a3-1b8b-43aa-b371-3a1380c2d74f}, !- Handle
+  {5066d497-e122-4258-b4da-dd428c2874f3}, !- Handle
   Node 123,                               !- Name
-  {47823719-2cd7-4de1-b3f7-470f5b0197c0}, !- Inlet Port
-  {8738bf9d-1739-4e0f-b986-ee5e05d759d7}; !- Outlet Port
+  {ec053b46-9f70-492c-8297-a9ababa88484}, !- Inlet Port
+  {0c5e3211-2d90-4dc7-a3ea-cc484b788f42}; !- Outlet Port
 
 OS:Connection,
-  {26808513-76d5-430c-8632-288fdd54bbd1}, !- Handle
-  {2e4d8dd9-5288-4353-b90f-672be656f18f}, !- Name
-  {7b0e526b-0cc1-4afb-b295-17ce1b27fc63}, !- Source Object
+  {fd97dee6-6bf1-49be-96ab-391cf7362b6f}, !- Handle
+  {8a465643-d07e-462e-845b-d1d8432448fd}, !- Name
+  {2064161e-6443-425f-9bd7-dcdc62f201ee}, !- Source Object
   3,                                      !- Outlet Port
-  {8f80e286-b6e6-4ca2-8468-108786bdb029}, !- Target Object
+  {a1ae9292-f7b1-46a3-9972-5c19f61e63b9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {47823719-2cd7-4de1-b3f7-470f5b0197c0}, !- Handle
-  {12fa83a6-5753-4e31-b0d6-9cc489d93520}, !- Name
-  {8f80e286-b6e6-4ca2-8468-108786bdb029}, !- Source Object
+  {ec053b46-9f70-492c-8297-a9ababa88484}, !- Handle
+  {1f675bba-832a-46c2-927f-8be86052cbcc}, !- Name
+  {a1ae9292-f7b1-46a3-9972-5c19f61e63b9}, !- Source Object
   3,                                      !- Outlet Port
-  {d9a421a3-1b8b-43aa-b371-3a1380c2d74f}, !- Target Object
+  {5066d497-e122-4258-b4da-dd428c2874f3}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8738bf9d-1739-4e0f-b986-ee5e05d759d7}, !- Handle
-  {19e113c5-8441-4818-a608-32e01b02f2d7}, !- Name
-  {d9a421a3-1b8b-43aa-b371-3a1380c2d74f}, !- Source Object
+  {0c5e3211-2d90-4dc7-a3ea-cc484b788f42}, !- Handle
+  {607ae570-162a-4176-a807-90f653eb8830}, !- Name
+  {5066d497-e122-4258-b4da-dd428c2874f3}, !- Source Object
   3,                                      !- Outlet Port
-  {eb0f6596-2925-4b0c-a9c6-62905af1ab03}, !- Target Object
+  {c5227386-386c-4331-998b-cf87c55d0e50}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {6420a287-cd36-4fbc-951c-cd0554de9c94}, !- Handle
+  {6dbaa414-9a3b-4cdc-9750-55e332f66ae5}, !- Handle
   Pipe Adiabatic 26,                      !- Name
-  {2302e09a-8a1a-45f7-945a-e7000107f632}, !- Inlet Node Name
-  {8f1c0147-2e19-458b-a710-923f23a6f071}; !- Outlet Node Name
+  {0e463071-863b-4ccb-bbdf-aeb6c741aad8}, !- Inlet Node Name
+  {043dafc5-46dd-408d-88f8-cdf4734d760f}; !- Outlet Node Name
 
 OS:Node,
-  {120a6e2c-0fb4-4b51-b1f6-f5f9491f4568}, !- Handle
+  {e4f8fcce-76a1-4dcf-8d06-33225db2af3b}, !- Handle
   Node 124,                               !- Name
-  {39be84f7-ee5a-4b26-b467-d89e764a7232}, !- Inlet Port
-  {2302e09a-8a1a-45f7-945a-e7000107f632}; !- Outlet Port
+  {586db999-5cae-4af4-b3ce-ac568c50a772}, !- Inlet Port
+  {0e463071-863b-4ccb-bbdf-aeb6c741aad8}; !- Outlet Port
 
 OS:Connection,
-  {39be84f7-ee5a-4b26-b467-d89e764a7232}, !- Handle
-  {bd5af652-04d4-491a-a844-61f0748ab1b6}, !- Name
-  {00992a26-af4c-420c-8e5d-3c8b5bbdacc7}, !- Source Object
+  {586db999-5cae-4af4-b3ce-ac568c50a772}, !- Handle
+  {bc94ea05-650a-4b45-8633-4e974e06964d}, !- Name
+  {f270bdfd-de63-4882-83a3-8990a9b83e33}, !- Source Object
   4,                                      !- Outlet Port
-  {120a6e2c-0fb4-4b51-b1f6-f5f9491f4568}, !- Target Object
+  {e4f8fcce-76a1-4dcf-8d06-33225db2af3b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {12a89066-2ccb-4109-926a-27ba63514fc8}, !- Handle
+  {5820bed2-f239-4374-be7c-1337a6cdd179}, !- Handle
   Node 125,                               !- Name
-  {8f1c0147-2e19-458b-a710-923f23a6f071}, !- Inlet Port
-  {dc959968-7742-42bb-b7d0-2c48207bcc48}; !- Outlet Port
+  {043dafc5-46dd-408d-88f8-cdf4734d760f}, !- Inlet Port
+  {9088bcd1-4059-4377-b12e-63b88080248a}; !- Outlet Port
 
 OS:Connection,
-  {2302e09a-8a1a-45f7-945a-e7000107f632}, !- Handle
-  {68b83b5c-7204-402e-b3be-2a82e4a3b6d0}, !- Name
-  {120a6e2c-0fb4-4b51-b1f6-f5f9491f4568}, !- Source Object
+  {0e463071-863b-4ccb-bbdf-aeb6c741aad8}, !- Handle
+  {efd3ba1c-d6c6-4a1c-bc20-3a7087ec477d}, !- Name
+  {e4f8fcce-76a1-4dcf-8d06-33225db2af3b}, !- Source Object
   3,                                      !- Outlet Port
-  {6420a287-cd36-4fbc-951c-cd0554de9c94}, !- Target Object
+  {6dbaa414-9a3b-4cdc-9750-55e332f66ae5}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8f1c0147-2e19-458b-a710-923f23a6f071}, !- Handle
-  {28e453b1-5a23-431f-bc3f-8edeb39cdad6}, !- Name
-  {6420a287-cd36-4fbc-951c-cd0554de9c94}, !- Source Object
+  {043dafc5-46dd-408d-88f8-cdf4734d760f}, !- Handle
+  {eaf903c1-0a9c-41c2-81b4-2ee30c90c4e7}, !- Name
+  {6dbaa414-9a3b-4cdc-9750-55e332f66ae5}, !- Source Object
   3,                                      !- Outlet Port
-  {12a89066-2ccb-4109-926a-27ba63514fc8}, !- Target Object
+  {5820bed2-f239-4374-be7c-1337a6cdd179}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {dc959968-7742-42bb-b7d0-2c48207bcc48}, !- Handle
-  {0daa3871-9377-415a-a760-7baf9bbb8d1b}, !- Name
-  {12a89066-2ccb-4109-926a-27ba63514fc8}, !- Source Object
+  {9088bcd1-4059-4377-b12e-63b88080248a}, !- Handle
+  {5327d10d-efa8-4cef-9008-2b6654c52744}, !- Name
+  {5820bed2-f239-4374-be7c-1337a6cdd179}, !- Source Object
   3,                                      !- Outlet Port
-  {eb0f6596-2925-4b0c-a9c6-62905af1ab03}, !- Target Object
+  {c5227386-386c-4331-998b-cf87c55d0e50}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {43c7d93f-b252-4f4c-ac17-42d70d1bfa32}, !- Handle
+  {aa3d5fc4-5e00-48ef-b1ef-95002cfa794c}, !- Handle
   Pipe Adiabatic 27,                      !- Name
-  {5b6408d8-5121-435a-952e-a32880af7129}, !- Inlet Node Name
-  {8b62114e-0e6e-4e02-9466-2c0d52b19f0a}; !- Outlet Node Name
+  {f7a64229-3d04-46af-8a16-914ba15b0951}, !- Inlet Node Name
+  {90074bbf-dd24-4ce0-a00a-f70571a2829d}; !- Outlet Node Name
 
 OS:Node,
-  {b121610c-7087-4a34-ba6e-0e5a76dae971}, !- Handle
+  {365e2695-2c3d-4a43-9f54-dfb525b60666}, !- Handle
   Node 126,                               !- Name
-  {256d2afe-4bce-4889-92e2-cb1dc9050a75}, !- Inlet Port
-  {5b6408d8-5121-435a-952e-a32880af7129}; !- Outlet Port
+  {9bf5bf88-3d03-4a8a-8d71-57c5496fa79c}, !- Inlet Port
+  {f7a64229-3d04-46af-8a16-914ba15b0951}; !- Outlet Port
 
 OS:Connection,
-  {256d2afe-4bce-4889-92e2-cb1dc9050a75}, !- Handle
-  {c5e2b047-b193-4743-8b5b-3e7bfb90beb5}, !- Name
-  {eb0f6596-2925-4b0c-a9c6-62905af1ab03}, !- Source Object
+  {9bf5bf88-3d03-4a8a-8d71-57c5496fa79c}, !- Handle
+  {f30734bc-a3f4-4fc7-b949-f4baf8f3f701}, !- Name
+  {c5227386-386c-4331-998b-cf87c55d0e50}, !- Source Object
   2,                                      !- Outlet Port
-  {b121610c-7087-4a34-ba6e-0e5a76dae971}, !- Target Object
+  {365e2695-2c3d-4a43-9f54-dfb525b60666}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5b6408d8-5121-435a-952e-a32880af7129}, !- Handle
-  {b6a20482-723c-44b1-b45e-80149e99fb04}, !- Name
-  {b121610c-7087-4a34-ba6e-0e5a76dae971}, !- Source Object
+  {f7a64229-3d04-46af-8a16-914ba15b0951}, !- Handle
+  {cd73bb85-cb44-49e9-b5ef-89706462ba93}, !- Name
+  {365e2695-2c3d-4a43-9f54-dfb525b60666}, !- Source Object
   3,                                      !- Outlet Port
-  {43c7d93f-b252-4f4c-ac17-42d70d1bfa32}, !- Target Object
+  {aa3d5fc4-5e00-48ef-b1ef-95002cfa794c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8b62114e-0e6e-4e02-9466-2c0d52b19f0a}, !- Handle
-  {07f9ae34-e39f-4dc5-bde7-ae7592a92975}, !- Name
-  {43c7d93f-b252-4f4c-ac17-42d70d1bfa32}, !- Source Object
+  {90074bbf-dd24-4ce0-a00a-f70571a2829d}, !- Handle
+  {207fdbf5-9f6b-4c20-a052-bcbff3e5826c}, !- Name
+  {aa3d5fc4-5e00-48ef-b1ef-95002cfa794c}, !- Source Object
   3,                                      !- Outlet Port
-  {29daa881-3c34-42c4-8633-c112c2bc316b}, !- Target Object
+  {54eefe27-5eb8-473b-8021-ad60bdc6d4fc}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pump:VariableSpeed,
-  {c8998907-0377-4f00-b2e7-7a83c6ab25ad}, !- Handle
+  {a300f71f-9896-4610-a7dc-b1fbff321605}, !- Handle
   Pump Variable Speed 6,                  !- Name
-  {ffd0cbae-c076-41b9-8a6a-a91db7c6d68c}, !- Inlet Node Name
-  {2df887a5-d883-4371-8b25-869bb89cca3b}, !- Outlet Node Name
+  {f7f3dc7d-68d8-4072-8dab-d149da556a4b}, !- Inlet Node Name
+  {6a06e48d-baee-4ef6-bdf8-703077c7ad70}, !- Outlet Node Name
   ,                                       !- Rated Flow Rate {m3/s}
   ,                                       !- Rated Pump Head {Pa}
   ,                                       !- Rated Power Consumption {W}
@@ -6696,233 +6704,233 @@ OS:Pump:VariableSpeed,
   0;                                      !- Design Minimum Flow Rate Fraction
 
 OS:Node,
-  {331b6311-cf2c-4826-99c1-c415f325527a}, !- Handle
+  {ce5e5257-8ddf-416e-8ad9-30172b97a4f0}, !- Handle
   Node 127,                               !- Name
-  {2df887a5-d883-4371-8b25-869bb89cca3b}, !- Inlet Port
-  {7ab44c93-1334-43e7-a816-0eb442234436}; !- Outlet Port
+  {6a06e48d-baee-4ef6-bdf8-703077c7ad70}, !- Inlet Port
+  {5161877d-6e97-4e8b-b6f1-2a7c157eab9b}; !- Outlet Port
 
 OS:Connection,
-  {ffd0cbae-c076-41b9-8a6a-a91db7c6d68c}, !- Handle
-  {c357b85a-ae31-4dda-b671-9dcdf8a53b48}, !- Name
-  {b7589078-5daa-425b-84c8-07a939468be0}, !- Source Object
+  {f7f3dc7d-68d8-4072-8dab-d149da556a4b}, !- Handle
+  {426dcf52-6883-4c44-b960-a50849e20afa}, !- Name
+  {eb836a85-3fc3-452a-aacf-89863139ec5a}, !- Source Object
   3,                                      !- Outlet Port
-  {c8998907-0377-4f00-b2e7-7a83c6ab25ad}, !- Target Object
+  {a300f71f-9896-4610-a7dc-b1fbff321605}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2df887a5-d883-4371-8b25-869bb89cca3b}, !- Handle
-  {0d97a91d-5811-4408-81bc-bfdd92695d54}, !- Name
-  {c8998907-0377-4f00-b2e7-7a83c6ab25ad}, !- Source Object
+  {6a06e48d-baee-4ef6-bdf8-703077c7ad70}, !- Handle
+  {9889cd59-400e-4ee5-9e27-987c324837c1}, !- Name
+  {a300f71f-9896-4610-a7dc-b1fbff321605}, !- Source Object
   3,                                      !- Outlet Port
-  {331b6311-cf2c-4826-99c1-c415f325527a}, !- Target Object
+  {ce5e5257-8ddf-416e-8ad9-30172b97a4f0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7ab44c93-1334-43e7-a816-0eb442234436}, !- Handle
-  {303bd81a-9cec-456d-add4-e47b3a41ef34}, !- Name
-  {331b6311-cf2c-4826-99c1-c415f325527a}, !- Source Object
+  {5161877d-6e97-4e8b-b6f1-2a7c157eab9b}, !- Handle
+  {bf6d7792-03a2-4c48-8840-fbc77970a974}, !- Name
+  {ce5e5257-8ddf-416e-8ad9-30172b97a4f0}, !- Source Object
   3,                                      !- Outlet Port
-  {00992a26-af4c-420c-8e5d-3c8b5bbdacc7}, !- Target Object
+  {f270bdfd-de63-4882-83a3-8990a9b83e33}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {be81c69c-b773-4f87-b6d2-68c462496cfe}, !- Handle
+  {86c73f9d-2491-404f-8d53-fce396fecdac}, !- Handle
   Node 128,                               !- Name
-  {534d9792-6d2a-4d59-a798-e9c471410f08}, !- Inlet Port
-  {71527dc2-01f2-4fcb-abfa-36197f75b242}; !- Outlet Port
+  {71dc6505-11ed-4fb8-97b2-b1f90d17df6e}, !- Inlet Port
+  {1773bc50-0787-414d-b5c7-43d5439e21c7}; !- Outlet Port
 
 OS:Connection,
-  {db119f20-167c-4d08-8c5c-ecd631dae498}, !- Handle
-  {9e870c03-9d02-4679-84be-41d1d20a7895}, !- Name
-  {37cd20a6-3f17-45b2-9b49-33832cc37e97}, !- Source Object
+  {1ac82f54-903e-4369-9993-424bca9ff0f2}, !- Handle
+  {60af028a-72b6-4439-bbcb-692d6ecb2739}, !- Name
+  {31d00f2a-e2e4-4999-8fae-4597980e42cb}, !- Source Object
   3,                                      !- Outlet Port
-  {ab01a737-8119-4bd6-97a6-cd847b52d340}, !- Target Object
+  {6ebfdf57-c0f7-46d0-b1fc-fb78811ee76e}, !- Target Object
   17;                                     !- Inlet Port
 
 OS:Connection,
-  {534d9792-6d2a-4d59-a798-e9c471410f08}, !- Handle
-  {4ff32e84-fa59-4b3b-aaae-943606104efc}, !- Name
-  {ab01a737-8119-4bd6-97a6-cd847b52d340}, !- Source Object
+  {71dc6505-11ed-4fb8-97b2-b1f90d17df6e}, !- Handle
+  {7e03962e-9e3f-40ce-88de-d44842c68e25}, !- Name
+  {6ebfdf57-c0f7-46d0-b1fc-fb78811ee76e}, !- Source Object
   18,                                     !- Outlet Port
-  {be81c69c-b773-4f87-b6d2-68c462496cfe}, !- Target Object
+  {86c73f9d-2491-404f-8d53-fce396fecdac}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {71527dc2-01f2-4fcb-abfa-36197f75b242}, !- Handle
-  {7c2ffc8c-498e-4bc2-9018-ed1128013972}, !- Name
-  {be81c69c-b773-4f87-b6d2-68c462496cfe}, !- Source Object
+  {1773bc50-0787-414d-b5c7-43d5439e21c7}, !- Handle
+  {31a700b3-f7fa-4d37-8725-cc5909771e07}, !- Name
+  {86c73f9d-2491-404f-8d53-fce396fecdac}, !- Source Object
   3,                                      !- Outlet Port
-  {2092e766-a134-472e-a00a-38b2b1c2d6ae}, !- Target Object
+  {0316a5d6-6afc-49cc-b965-7f02229e9ca3}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {7ff44b42-0cf1-49aa-8a9d-2d743666013f}, !- Handle
+  {246deae4-ec92-4cfe-813b-74bae9229ad9}, !- Handle
   Pipe Adiabatic 28,                      !- Name
-  {7bf96b1a-2f48-43d4-9e86-94fb7fb15413}, !- Inlet Node Name
-  {c63c1b94-b004-43ed-bda7-25e2d4d0b7fd}; !- Outlet Node Name
+  {975c1da5-5886-49fa-a23a-b64543050505}, !- Inlet Node Name
+  {1bd89b34-6368-4412-91fb-3a5ba26bdbdb}; !- Outlet Node Name
 
 OS:Node,
-  {c51ae49c-b517-480e-b8dd-079057f4d12f}, !- Handle
+  {88e5892e-41e4-458a-81c3-005d68d0ae86}, !- Handle
   Node 129,                               !- Name
-  {49400498-cfac-4858-a365-94da3888d382}, !- Inlet Port
-  {7bf96b1a-2f48-43d4-9e86-94fb7fb15413}; !- Outlet Port
+  {11288021-cd15-42dd-bf90-7dbbb1e0d071}, !- Inlet Port
+  {975c1da5-5886-49fa-a23a-b64543050505}; !- Outlet Port
 
 OS:Connection,
-  {49400498-cfac-4858-a365-94da3888d382}, !- Handle
-  {76f0814e-c37d-419d-a117-d0c4d4b39729}, !- Name
-  {9fa609d7-f7d1-4075-a9ee-8882e4762d33}, !- Source Object
+  {11288021-cd15-42dd-bf90-7dbbb1e0d071}, !- Handle
+  {b5729708-4c52-413a-bf23-fb003cd9fe4f}, !- Name
+  {9e075730-8f1c-4f8c-b928-030b840de2f1}, !- Source Object
   4,                                      !- Outlet Port
-  {c51ae49c-b517-480e-b8dd-079057f4d12f}, !- Target Object
+  {88e5892e-41e4-458a-81c3-005d68d0ae86}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {eb35820c-568c-493f-b5d9-7104e90f7d3d}, !- Handle
+  {28985703-83cc-4687-a6cd-172658961f58}, !- Handle
   Node 130,                               !- Name
-  {c63c1b94-b004-43ed-bda7-25e2d4d0b7fd}, !- Inlet Port
-  {ef59ddbc-4b6f-4a99-a09b-49040551193a}; !- Outlet Port
+  {1bd89b34-6368-4412-91fb-3a5ba26bdbdb}, !- Inlet Port
+  {0c030d40-bbde-4265-af15-52aa80b8f5ec}; !- Outlet Port
 
 OS:Connection,
-  {7bf96b1a-2f48-43d4-9e86-94fb7fb15413}, !- Handle
-  {ba827456-2e9f-4150-996a-d81a01e7fd5c}, !- Name
-  {c51ae49c-b517-480e-b8dd-079057f4d12f}, !- Source Object
+  {975c1da5-5886-49fa-a23a-b64543050505}, !- Handle
+  {d0b3bf64-441c-4d16-ad54-f0765af4e0e8}, !- Name
+  {88e5892e-41e4-458a-81c3-005d68d0ae86}, !- Source Object
   3,                                      !- Outlet Port
-  {7ff44b42-0cf1-49aa-8a9d-2d743666013f}, !- Target Object
+  {246deae4-ec92-4cfe-813b-74bae9229ad9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {c63c1b94-b004-43ed-bda7-25e2d4d0b7fd}, !- Handle
-  {adaedf5e-dff7-46b6-aba7-1664d02f651d}, !- Name
-  {7ff44b42-0cf1-49aa-8a9d-2d743666013f}, !- Source Object
+  {1bd89b34-6368-4412-91fb-3a5ba26bdbdb}, !- Handle
+  {58daca27-9dd7-4708-953a-bb1da5c30c32}, !- Name
+  {246deae4-ec92-4cfe-813b-74bae9229ad9}, !- Source Object
   3,                                      !- Outlet Port
-  {eb35820c-568c-493f-b5d9-7104e90f7d3d}, !- Target Object
+  {28985703-83cc-4687-a6cd-172658961f58}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {ef59ddbc-4b6f-4a99-a09b-49040551193a}, !- Handle
-  {44e53784-7827-4f34-b1ae-6a78d91bd567}, !- Name
-  {eb35820c-568c-493f-b5d9-7104e90f7d3d}, !- Source Object
+  {0c030d40-bbde-4265-af15-52aa80b8f5ec}, !- Handle
+  {b37587ac-ff79-433a-b220-7cf29719fd18}, !- Name
+  {28985703-83cc-4687-a6cd-172658961f58}, !- Source Object
   3,                                      !- Outlet Port
-  {2092e766-a134-472e-a00a-38b2b1c2d6ae}, !- Target Object
+  {0316a5d6-6afc-49cc-b965-7f02229e9ca3}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {e7ad2ccd-fdb3-4037-9239-f568557adde2}, !- Handle
+  {9458a463-b22d-412d-96af-b04332c9dfae}, !- Handle
   Pipe Adiabatic 29,                      !- Name
-  {b3c05703-1fff-4f19-86fa-44c4b2ab3038}, !- Inlet Node Name
-  {5df08018-cb3d-4d25-9815-d5389d6e2cf7}; !- Outlet Node Name
+  {bb24aa0b-cd3e-4202-a995-622637e715f7}, !- Inlet Node Name
+  {34a15dc0-34b1-435e-9347-c39f6a7c449b}; !- Outlet Node Name
 
 OS:Node,
-  {2b786039-c3cc-45e2-9b0e-8fc34ccc34e2}, !- Handle
+  {7de0c800-b526-41f4-b14e-dc0e0b7a77bf}, !- Handle
   Node 131,                               !- Name
-  {5df08018-cb3d-4d25-9815-d5389d6e2cf7}, !- Inlet Port
-  {85e93d36-a425-4b92-b06d-411eae37f598}; !- Outlet Port
+  {34a15dc0-34b1-435e-9347-c39f6a7c449b}, !- Inlet Port
+  {fd7e6381-efd1-4c87-b56e-355364eb5a67}; !- Outlet Port
 
 OS:Connection,
-  {b3c05703-1fff-4f19-86fa-44c4b2ab3038}, !- Handle
-  {569d70a0-9a89-4d64-8863-05ff95d77cab}, !- Name
-  {4fe4af14-ada5-4ee4-9069-23a019900026}, !- Source Object
+  {bb24aa0b-cd3e-4202-a995-622637e715f7}, !- Handle
+  {38d390f4-f19b-41f9-88a1-4e6e4333f15d}, !- Name
+  {09eb4ebf-fb2c-4a6e-be3a-d506d2cd5e86}, !- Source Object
   3,                                      !- Outlet Port
-  {e7ad2ccd-fdb3-4037-9239-f568557adde2}, !- Target Object
+  {9458a463-b22d-412d-96af-b04332c9dfae}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {5df08018-cb3d-4d25-9815-d5389d6e2cf7}, !- Handle
-  {468e437f-aa1c-443e-b851-3824c8e98c53}, !- Name
-  {e7ad2ccd-fdb3-4037-9239-f568557adde2}, !- Source Object
+  {34a15dc0-34b1-435e-9347-c39f6a7c449b}, !- Handle
+  {830fa28e-1ac6-49ce-ad7a-67130b136e66}, !- Name
+  {9458a463-b22d-412d-96af-b04332c9dfae}, !- Source Object
   3,                                      !- Outlet Port
-  {2b786039-c3cc-45e2-9b0e-8fc34ccc34e2}, !- Target Object
+  {7de0c800-b526-41f4-b14e-dc0e0b7a77bf}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {85e93d36-a425-4b92-b06d-411eae37f598}, !- Handle
-  {55bd4237-3c7b-4595-bd08-cd238811b9be}, !- Name
-  {2b786039-c3cc-45e2-9b0e-8fc34ccc34e2}, !- Source Object
+  {fd7e6381-efd1-4c87-b56e-355364eb5a67}, !- Handle
+  {c41d391d-8fb1-4759-9008-c045eefd1d92}, !- Name
+  {7de0c800-b526-41f4-b14e-dc0e0b7a77bf}, !- Source Object
   3,                                      !- Outlet Port
-  {9fa609d7-f7d1-4075-a9ee-8882e4762d33}, !- Target Object
+  {9e075730-8f1c-4f8c-b928-030b840de2f1}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Pipe:Adiabatic,
-  {6bfa884e-13e3-43e1-9ba0-6a08a99839e9}, !- Handle
+  {bee5e070-f328-49d0-87f7-2090544024f2}, !- Handle
   Pipe Adiabatic 30,                      !- Name
-  {38ae5b28-cdc3-436a-a2c1-87428497c72d}, !- Inlet Node Name
-  {7bdf6ca8-446b-468a-92a1-4af3ab9aa60d}; !- Outlet Node Name
+  {59077e34-6078-4056-b82f-a749eb70dc24}, !- Inlet Node Name
+  {0d2335bc-9e9f-46ce-b479-579bde4ae244}; !- Outlet Node Name
 
 OS:Node,
-  {de0c5a49-de90-4b5b-b7b8-677a5a3fdce3}, !- Handle
+  {2c20ac24-e975-47a8-8bfc-82e0fcd991d9}, !- Handle
   Node 132,                               !- Name
-  {f42643b0-82ec-4d88-8045-9527c50fbde0}, !- Inlet Port
-  {38ae5b28-cdc3-436a-a2c1-87428497c72d}; !- Outlet Port
+  {68bb0c10-de47-4191-b2b4-68bb0cad3a5d}, !- Inlet Port
+  {59077e34-6078-4056-b82f-a749eb70dc24}; !- Outlet Port
 
 OS:Connection,
-  {f42643b0-82ec-4d88-8045-9527c50fbde0}, !- Handle
-  {efc2b247-f465-4c88-be87-34f2f2157b34}, !- Name
-  {2092e766-a134-472e-a00a-38b2b1c2d6ae}, !- Source Object
+  {68bb0c10-de47-4191-b2b4-68bb0cad3a5d}, !- Handle
+  {82390f4d-d26d-48b8-b139-49cd94e0fae8}, !- Name
+  {0316a5d6-6afc-49cc-b965-7f02229e9ca3}, !- Source Object
   2,                                      !- Outlet Port
-  {de0c5a49-de90-4b5b-b7b8-677a5a3fdce3}, !- Target Object
+  {2c20ac24-e975-47a8-8bfc-82e0fcd991d9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {38ae5b28-cdc3-436a-a2c1-87428497c72d}, !- Handle
-  {42413080-8d21-4998-a531-3d2f823f598d}, !- Name
-  {de0c5a49-de90-4b5b-b7b8-677a5a3fdce3}, !- Source Object
+  {59077e34-6078-4056-b82f-a749eb70dc24}, !- Handle
+  {a0f52711-baae-464e-a3c4-e3bdeb63ac07}, !- Name
+  {2c20ac24-e975-47a8-8bfc-82e0fcd991d9}, !- Source Object
   3,                                      !- Outlet Port
-  {6bfa884e-13e3-43e1-9ba0-6a08a99839e9}, !- Target Object
+  {bee5e070-f328-49d0-87f7-2090544024f2}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {7bdf6ca8-446b-468a-92a1-4af3ab9aa60d}, !- Handle
-  {839e727c-af6c-4fb8-ac7a-cf00c59bd7f7}, !- Name
-  {6bfa884e-13e3-43e1-9ba0-6a08a99839e9}, !- Source Object
+  {0d2335bc-9e9f-46ce-b479-579bde4ae244}, !- Handle
+  {7935d81e-adcd-49f4-b929-d7ec12037e6e}, !- Name
+  {bee5e070-f328-49d0-87f7-2090544024f2}, !- Source Object
   3,                                      !- Outlet Port
-  {6ecee92a-39b8-482c-bf5f-fec1483b4e93}, !- Target Object
+  {89be91ef-ead5-4a21-9a73-bbb5b27b094b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:SetpointManager:FollowOutdoorAirTemperature,
-  {c6a55f9a-25a5-47ea-b346-b46e5ebaa25c}, !- Handle
+  {d2e0171f-19e0-41bb-9065-00c8e6a9e995}, !- Handle
   Setpoint Manager Follow Outdoor Air Temperature 2, !- Name
   Temperature,                            !- Control Variable
   OutdoorAirWetBulb,                      !- Reference Temperature Type
   1.5,                                    !- Offset Temperature Difference {deltaC}
   80,                                     !- Maximum Setpoint Temperature {C}
   6,                                      !- Minimum Setpoint Temperature {C}
-  {29daa881-3c34-42c4-8633-c112c2bc316b}; !- Setpoint Node or NodeList Name
+  {54eefe27-5eb8-473b-8021-ad60bdc6d4fc}; !- Setpoint Node or NodeList Name
 
 OS:Node,
-  {dccb2b67-82ad-4224-8f98-a7b88a3698d2}, !- Handle
+  {ceb873e0-6ced-400a-a29f-28a015e14e5c}, !- Handle
   Node 133,                               !- Name
-  {0e4f48c5-4636-43ba-9cae-2b5b1b22b781}, !- Inlet Port
-  {b6abd7f9-9bae-4501-a2e6-f11cb4d1974a}; !- Outlet Port
+  {dcf5e50d-d2ff-4c97-ae32-3a3c9967e2e0}, !- Inlet Port
+  {6d3126d0-b075-4219-8195-bf1d21d3e65c}; !- Outlet Port
 
 OS:Connection,
-  {68cd1584-e440-40f6-8a3d-78161a6a85e3}, !- Handle
-  {6cb7215f-9c22-4ab4-a9a2-254e11a1ad9b}, !- Name
-  {e3793b17-3ca2-4da6-963c-11f2fcdc85d1}, !- Source Object
+  {5d52656a-c140-436d-bb13-41035ba30175}, !- Handle
+  {6370b421-77ae-4370-ab1c-e289a61d581b}, !- Name
+  {e4996cbb-8c3d-409e-987f-d01baab7731a}, !- Source Object
   3,                                      !- Outlet Port
-  {c5243fcc-3139-4d7b-a5b0-3b7b711e0e28}, !- Target Object
+  {b013d9bb-6e7b-43b5-b933-8a3197525aac}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {0e4f48c5-4636-43ba-9cae-2b5b1b22b781}, !- Handle
-  {62411e0c-f238-40ab-a166-22b53ae59bb9}, !- Name
-  {f6888b8b-7a06-4454-b283-9947d282069d}, !- Source Object
+  {dcf5e50d-d2ff-4c97-ae32-3a3c9967e2e0}, !- Handle
+  {7fc15d27-62ab-4304-a63e-dbf02005d7d3}, !- Name
+  {b8f5d8e3-c832-4f97-9096-15658f3433a9}, !- Source Object
   3,                                      !- Outlet Port
-  {dccb2b67-82ad-4224-8f98-a7b88a3698d2}, !- Target Object
+  {ceb873e0-6ced-400a-a29f-28a015e14e5c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {3cafb1a1-021e-43cb-a7dc-cea372fb991f}, !- Handle
+  {2e295cb8-5e31-4c59-9c57-dd649e6430ca}, !- Handle
   Air Terminal Single Duct VAV Reheat 3,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {a6b9b7b3-c32f-4d04-bbb8-77dade5f2b84}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {d29f33e4-daaa-4e5d-ad34-81cb7e9d3a02}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {ea4f3fb5-03e5-4ce3-96fe-8eb83f3ba3e6}, !- Reheat Coil Name
+  {dd4f77e4-bc7b-4498-be5e-710abdb45ecf}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {284d264d-3fad-4c62-98cb-c4e9c378b7ac}, !- Air Outlet Node Name
+  {77935a2e-f33e-4e23-a151-e748cebaad0e}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -6931,13 +6939,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {ea4f3fb5-03e5-4ce3-96fe-8eb83f3ba3e6}, !- Handle
+  {dd4f77e4-bc7b-4498-be5e-710abdb45ecf}, !- Handle
   Coil Heating Water 5,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {f33c7199-e122-4617-9e5d-838cf693b8ae}, !- Water Inlet Node Name
-  {4297c6f8-e9e5-4189-8879-596f2e146da6}, !- Water Outlet Node Name
+  {2db1de21-e199-4f7b-9b40-0e3924b0d893}, !- Water Inlet Node Name
+  {b69166db-b2ad-49a0-aa18-15cd48793465}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -6949,121 +6957,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {b2712229-d632-473c-b994-7738890d411c}, !- Handle
+  {c71befaf-e534-4b4f-8c74-a935cc1e4bf3}, !- Handle
   Node 134,                               !- Name
-  {18d3863b-f81d-4098-b28b-d4b8746dd143}, !- Inlet Port
-  {f33c7199-e122-4617-9e5d-838cf693b8ae}; !- Outlet Port
+  {e26df7d1-9b27-4649-8487-043b669a41ac}, !- Inlet Port
+  {2db1de21-e199-4f7b-9b40-0e3924b0d893}; !- Outlet Port
 
 OS:Connection,
-  {18d3863b-f81d-4098-b28b-d4b8746dd143}, !- Handle
-  {c066962b-6a8b-45a8-b03c-58a6ceeb3d9d}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {e26df7d1-9b27-4649-8487-043b669a41ac}, !- Handle
+  {0ed852e4-45ac-4513-a3f1-529a0e8f8a10}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   6,                                      !- Outlet Port
-  {b2712229-d632-473c-b994-7738890d411c}, !- Target Object
+  {c71befaf-e534-4b4f-8c74-a935cc1e4bf3}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {deeea355-360e-4f50-9039-bea75100827b}, !- Handle
+  {a6f7b28a-d8bc-4986-a455-2bdc63035447}, !- Handle
   Node 135,                               !- Name
-  {4297c6f8-e9e5-4189-8879-596f2e146da6}, !- Inlet Port
-  {95849612-703e-4aca-b108-9b0c30f0c90d}; !- Outlet Port
+  {b69166db-b2ad-49a0-aa18-15cd48793465}, !- Inlet Port
+  {9bc3f8e8-59a9-4fa5-8cb7-2e33d163d6cb}; !- Outlet Port
 
 OS:Connection,
-  {f33c7199-e122-4617-9e5d-838cf693b8ae}, !- Handle
-  {9a02c566-fde1-4e28-8777-8b7e775bb442}, !- Name
-  {b2712229-d632-473c-b994-7738890d411c}, !- Source Object
+  {2db1de21-e199-4f7b-9b40-0e3924b0d893}, !- Handle
+  {1fa8a9aa-8ecb-4d90-9f68-f820a77f8a35}, !- Name
+  {c71befaf-e534-4b4f-8c74-a935cc1e4bf3}, !- Source Object
   3,                                      !- Outlet Port
-  {ea4f3fb5-03e5-4ce3-96fe-8eb83f3ba3e6}, !- Target Object
+  {dd4f77e4-bc7b-4498-be5e-710abdb45ecf}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {4297c6f8-e9e5-4189-8879-596f2e146da6}, !- Handle
-  {072d4a69-fa32-44d8-b994-f7d24a251bd7}, !- Name
-  {ea4f3fb5-03e5-4ce3-96fe-8eb83f3ba3e6}, !- Source Object
+  {b69166db-b2ad-49a0-aa18-15cd48793465}, !- Handle
+  {1847038e-6061-4795-b4bb-74107334e635}, !- Name
+  {dd4f77e4-bc7b-4498-be5e-710abdb45ecf}, !- Source Object
   6,                                      !- Outlet Port
-  {deeea355-360e-4f50-9039-bea75100827b}, !- Target Object
+  {a6f7b28a-d8bc-4986-a455-2bdc63035447}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {95849612-703e-4aca-b108-9b0c30f0c90d}, !- Handle
-  {1e9a62c8-51d1-441f-a3ba-ce29fe8ccf80}, !- Name
-  {deeea355-360e-4f50-9039-bea75100827b}, !- Source Object
+  {9bc3f8e8-59a9-4fa5-8cb7-2e33d163d6cb}, !- Handle
+  {f816b5b2-564e-4693-88a6-4dfafd585042}, !- Name
+  {a6f7b28a-d8bc-4986-a455-2bdc63035447}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Node,
-  {1334496e-85ce-4d85-8b30-8008127609c3}, !- Handle
+  {b2657157-2315-4f9b-af60-5f3b2082cc42}, !- Handle
   Node 136,                               !- Name
-  {284d264d-3fad-4c62-98cb-c4e9c378b7ac}, !- Inlet Port
-  {d7ccddf8-fd24-47b1-b120-71f7346eaa6a}; !- Outlet Port
+  {77935a2e-f33e-4e23-a151-e748cebaad0e}, !- Inlet Port
+  {bfa2db62-9c93-4ca6-9c4a-a35d738f984e}; !- Outlet Port
 
 OS:Node,
-  {ed3de5f1-1f64-42a9-abbf-f4c15bdd2e81}, !- Handle
+  {28411a87-2b1d-4aac-9a3e-05f86658903d}, !- Handle
   Node 137,                               !- Name
-  {64e0b73f-8b69-4661-b689-f15e03c38d45}, !- Inlet Port
-  {1c9aaadc-256c-4671-b89f-d5b12729a411}; !- Outlet Port
+  {7c6e54e9-68fc-4eb2-9694-3cf0e5331912}, !- Inlet Port
+  {b66e0f13-4960-4773-a86a-2769ebe11b67}; !- Outlet Port
 
 OS:Connection,
-  {d7ccddf8-fd24-47b1-b120-71f7346eaa6a}, !- Handle
-  {93615ac3-4296-4530-a7bc-a6a4f2f7cf88}, !- Name
-  {1334496e-85ce-4d85-8b30-8008127609c3}, !- Source Object
+  {bfa2db62-9c93-4ca6-9c4a-a35d738f984e}, !- Handle
+  {73690f80-be7e-42ee-8798-57a1f20ac183}, !- Name
+  {b2657157-2315-4f9b-af60-5f3b2082cc42}, !- Source Object
   3,                                      !- Outlet Port
-  {aeac121c-c6ed-464b-9940-dbaf54f5bfde}, !- Target Object
+  {cf402869-4714-4cf1-885a-7a74464049fd}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {64e0b73f-8b69-4661-b689-f15e03c38d45}, !- Handle
-  {c24b6842-1d37-447c-8d97-2009599b808e}, !- Name
-  {e2d252d0-fabd-4afb-b386-bc11c7618a04}, !- Source Object
+  {7c6e54e9-68fc-4eb2-9694-3cf0e5331912}, !- Handle
+  {2fe22f23-c187-4429-9aa9-d47a2e8b70c3}, !- Name
+  {ad7c48a9-7942-4555-ac3a-44c7a61df8a7}, !- Source Object
   3,                                      !- Outlet Port
-  {ed3de5f1-1f64-42a9-abbf-f4c15bdd2e81}, !- Target Object
+  {28411a87-2b1d-4aac-9a3e-05f86658903d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {7901782e-7ffa-4e30-a18f-ffd3bba8807d}, !- Handle
+  {eb09fd67-38ac-4a1c-a450-f0cab3b102f9}, !- Handle
   Node 138,                               !- Name
-  {30fe412b-477a-4ac3-9c81-2b9fd3e11953}, !- Inlet Port
-  {a6b9b7b3-c32f-4d04-bbb8-77dade5f2b84}; !- Outlet Port
+  {1843d656-bfd4-4aa9-ab50-588452bfd9fa}, !- Inlet Port
+  {d29f33e4-daaa-4e5d-ad34-81cb7e9d3a02}; !- Outlet Port
 
 OS:Connection,
-  {30fe412b-477a-4ac3-9c81-2b9fd3e11953}, !- Handle
-  {a8725f73-dfee-4d73-a987-89e2013243e0}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {1843d656-bfd4-4aa9-ab50-588452bfd9fa}, !- Handle
+  {5dc9b026-432f-4043-a481-f41fecf9ce7e}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   4,                                      !- Outlet Port
-  {7901782e-7ffa-4e30-a18f-ffd3bba8807d}, !- Target Object
+  {eb09fd67-38ac-4a1c-a450-f0cab3b102f9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a6b9b7b3-c32f-4d04-bbb8-77dade5f2b84}, !- Handle
-  {a2dcb6a7-67c5-42e8-b949-c8ff848b0869}, !- Name
-  {7901782e-7ffa-4e30-a18f-ffd3bba8807d}, !- Source Object
+  {d29f33e4-daaa-4e5d-ad34-81cb7e9d3a02}, !- Handle
+  {881fcc61-368c-4f1a-af54-331cf1c728aa}, !- Name
+  {eb09fd67-38ac-4a1c-a450-f0cab3b102f9}, !- Source Object
   3,                                      !- Outlet Port
-  {3cafb1a1-021e-43cb-a7dc-cea372fb991f}, !- Target Object
+  {2e295cb8-5e31-4c59-9c57-dd649e6430ca}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {284d264d-3fad-4c62-98cb-c4e9c378b7ac}, !- Handle
-  {fd2acd16-ec57-4b69-9f25-32c1841a298e}, !- Name
-  {3cafb1a1-021e-43cb-a7dc-cea372fb991f}, !- Source Object
+  {77935a2e-f33e-4e23-a151-e748cebaad0e}, !- Handle
+  {54f0cca0-64ae-4d65-b698-e98713cd4843}, !- Name
+  {2e295cb8-5e31-4c59-9c57-dd649e6430ca}, !- Source Object
   12,                                     !- Outlet Port
-  {1334496e-85ce-4d85-8b30-8008127609c3}, !- Target Object
+  {b2657157-2315-4f9b-af60-5f3b2082cc42}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {76fa19cc-5ecb-424d-a368-9f1899b08695}, !- Handle
+  {5189153b-e701-4fa0-97de-72c39b9e5310}, !- Handle
   Air Terminal Single Duct VAV Reheat 4,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {8b1f7df9-0929-4cca-b565-d1a51b4ea954}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {4cabbe99-c89d-4e6a-8f2f-f8c1f7ee3074}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {5da849c1-779c-40fe-a739-eb025c5bb2bc}, !- Reheat Coil Name
+  {03df62c4-28e9-4508-8be8-ab0a2139884d}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {884ec363-e187-4e84-a03c-6d05501ac65d}, !- Air Outlet Node Name
+  {5a2b7e6e-709a-4abf-ba40-d7084aa1a8ba}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7072,13 +7080,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {5da849c1-779c-40fe-a739-eb025c5bb2bc}, !- Handle
+  {03df62c4-28e9-4508-8be8-ab0a2139884d}, !- Handle
   Coil Heating Water 6,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {b3cb3c0d-cae2-41a7-91eb-ef80c5d90185}, !- Water Inlet Node Name
-  {818333f7-9ed2-4d70-a9b7-78d4491a0383}, !- Water Outlet Node Name
+  {48cb44c2-803e-4780-9809-98d89a37f2fd}, !- Water Inlet Node Name
+  {880b2884-08ff-4845-a0e4-681632d12184}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7090,121 +7098,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {512dde18-7539-4719-8b10-3338d67d9fd3}, !- Handle
+  {d274eca2-0959-4446-bbd2-620417cd9f37}, !- Handle
   Node 139,                               !- Name
-  {d5c457b9-9efc-49b6-b478-8526aa343962}, !- Inlet Port
-  {b3cb3c0d-cae2-41a7-91eb-ef80c5d90185}; !- Outlet Port
+  {64cc8bd9-16ce-41bb-818e-004931b65858}, !- Inlet Port
+  {48cb44c2-803e-4780-9809-98d89a37f2fd}; !- Outlet Port
 
 OS:Connection,
-  {d5c457b9-9efc-49b6-b478-8526aa343962}, !- Handle
-  {0691239a-7193-4427-8941-98aaa145d097}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {64cc8bd9-16ce-41bb-818e-004931b65858}, !- Handle
+  {b4d7b977-d68e-4cde-aebb-eb6bdd3491b8}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   7,                                      !- Outlet Port
-  {512dde18-7539-4719-8b10-3338d67d9fd3}, !- Target Object
+  {d274eca2-0959-4446-bbd2-620417cd9f37}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {194c7cf7-e5ca-4d3a-8b92-647ede1eef5e}, !- Handle
+  {5f1ebb6e-96f2-46d7-a3bb-4a9a5ef7102a}, !- Handle
   Node 140,                               !- Name
-  {818333f7-9ed2-4d70-a9b7-78d4491a0383}, !- Inlet Port
-  {3b941dd9-48ba-41d1-a39b-a3efd46631cf}; !- Outlet Port
+  {880b2884-08ff-4845-a0e4-681632d12184}, !- Inlet Port
+  {3d018a21-b19a-4106-be83-cc40fcf33282}; !- Outlet Port
 
 OS:Connection,
-  {b3cb3c0d-cae2-41a7-91eb-ef80c5d90185}, !- Handle
-  {f27c2716-86a4-476a-a70c-4600fe9bbb37}, !- Name
-  {512dde18-7539-4719-8b10-3338d67d9fd3}, !- Source Object
+  {48cb44c2-803e-4780-9809-98d89a37f2fd}, !- Handle
+  {8eae8650-02b7-41c4-bd0b-3844e1570f38}, !- Name
+  {d274eca2-0959-4446-bbd2-620417cd9f37}, !- Source Object
   3,                                      !- Outlet Port
-  {5da849c1-779c-40fe-a739-eb025c5bb2bc}, !- Target Object
+  {03df62c4-28e9-4508-8be8-ab0a2139884d}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {818333f7-9ed2-4d70-a9b7-78d4491a0383}, !- Handle
-  {6ff9e1bc-3399-4639-8d6b-3cc476bdfcc2}, !- Name
-  {5da849c1-779c-40fe-a739-eb025c5bb2bc}, !- Source Object
+  {880b2884-08ff-4845-a0e4-681632d12184}, !- Handle
+  {9accdf3a-2700-469b-bc44-99bf6a26c258}, !- Name
+  {03df62c4-28e9-4508-8be8-ab0a2139884d}, !- Source Object
   6,                                      !- Outlet Port
-  {194c7cf7-e5ca-4d3a-8b92-647ede1eef5e}, !- Target Object
+  {5f1ebb6e-96f2-46d7-a3bb-4a9a5ef7102a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {3b941dd9-48ba-41d1-a39b-a3efd46631cf}, !- Handle
-  {39e25446-479c-402f-aacd-38193f281608}, !- Name
-  {194c7cf7-e5ca-4d3a-8b92-647ede1eef5e}, !- Source Object
+  {3d018a21-b19a-4106-be83-cc40fcf33282}, !- Handle
+  {060b5e41-b73a-4a6a-a693-f88772351983}, !- Name
+  {5f1ebb6e-96f2-46d7-a3bb-4a9a5ef7102a}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Node,
-  {3f06cb52-f9b9-4af9-9d72-72bfeac23f60}, !- Handle
+  {ff69bb06-4c7c-490d-834a-3cd902149826}, !- Handle
   Node 141,                               !- Name
-  {884ec363-e187-4e84-a03c-6d05501ac65d}, !- Inlet Port
-  {2de80d95-bcc9-4192-bdec-740f75efb5f8}; !- Outlet Port
+  {5a2b7e6e-709a-4abf-ba40-d7084aa1a8ba}, !- Inlet Port
+  {71510ca9-685c-460b-84f9-05cd7042ee52}; !- Outlet Port
 
 OS:Node,
-  {4237dfe8-731d-4129-a671-be330ff86590}, !- Handle
+  {ce4586fd-e05d-402a-a503-4cfac5cad066}, !- Handle
   Node 142,                               !- Name
-  {c5469a77-2337-44a5-be7e-3f6f76e91a13}, !- Inlet Port
-  {54e76f14-2659-4e64-a718-f9a6231ffb40}; !- Outlet Port
+  {4914116b-30d4-4458-a502-9e7496e6d032}, !- Inlet Port
+  {20c301d1-0c91-4afe-9755-379024d76969}; !- Outlet Port
 
 OS:Connection,
-  {2de80d95-bcc9-4192-bdec-740f75efb5f8}, !- Handle
-  {f17d87c9-a007-4182-b2a1-6a4b4e409d60}, !- Name
-  {3f06cb52-f9b9-4af9-9d72-72bfeac23f60}, !- Source Object
+  {71510ca9-685c-460b-84f9-05cd7042ee52}, !- Handle
+  {e2ae9654-1751-4fc7-ad61-8c2608327c29}, !- Name
+  {ff69bb06-4c7c-490d-834a-3cd902149826}, !- Source Object
   3,                                      !- Outlet Port
-  {a3ae2cfe-592b-4de8-a162-12d5d60726a6}, !- Target Object
+  {f9cf39c5-f2b9-433a-8441-a27787b1837a}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {c5469a77-2337-44a5-be7e-3f6f76e91a13}, !- Handle
-  {8a96fd43-73b3-40f8-9679-f10225636de8}, !- Name
-  {6cde623f-f7ab-4c23-95d7-ec8881d9f865}, !- Source Object
+  {4914116b-30d4-4458-a502-9e7496e6d032}, !- Handle
+  {bf379068-c235-4df8-8c29-2d40c878f518}, !- Name
+  {34e1d912-530c-4fbf-af8d-90ce615cb03d}, !- Source Object
   3,                                      !- Outlet Port
-  {4237dfe8-731d-4129-a671-be330ff86590}, !- Target Object
+  {ce4586fd-e05d-402a-a503-4cfac5cad066}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {97db4182-58e5-4ab1-a810-56d686a2fda9}, !- Handle
+  {4dc62243-7bf4-4752-b466-ab9e4423b0ac}, !- Handle
   Node 143,                               !- Name
-  {0526cc54-a063-49c5-ba6a-d2ca3c67f616}, !- Inlet Port
-  {8b1f7df9-0929-4cca-b565-d1a51b4ea954}; !- Outlet Port
+  {c3df2f0c-ae8c-4b1c-adb8-bc6486adb727}, !- Inlet Port
+  {4cabbe99-c89d-4e6a-8f2f-f8c1f7ee3074}; !- Outlet Port
 
 OS:Connection,
-  {0526cc54-a063-49c5-ba6a-d2ca3c67f616}, !- Handle
-  {33599425-afe2-46f6-8ffc-cf3bfff0e83e}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {c3df2f0c-ae8c-4b1c-adb8-bc6486adb727}, !- Handle
+  {1a959a19-edd7-42c2-a0db-50d4ada1fa98}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   5,                                      !- Outlet Port
-  {97db4182-58e5-4ab1-a810-56d686a2fda9}, !- Target Object
+  {4dc62243-7bf4-4752-b466-ab9e4423b0ac}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8b1f7df9-0929-4cca-b565-d1a51b4ea954}, !- Handle
-  {44b10f59-499d-4084-b5bd-9431bf21104d}, !- Name
-  {97db4182-58e5-4ab1-a810-56d686a2fda9}, !- Source Object
+  {4cabbe99-c89d-4e6a-8f2f-f8c1f7ee3074}, !- Handle
+  {cd449e7d-74ca-4a72-8096-2a11bc860eef}, !- Name
+  {4dc62243-7bf4-4752-b466-ab9e4423b0ac}, !- Source Object
   3,                                      !- Outlet Port
-  {76fa19cc-5ecb-424d-a368-9f1899b08695}, !- Target Object
+  {5189153b-e701-4fa0-97de-72c39b9e5310}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {884ec363-e187-4e84-a03c-6d05501ac65d}, !- Handle
-  {7f0f8bf9-5eb7-4d84-a48e-b98d258c91ba}, !- Name
-  {76fa19cc-5ecb-424d-a368-9f1899b08695}, !- Source Object
+  {5a2b7e6e-709a-4abf-ba40-d7084aa1a8ba}, !- Handle
+  {65c28dbb-8961-42e9-b333-a254bdc42d3b}, !- Name
+  {5189153b-e701-4fa0-97de-72c39b9e5310}, !- Source Object
   12,                                     !- Outlet Port
-  {3f06cb52-f9b9-4af9-9d72-72bfeac23f60}, !- Target Object
+  {ff69bb06-4c7c-490d-834a-3cd902149826}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {f26318e7-88a8-4820-b495-0417a5a8b97d}, !- Handle
+  {d389a078-5041-4852-9722-e526425acfd5}, !- Handle
   Air Terminal Single Duct VAV Reheat 5,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {218c2aef-f12b-4c10-9670-ba628ad4528a}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {039e4cd5-25ee-4b48-b602-49a23709ee02}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {906b758b-e7d1-4707-934a-efec94d88847}, !- Reheat Coil Name
+  {a7e7f109-f68f-4670-871f-65e8e2009aed}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {de121df7-6349-4193-a338-5a0a13bb9739}, !- Air Outlet Node Name
+  {25004e5a-8124-41d7-a25a-3f7fa675b61a}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7213,13 +7221,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {906b758b-e7d1-4707-934a-efec94d88847}, !- Handle
+  {a7e7f109-f68f-4670-871f-65e8e2009aed}, !- Handle
   Coil Heating Water 7,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {29c9dff9-5113-4f52-b549-766baf6959a0}, !- Water Inlet Node Name
-  {0cc70d6d-922a-4979-ab99-0770f1fccd33}, !- Water Outlet Node Name
+  {fa358bf2-f688-48fa-b663-b153cb24ed34}, !- Water Inlet Node Name
+  {8a650067-aa0a-4723-90ba-c913cbbbfdf7}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7231,121 +7239,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {d48f0b75-5fc9-494a-b4b0-4d4c0800b68a}, !- Handle
+  {4b4e8f86-6ca6-4d9c-9f30-5b869a72f17a}, !- Handle
   Node 144,                               !- Name
-  {dbbea107-105c-4b71-b359-f226723280e0}, !- Inlet Port
-  {29c9dff9-5113-4f52-b549-766baf6959a0}; !- Outlet Port
+  {e8053859-f805-4144-9bb0-84c64851b3a6}, !- Inlet Port
+  {fa358bf2-f688-48fa-b663-b153cb24ed34}; !- Outlet Port
 
 OS:Connection,
-  {dbbea107-105c-4b71-b359-f226723280e0}, !- Handle
-  {71fddb0e-6eaa-4cd7-9f46-7cc19e7fa518}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {e8053859-f805-4144-9bb0-84c64851b3a6}, !- Handle
+  {590a0087-fdc5-48ce-9be2-8f31e279d58e}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   8,                                      !- Outlet Port
-  {d48f0b75-5fc9-494a-b4b0-4d4c0800b68a}, !- Target Object
+  {4b4e8f86-6ca6-4d9c-9f30-5b869a72f17a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {3a83411d-ead5-41a4-9aef-32bad564497b}, !- Handle
+  {0a86aa1c-b4a9-4b71-9509-a228c603c083}, !- Handle
   Node 145,                               !- Name
-  {0cc70d6d-922a-4979-ab99-0770f1fccd33}, !- Inlet Port
-  {f53d4c85-24da-4500-9d80-d51bcbdc4672}; !- Outlet Port
+  {8a650067-aa0a-4723-90ba-c913cbbbfdf7}, !- Inlet Port
+  {3666745f-1666-405a-97c7-f56cfe73cb8d}; !- Outlet Port
 
 OS:Connection,
-  {29c9dff9-5113-4f52-b549-766baf6959a0}, !- Handle
-  {0060b740-68e9-443f-b71e-e35cd1c9d394}, !- Name
-  {d48f0b75-5fc9-494a-b4b0-4d4c0800b68a}, !- Source Object
+  {fa358bf2-f688-48fa-b663-b153cb24ed34}, !- Handle
+  {b1850b14-6c7e-497b-9cf5-c9fe6ed424f4}, !- Name
+  {4b4e8f86-6ca6-4d9c-9f30-5b869a72f17a}, !- Source Object
   3,                                      !- Outlet Port
-  {906b758b-e7d1-4707-934a-efec94d88847}, !- Target Object
+  {a7e7f109-f68f-4670-871f-65e8e2009aed}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {0cc70d6d-922a-4979-ab99-0770f1fccd33}, !- Handle
-  {5ab5d541-cd0b-42af-a695-4dba31420fc5}, !- Name
-  {906b758b-e7d1-4707-934a-efec94d88847}, !- Source Object
+  {8a650067-aa0a-4723-90ba-c913cbbbfdf7}, !- Handle
+  {ff1f8cc0-2dfd-489a-baba-2249d9cdb914}, !- Name
+  {a7e7f109-f68f-4670-871f-65e8e2009aed}, !- Source Object
   6,                                      !- Outlet Port
-  {3a83411d-ead5-41a4-9aef-32bad564497b}, !- Target Object
+  {0a86aa1c-b4a9-4b71-9509-a228c603c083}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f53d4c85-24da-4500-9d80-d51bcbdc4672}, !- Handle
-  {a6e110ce-af67-4b53-9ccd-72d0bc9688f2}, !- Name
-  {3a83411d-ead5-41a4-9aef-32bad564497b}, !- Source Object
+  {3666745f-1666-405a-97c7-f56cfe73cb8d}, !- Handle
+  {4d46d9a6-7d6a-458b-a0ae-cf9c9d811c20}, !- Name
+  {0a86aa1c-b4a9-4b71-9509-a228c603c083}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Node,
-  {b4d78f82-9e83-4ad5-89c0-369843302a27}, !- Handle
+  {3e0c1d23-1583-4560-b9bd-9d8756ea3781}, !- Handle
   Node 146,                               !- Name
-  {de121df7-6349-4193-a338-5a0a13bb9739}, !- Inlet Port
-  {6c09741b-d952-4e5c-aa80-c52742d35784}; !- Outlet Port
+  {25004e5a-8124-41d7-a25a-3f7fa675b61a}, !- Inlet Port
+  {1a3ca6f8-187b-44b5-958b-1d75b6ad9905}; !- Outlet Port
 
 OS:Node,
-  {ea637f2a-c138-498f-ba2a-16610db82248}, !- Handle
+  {273b8de4-bd8e-49ea-bef0-8db30bb20e6c}, !- Handle
   Node 147,                               !- Name
-  {f5de5e5e-4f7d-4a6c-b7b0-4d18d2018500}, !- Inlet Port
-  {bc8de337-17b9-47ec-8cf2-50f51b50ecfc}; !- Outlet Port
+  {81044b0b-9c59-40d6-be5c-b3656c2bf481}, !- Inlet Port
+  {8d428648-b1ef-4467-adac-20605cbd42b1}; !- Outlet Port
 
 OS:Connection,
-  {6c09741b-d952-4e5c-aa80-c52742d35784}, !- Handle
-  {3da2f2c7-c9ba-4f17-b2cf-832d2485d899}, !- Name
-  {b4d78f82-9e83-4ad5-89c0-369843302a27}, !- Source Object
+  {1a3ca6f8-187b-44b5-958b-1d75b6ad9905}, !- Handle
+  {98dc14b1-540f-4b47-a844-bf6c085b86d3}, !- Name
+  {3e0c1d23-1583-4560-b9bd-9d8756ea3781}, !- Source Object
   3,                                      !- Outlet Port
-  {ed966860-1232-4cea-a353-bc9278caa407}, !- Target Object
+  {3f08aa56-9494-4c79-b410-53887ea5b9e6}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {f5de5e5e-4f7d-4a6c-b7b0-4d18d2018500}, !- Handle
-  {21b3f0a5-1cb8-4c9f-be3e-e2afa04483e2}, !- Name
-  {2dc6338d-d0c4-4b49-a80f-60ac3fa78931}, !- Source Object
+  {81044b0b-9c59-40d6-be5c-b3656c2bf481}, !- Handle
+  {5195ce04-e3cb-41ca-812c-376460d5fd89}, !- Name
+  {ba7d211e-dc53-45ab-b570-f7e48508ea4f}, !- Source Object
   3,                                      !- Outlet Port
-  {ea637f2a-c138-498f-ba2a-16610db82248}, !- Target Object
+  {273b8de4-bd8e-49ea-bef0-8db30bb20e6c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {97be9453-7f03-4ebc-afe2-bd06f74f8a67}, !- Handle
+  {5b1496b2-a4cd-45a0-aec3-31b7ec6bafd3}, !- Handle
   Node 148,                               !- Name
-  {18da5ca4-9b8c-42fd-810a-1dfb2ac8cf3c}, !- Inlet Port
-  {218c2aef-f12b-4c10-9670-ba628ad4528a}; !- Outlet Port
+  {6c00b31f-ea66-4560-9ace-46d92fcc23ea}, !- Inlet Port
+  {039e4cd5-25ee-4b48-b602-49a23709ee02}; !- Outlet Port
 
 OS:Connection,
-  {18da5ca4-9b8c-42fd-810a-1dfb2ac8cf3c}, !- Handle
-  {acd3536d-2153-4a84-995c-5c9faec98971}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {6c00b31f-ea66-4560-9ace-46d92fcc23ea}, !- Handle
+  {50741193-6ba1-4d32-a567-2ab996c2fc0f}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   6,                                      !- Outlet Port
-  {97be9453-7f03-4ebc-afe2-bd06f74f8a67}, !- Target Object
+  {5b1496b2-a4cd-45a0-aec3-31b7ec6bafd3}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {218c2aef-f12b-4c10-9670-ba628ad4528a}, !- Handle
-  {544b9a32-cc3c-4ad2-aebc-b0ce09123db2}, !- Name
-  {97be9453-7f03-4ebc-afe2-bd06f74f8a67}, !- Source Object
+  {039e4cd5-25ee-4b48-b602-49a23709ee02}, !- Handle
+  {2954dff5-2b18-42d3-ae8a-95dcda42f4ba}, !- Name
+  {5b1496b2-a4cd-45a0-aec3-31b7ec6bafd3}, !- Source Object
   3,                                      !- Outlet Port
-  {f26318e7-88a8-4820-b495-0417a5a8b97d}, !- Target Object
+  {d389a078-5041-4852-9722-e526425acfd5}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {de121df7-6349-4193-a338-5a0a13bb9739}, !- Handle
-  {e2606857-e9aa-4541-9836-943175856bf9}, !- Name
-  {f26318e7-88a8-4820-b495-0417a5a8b97d}, !- Source Object
+  {25004e5a-8124-41d7-a25a-3f7fa675b61a}, !- Handle
+  {28598357-0713-41ee-8c4e-8a5e357360b0}, !- Name
+  {d389a078-5041-4852-9722-e526425acfd5}, !- Source Object
   12,                                     !- Outlet Port
-  {b4d78f82-9e83-4ad5-89c0-369843302a27}, !- Target Object
+  {3e0c1d23-1583-4560-b9bd-9d8756ea3781}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {064a47d4-d54e-4628-a7d0-f9b33315492d}, !- Handle
+  {67d04328-a01e-4162-b2f0-3cafe9307180}, !- Handle
   Air Terminal Single Duct VAV Reheat 6,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {0e7340d6-e235-4547-99c3-b7c3f25a44b9}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {ac1f0868-a44d-4edd-be63-1fba54d9916a}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {81eba9b4-eb92-4548-b3a4-2b47f7156360}, !- Reheat Coil Name
+  {6723e8ff-3f23-4505-ab65-ab08a79daa9d}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {9ae8d93f-e07b-4360-b395-4a163f1d489f}, !- Air Outlet Node Name
+  {8621388a-de7f-4e73-a0d0-09293a5b196b}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7354,13 +7362,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {81eba9b4-eb92-4548-b3a4-2b47f7156360}, !- Handle
+  {6723e8ff-3f23-4505-ab65-ab08a79daa9d}, !- Handle
   Coil Heating Water 8,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {6c3e1382-7d53-404c-9c3a-f9285c62770f}, !- Water Inlet Node Name
-  {4000bb44-c072-4266-80a3-adf05a2985b5}, !- Water Outlet Node Name
+  {45c08cb9-326c-4682-b186-5ec17adf4197}, !- Water Inlet Node Name
+  {6d9f308d-4661-468e-a018-572fa09ff3f0}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7372,121 +7380,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {7da395a3-0ec6-4ad5-81d9-81b33a2a8f6e}, !- Handle
+  {d4629cc5-9796-403e-ab55-6595e3e5ea52}, !- Handle
   Node 149,                               !- Name
-  {aa17d262-20e5-4567-a91a-90040eac5940}, !- Inlet Port
-  {6c3e1382-7d53-404c-9c3a-f9285c62770f}; !- Outlet Port
+  {90de4ab5-1988-40d8-bc96-9ac1c633c5b4}, !- Inlet Port
+  {45c08cb9-326c-4682-b186-5ec17adf4197}; !- Outlet Port
 
 OS:Connection,
-  {aa17d262-20e5-4567-a91a-90040eac5940}, !- Handle
-  {ab86f6ab-f0ae-4ee2-b624-a6849f151fba}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {90de4ab5-1988-40d8-bc96-9ac1c633c5b4}, !- Handle
+  {e8350b1c-a3e0-4388-82d2-38f0281378c9}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   9,                                      !- Outlet Port
-  {7da395a3-0ec6-4ad5-81d9-81b33a2a8f6e}, !- Target Object
+  {d4629cc5-9796-403e-ab55-6595e3e5ea52}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {822c2d53-331e-4174-be0f-388f7efbe2e4}, !- Handle
+  {2f90332c-0090-485a-bb64-3f64a6d8bbfd}, !- Handle
   Node 150,                               !- Name
-  {4000bb44-c072-4266-80a3-adf05a2985b5}, !- Inlet Port
-  {6adfad65-fb86-442d-8a53-97197745427d}; !- Outlet Port
+  {6d9f308d-4661-468e-a018-572fa09ff3f0}, !- Inlet Port
+  {3050413d-24c7-46e5-9098-b2f1ec525ab2}; !- Outlet Port
 
 OS:Connection,
-  {6c3e1382-7d53-404c-9c3a-f9285c62770f}, !- Handle
-  {0e4410be-a762-46ba-9791-162d3cc8b1e3}, !- Name
-  {7da395a3-0ec6-4ad5-81d9-81b33a2a8f6e}, !- Source Object
+  {45c08cb9-326c-4682-b186-5ec17adf4197}, !- Handle
+  {9c2a2245-09a1-413b-a74a-b4af786eb438}, !- Name
+  {d4629cc5-9796-403e-ab55-6595e3e5ea52}, !- Source Object
   3,                                      !- Outlet Port
-  {81eba9b4-eb92-4548-b3a4-2b47f7156360}, !- Target Object
+  {6723e8ff-3f23-4505-ab65-ab08a79daa9d}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {4000bb44-c072-4266-80a3-adf05a2985b5}, !- Handle
-  {cccff9c7-c725-4b21-b019-a46ca5bc21e4}, !- Name
-  {81eba9b4-eb92-4548-b3a4-2b47f7156360}, !- Source Object
+  {6d9f308d-4661-468e-a018-572fa09ff3f0}, !- Handle
+  {f30cc353-46f7-4b70-b03a-a30578490e63}, !- Name
+  {6723e8ff-3f23-4505-ab65-ab08a79daa9d}, !- Source Object
   6,                                      !- Outlet Port
-  {822c2d53-331e-4174-be0f-388f7efbe2e4}, !- Target Object
+  {2f90332c-0090-485a-bb64-3f64a6d8bbfd}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {6adfad65-fb86-442d-8a53-97197745427d}, !- Handle
-  {fac4d16e-8ae0-4570-8be3-70549367660a}, !- Name
-  {822c2d53-331e-4174-be0f-388f7efbe2e4}, !- Source Object
+  {3050413d-24c7-46e5-9098-b2f1ec525ab2}, !- Handle
+  {ab553bcd-4326-49b8-93c9-78ac038f68ca}, !- Name
+  {2f90332c-0090-485a-bb64-3f64a6d8bbfd}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   9;                                      !- Inlet Port
 
 OS:Node,
-  {997125fd-e1bd-4c09-939c-69b13a039917}, !- Handle
+  {adb5746f-9506-4f16-8072-1d61488bb3e8}, !- Handle
   Node 151,                               !- Name
-  {9ae8d93f-e07b-4360-b395-4a163f1d489f}, !- Inlet Port
-  {d0bd5d4d-80c7-42cc-b0f4-0887e71ebf4e}; !- Outlet Port
+  {8621388a-de7f-4e73-a0d0-09293a5b196b}, !- Inlet Port
+  {4f9085b7-c352-48e0-b20d-31eaa553041e}; !- Outlet Port
 
 OS:Node,
-  {dcda9a31-84d4-44e4-8d3a-6061ec8b9d46}, !- Handle
+  {640bea84-4f69-4a46-aa94-0af5d92f920a}, !- Handle
   Node 152,                               !- Name
-  {34a25964-83f0-43fb-b0ee-f6d22c98bcc4}, !- Inlet Port
-  {27c16f95-f186-4ba8-8ef6-f515fb9b3b10}; !- Outlet Port
+  {897726d5-146b-47b7-bdbd-d5bc013a27c4}, !- Inlet Port
+  {4a82b16b-05b4-4e3e-8369-5e6d9e8e8fe7}; !- Outlet Port
 
 OS:Connection,
-  {d0bd5d4d-80c7-42cc-b0f4-0887e71ebf4e}, !- Handle
-  {c9e301af-f71d-4b1e-a02f-62188bbbf519}, !- Name
-  {997125fd-e1bd-4c09-939c-69b13a039917}, !- Source Object
+  {4f9085b7-c352-48e0-b20d-31eaa553041e}, !- Handle
+  {74ebbde8-7434-4172-9256-0d2fbb960aef}, !- Name
+  {adb5746f-9506-4f16-8072-1d61488bb3e8}, !- Source Object
   3,                                      !- Outlet Port
-  {b170267c-aa2a-4cab-b508-4f08913dcb06}, !- Target Object
+  {e6c35a45-e312-4899-b164-f90bc07b1f8c}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {34a25964-83f0-43fb-b0ee-f6d22c98bcc4}, !- Handle
-  {c79502c3-9828-48b7-9761-a662f43105ed}, !- Name
-  {b4efd025-13e6-447a-b284-f912d5c35ae8}, !- Source Object
+  {897726d5-146b-47b7-bdbd-d5bc013a27c4}, !- Handle
+  {9621f87e-9acf-48be-8b79-98acdea1374d}, !- Name
+  {211feab5-a8be-4eae-9a23-92893c02fd56}, !- Source Object
   3,                                      !- Outlet Port
-  {dcda9a31-84d4-44e4-8d3a-6061ec8b9d46}, !- Target Object
+  {640bea84-4f69-4a46-aa94-0af5d92f920a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {55a81b41-beed-413c-b248-e313433553e8}, !- Handle
+  {d6eb7cea-c23c-4e7d-a9d0-fe07d36efe7d}, !- Handle
   Node 153,                               !- Name
-  {364d65e7-2bbd-465c-888e-d48aeee45ef3}, !- Inlet Port
-  {0e7340d6-e235-4547-99c3-b7c3f25a44b9}; !- Outlet Port
+  {b50c72c5-3e13-41ab-b843-2b9ea0a3dc79}, !- Inlet Port
+  {ac1f0868-a44d-4edd-be63-1fba54d9916a}; !- Outlet Port
 
 OS:Connection,
-  {364d65e7-2bbd-465c-888e-d48aeee45ef3}, !- Handle
-  {4b55bf8d-e173-41d2-a5fc-443d838120a1}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {b50c72c5-3e13-41ab-b843-2b9ea0a3dc79}, !- Handle
+  {f73afd0b-6863-4a0b-92ff-6a6ed37ac88f}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   7,                                      !- Outlet Port
-  {55a81b41-beed-413c-b248-e313433553e8}, !- Target Object
+  {d6eb7cea-c23c-4e7d-a9d0-fe07d36efe7d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {0e7340d6-e235-4547-99c3-b7c3f25a44b9}, !- Handle
-  {2d9a3294-db64-40ab-83de-15cb3ac07d63}, !- Name
-  {55a81b41-beed-413c-b248-e313433553e8}, !- Source Object
+  {ac1f0868-a44d-4edd-be63-1fba54d9916a}, !- Handle
+  {5f233403-e210-49ca-96fe-f163aabc79cc}, !- Name
+  {d6eb7cea-c23c-4e7d-a9d0-fe07d36efe7d}, !- Source Object
   3,                                      !- Outlet Port
-  {064a47d4-d54e-4628-a7d0-f9b33315492d}, !- Target Object
+  {67d04328-a01e-4162-b2f0-3cafe9307180}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {9ae8d93f-e07b-4360-b395-4a163f1d489f}, !- Handle
-  {304d5827-b040-4d5b-a559-6b23a432ee01}, !- Name
-  {064a47d4-d54e-4628-a7d0-f9b33315492d}, !- Source Object
+  {8621388a-de7f-4e73-a0d0-09293a5b196b}, !- Handle
+  {93d7afbd-2986-4fac-8902-56b782bb202c}, !- Name
+  {67d04328-a01e-4162-b2f0-3cafe9307180}, !- Source Object
   12,                                     !- Outlet Port
-  {997125fd-e1bd-4c09-939c-69b13a039917}, !- Target Object
+  {adb5746f-9506-4f16-8072-1d61488bb3e8}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {f1ff8e41-03ff-4026-9f99-a76292df356c}, !- Handle
+  {0799162a-1fa1-48f8-b93c-192e5bb22da4}, !- Handle
   Air Terminal Single Duct VAV Reheat 7,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {d41414c9-1e39-4e90-8c68-f6e140b14130}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {0037d33c-d2ae-4ea1-98b8-2bdb3faaa0b5}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {6642d817-6d7d-4083-8e00-176e140f82c9}, !- Reheat Coil Name
+  {7ecde166-0e89-49ff-8f55-98da262b5254}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {06d43481-9a33-401b-a0ad-197ec497bf6e}, !- Air Outlet Node Name
+  {ec6b66a2-b1c9-4662-b13a-c4dad8486d5e}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7495,13 +7503,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {6642d817-6d7d-4083-8e00-176e140f82c9}, !- Handle
+  {7ecde166-0e89-49ff-8f55-98da262b5254}, !- Handle
   Coil Heating Water 9,                   !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {1d9bfeb8-4c3c-41e9-8ee5-5e46e6b43f4b}, !- Water Inlet Node Name
-  {fd68a821-bd83-48f6-bdb6-c99a3a21fd5e}, !- Water Outlet Node Name
+  {d7e6ea90-687c-493d-81d5-7dcf0a27d5a5}, !- Water Inlet Node Name
+  {25ecb9ba-2ed6-45d5-9d6c-8dcc85cd753b}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7513,121 +7521,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {3b0a2f9d-8967-48e9-90d6-7aa2567a78af}, !- Handle
+  {20094794-aa36-4dd6-be59-44add6902c86}, !- Handle
   Node 154,                               !- Name
-  {2088155f-2b93-4116-8675-f7f46f5feded}, !- Inlet Port
-  {1d9bfeb8-4c3c-41e9-8ee5-5e46e6b43f4b}; !- Outlet Port
+  {fe6a891a-f00b-4ba6-b1ea-db04fd565691}, !- Inlet Port
+  {d7e6ea90-687c-493d-81d5-7dcf0a27d5a5}; !- Outlet Port
 
 OS:Connection,
-  {2088155f-2b93-4116-8675-f7f46f5feded}, !- Handle
-  {9d6b31df-7722-4048-b2ef-9be803b14dcc}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {fe6a891a-f00b-4ba6-b1ea-db04fd565691}, !- Handle
+  {f6409caa-73dd-472c-b928-ddf250618c32}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   10,                                     !- Outlet Port
-  {3b0a2f9d-8967-48e9-90d6-7aa2567a78af}, !- Target Object
+  {20094794-aa36-4dd6-be59-44add6902c86}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {62709099-7b69-4ab5-bf24-44a5b8772ede}, !- Handle
+  {867c002c-9dd9-4c7f-a108-54c75726a5d7}, !- Handle
   Node 155,                               !- Name
-  {fd68a821-bd83-48f6-bdb6-c99a3a21fd5e}, !- Inlet Port
-  {f0739955-9750-4252-b080-23ec71392f7c}; !- Outlet Port
+  {25ecb9ba-2ed6-45d5-9d6c-8dcc85cd753b}, !- Inlet Port
+  {e1c85cdd-008b-48df-85e7-17eccc20d9b4}; !- Outlet Port
 
 OS:Connection,
-  {1d9bfeb8-4c3c-41e9-8ee5-5e46e6b43f4b}, !- Handle
-  {5b324c22-275b-4c93-bbc2-63b65e674be7}, !- Name
-  {3b0a2f9d-8967-48e9-90d6-7aa2567a78af}, !- Source Object
+  {d7e6ea90-687c-493d-81d5-7dcf0a27d5a5}, !- Handle
+  {ad62445c-29ca-4f17-aa8b-c585c208e035}, !- Name
+  {20094794-aa36-4dd6-be59-44add6902c86}, !- Source Object
   3,                                      !- Outlet Port
-  {6642d817-6d7d-4083-8e00-176e140f82c9}, !- Target Object
+  {7ecde166-0e89-49ff-8f55-98da262b5254}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {fd68a821-bd83-48f6-bdb6-c99a3a21fd5e}, !- Handle
-  {4ce78e6a-eef4-4403-ac03-611b13d3d606}, !- Name
-  {6642d817-6d7d-4083-8e00-176e140f82c9}, !- Source Object
+  {25ecb9ba-2ed6-45d5-9d6c-8dcc85cd753b}, !- Handle
+  {836a470d-cdab-41c0-88c8-15ee826f272b}, !- Name
+  {7ecde166-0e89-49ff-8f55-98da262b5254}, !- Source Object
   6,                                      !- Outlet Port
-  {62709099-7b69-4ab5-bf24-44a5b8772ede}, !- Target Object
+  {867c002c-9dd9-4c7f-a108-54c75726a5d7}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {f0739955-9750-4252-b080-23ec71392f7c}, !- Handle
-  {43844d75-89f8-4e7e-91c5-ddd4a21e669b}, !- Name
-  {62709099-7b69-4ab5-bf24-44a5b8772ede}, !- Source Object
+  {e1c85cdd-008b-48df-85e7-17eccc20d9b4}, !- Handle
+  {0d5fa741-4f04-4e72-abdb-940458cbf04d}, !- Name
+  {867c002c-9dd9-4c7f-a108-54c75726a5d7}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   10;                                     !- Inlet Port
 
 OS:Node,
-  {cdf4ad24-a438-45da-b056-578a72850e7d}, !- Handle
+  {a43d0780-dee2-4eca-a742-c673950bc424}, !- Handle
   Node 156,                               !- Name
-  {06d43481-9a33-401b-a0ad-197ec497bf6e}, !- Inlet Port
-  {af636675-2a9b-49e3-9330-e95a4217788d}; !- Outlet Port
+  {ec6b66a2-b1c9-4662-b13a-c4dad8486d5e}, !- Inlet Port
+  {0fdc523a-dfe3-4fa6-bce2-06597247d63b}; !- Outlet Port
 
 OS:Node,
-  {077e5d59-c682-4352-bcd0-c1c6d7952c7c}, !- Handle
+  {50eabb1d-14cc-4441-8c53-fb1d0b6e9820}, !- Handle
   Node 157,                               !- Name
-  {cbe854c7-d3e3-4a7b-9728-c90e3b6ac999}, !- Inlet Port
-  {129ef53b-cdef-4685-9f8a-57868d81783d}; !- Outlet Port
+  {fd77d3b8-830f-45c2-9777-48e3b2724a1b}, !- Inlet Port
+  {0477092e-3b6d-4227-b47b-85868507cec0}; !- Outlet Port
 
 OS:Connection,
-  {af636675-2a9b-49e3-9330-e95a4217788d}, !- Handle
-  {82bf8c67-d4b8-40df-857c-af026cc379f7}, !- Name
-  {cdf4ad24-a438-45da-b056-578a72850e7d}, !- Source Object
+  {0fdc523a-dfe3-4fa6-bce2-06597247d63b}, !- Handle
+  {42db8956-bee9-4848-97a4-4eb26a1e3318}, !- Name
+  {a43d0780-dee2-4eca-a742-c673950bc424}, !- Source Object
   3,                                      !- Outlet Port
-  {1d75dadb-55ec-4edd-b070-8265f6db36f0}, !- Target Object
+  {cf354f66-ffe3-484b-a97f-674aa2d1a9ca}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {cbe854c7-d3e3-4a7b-9728-c90e3b6ac999}, !- Handle
-  {5d47cbb7-de57-4127-94b3-e30b7e038a02}, !- Name
-  {0d0c9790-59a6-4355-96d6-bc692c51f054}, !- Source Object
+  {fd77d3b8-830f-45c2-9777-48e3b2724a1b}, !- Handle
+  {b91a3f62-a634-450e-bf96-716d7130ece1}, !- Name
+  {ae8f18cb-499a-47ef-8c94-1e994eac29f1}, !- Source Object
   3,                                      !- Outlet Port
-  {077e5d59-c682-4352-bcd0-c1c6d7952c7c}, !- Target Object
+  {50eabb1d-14cc-4441-8c53-fb1d0b6e9820}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {5dd35662-96d0-46e7-9b41-cc81ad66b780}, !- Handle
+  {48f12e39-09cd-4cf2-941b-a8be388ba789}, !- Handle
   Node 158,                               !- Name
-  {55a0e15e-8b15-45e6-a3d1-75ea40497d3e}, !- Inlet Port
-  {d41414c9-1e39-4e90-8c68-f6e140b14130}; !- Outlet Port
+  {0e010d53-ca9e-4ddc-a61c-70cf086be9e5}, !- Inlet Port
+  {0037d33c-d2ae-4ea1-98b8-2bdb3faaa0b5}; !- Outlet Port
 
 OS:Connection,
-  {55a0e15e-8b15-45e6-a3d1-75ea40497d3e}, !- Handle
-  {6c8e1286-460e-4bb5-ba44-0c076e549f61}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {0e010d53-ca9e-4ddc-a61c-70cf086be9e5}, !- Handle
+  {4d9447e2-ee1d-4578-8c15-bec060595201}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   8,                                      !- Outlet Port
-  {5dd35662-96d0-46e7-9b41-cc81ad66b780}, !- Target Object
+  {48f12e39-09cd-4cf2-941b-a8be388ba789}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {d41414c9-1e39-4e90-8c68-f6e140b14130}, !- Handle
-  {4a05cf2f-1843-4987-9a56-754b0299fec4}, !- Name
-  {5dd35662-96d0-46e7-9b41-cc81ad66b780}, !- Source Object
+  {0037d33c-d2ae-4ea1-98b8-2bdb3faaa0b5}, !- Handle
+  {bc84ca6b-0b1b-4af3-9dda-b9b8a79a316f}, !- Name
+  {48f12e39-09cd-4cf2-941b-a8be388ba789}, !- Source Object
   3,                                      !- Outlet Port
-  {f1ff8e41-03ff-4026-9f99-a76292df356c}, !- Target Object
+  {0799162a-1fa1-48f8-b93c-192e5bb22da4}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {06d43481-9a33-401b-a0ad-197ec497bf6e}, !- Handle
-  {790bfc3a-c322-44f6-b0c3-306bc7fdd825}, !- Name
-  {f1ff8e41-03ff-4026-9f99-a76292df356c}, !- Source Object
+  {ec6b66a2-b1c9-4662-b13a-c4dad8486d5e}, !- Handle
+  {742cbc1b-7208-4c05-b904-b65706f31810}, !- Name
+  {0799162a-1fa1-48f8-b93c-192e5bb22da4}, !- Source Object
   12,                                     !- Outlet Port
-  {cdf4ad24-a438-45da-b056-578a72850e7d}, !- Target Object
+  {a43d0780-dee2-4eca-a742-c673950bc424}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {45255f53-2b67-4fe8-8758-8f019536684a}, !- Handle
+  {0442d587-a8e5-4fe5-9c02-eb1c04817d4a}, !- Handle
   Air Terminal Single Duct VAV Reheat 8,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {9869013d-8e01-4019-828e-5ffc0f4132de}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {588564cc-59e3-44ed-9439-c69907a85f95}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {2c5ac5cf-3c8f-4653-b9de-d11aaa2b65b1}, !- Reheat Coil Name
+  {e054996d-0712-4f27-b309-ce6f3fd932fb}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {9f04c94a-7e89-46dc-9651-a1a90d477de0}, !- Air Outlet Node Name
+  {992daf9f-2dc6-4a0e-963b-8139acb3badc}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7636,13 +7644,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {2c5ac5cf-3c8f-4653-b9de-d11aaa2b65b1}, !- Handle
+  {e054996d-0712-4f27-b309-ce6f3fd932fb}, !- Handle
   Coil Heating Water 10,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {0226b13c-967d-452e-926c-780778c44fb7}, !- Water Inlet Node Name
-  {4fc732ec-fb9c-433c-9fd1-eadc6436d6d8}, !- Water Outlet Node Name
+  {9aef6f4e-e7c8-4d7b-9076-029cc97a157f}, !- Water Inlet Node Name
+  {b970b7e4-7b5e-4ea8-836b-9b4bb898459c}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7654,121 +7662,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {5a24612c-9b3d-4f4f-9d31-965fe19408da}, !- Handle
+  {68095455-f572-4639-a5ed-079f158e91d9}, !- Handle
   Node 159,                               !- Name
-  {37e2e4f8-5462-44e9-be99-661c3e72fb13}, !- Inlet Port
-  {0226b13c-967d-452e-926c-780778c44fb7}; !- Outlet Port
+  {698a749b-69a9-4397-9aca-ddd126aa7c55}, !- Inlet Port
+  {9aef6f4e-e7c8-4d7b-9076-029cc97a157f}; !- Outlet Port
 
 OS:Connection,
-  {37e2e4f8-5462-44e9-be99-661c3e72fb13}, !- Handle
-  {c020c236-b8c8-460d-b733-0d4138bfa110}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {698a749b-69a9-4397-9aca-ddd126aa7c55}, !- Handle
+  {8f3addb1-2ee2-4541-87ed-c8252066aef7}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   11,                                     !- Outlet Port
-  {5a24612c-9b3d-4f4f-9d31-965fe19408da}, !- Target Object
+  {68095455-f572-4639-a5ed-079f158e91d9}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {b00a5112-6f52-4b46-842b-f0b19fb17b88}, !- Handle
+  {a7e903b6-93a7-4ec9-a36f-74158c3d1715}, !- Handle
   Node 160,                               !- Name
-  {4fc732ec-fb9c-433c-9fd1-eadc6436d6d8}, !- Inlet Port
-  {4967e7f5-33e6-43d9-a956-6b6c2a02ee5e}; !- Outlet Port
+  {b970b7e4-7b5e-4ea8-836b-9b4bb898459c}, !- Inlet Port
+  {04c089a7-65d7-4ad6-a7b5-4a9a5e22658c}; !- Outlet Port
 
 OS:Connection,
-  {0226b13c-967d-452e-926c-780778c44fb7}, !- Handle
-  {c45868d3-6eb4-47a7-816a-6f6ff154c072}, !- Name
-  {5a24612c-9b3d-4f4f-9d31-965fe19408da}, !- Source Object
+  {9aef6f4e-e7c8-4d7b-9076-029cc97a157f}, !- Handle
+  {474902c2-34ef-427b-be24-105cc502d66e}, !- Name
+  {68095455-f572-4639-a5ed-079f158e91d9}, !- Source Object
   3,                                      !- Outlet Port
-  {2c5ac5cf-3c8f-4653-b9de-d11aaa2b65b1}, !- Target Object
+  {e054996d-0712-4f27-b309-ce6f3fd932fb}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {4fc732ec-fb9c-433c-9fd1-eadc6436d6d8}, !- Handle
-  {23e402d5-7b82-41e6-9c70-b2a2ed884e92}, !- Name
-  {2c5ac5cf-3c8f-4653-b9de-d11aaa2b65b1}, !- Source Object
+  {b970b7e4-7b5e-4ea8-836b-9b4bb898459c}, !- Handle
+  {2a787c50-48e9-48b1-b9c8-d64f2ca62626}, !- Name
+  {e054996d-0712-4f27-b309-ce6f3fd932fb}, !- Source Object
   6,                                      !- Outlet Port
-  {b00a5112-6f52-4b46-842b-f0b19fb17b88}, !- Target Object
+  {a7e903b6-93a7-4ec9-a36f-74158c3d1715}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {4967e7f5-33e6-43d9-a956-6b6c2a02ee5e}, !- Handle
-  {95c8c5eb-63f4-44b0-a40b-069ec1c3c121}, !- Name
-  {b00a5112-6f52-4b46-842b-f0b19fb17b88}, !- Source Object
+  {04c089a7-65d7-4ad6-a7b5-4a9a5e22658c}, !- Handle
+  {c58ee9a9-aa99-48af-8ba9-7fe8dd674c7e}, !- Name
+  {a7e903b6-93a7-4ec9-a36f-74158c3d1715}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   11;                                     !- Inlet Port
 
 OS:Node,
-  {3ab7e4a2-37dc-446e-934e-fd747cedfa40}, !- Handle
+  {57eafb10-9113-4c86-bf14-e7ef76a28cdd}, !- Handle
   Node 161,                               !- Name
-  {9f04c94a-7e89-46dc-9651-a1a90d477de0}, !- Inlet Port
-  {3d89aabe-a1d7-477d-a87b-d89d399b04d8}; !- Outlet Port
+  {992daf9f-2dc6-4a0e-963b-8139acb3badc}, !- Inlet Port
+  {016d6a89-1f9d-4ea3-bbc9-0ca1de2ce2a6}; !- Outlet Port
 
 OS:Node,
-  {1e333ce2-c09a-4704-bbb4-07fdbb704518}, !- Handle
+  {f6a3ce39-9cdb-489e-9108-d6a76aa54fd6}, !- Handle
   Node 162,                               !- Name
-  {2109d080-3dd1-4e1e-95fb-96162b158021}, !- Inlet Port
-  {34a3d02f-dba1-4e3e-b679-061d5c0f4123}; !- Outlet Port
+  {4efc135c-a21e-4678-a8f8-844eedf91361}, !- Inlet Port
+  {16008e55-3a70-413d-9f7b-f27228cf721a}; !- Outlet Port
 
 OS:Connection,
-  {3d89aabe-a1d7-477d-a87b-d89d399b04d8}, !- Handle
-  {b1f48063-a5a7-4b9b-b845-32417c5f7fcd}, !- Name
-  {3ab7e4a2-37dc-446e-934e-fd747cedfa40}, !- Source Object
+  {016d6a89-1f9d-4ea3-bbc9-0ca1de2ce2a6}, !- Handle
+  {1439d771-ce2b-41fe-b1b9-6044c54d2bce}, !- Name
+  {57eafb10-9113-4c86-bf14-e7ef76a28cdd}, !- Source Object
   3,                                      !- Outlet Port
-  {805427ed-6ecb-4c7b-92f5-17fb93368acb}, !- Target Object
+  {c65ba217-31bb-4b57-a5a1-d1b8712ec70c}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {2109d080-3dd1-4e1e-95fb-96162b158021}, !- Handle
-  {9d7bb53f-cc92-498f-8eab-a4bdcc6634b0}, !- Name
-  {1ac43259-f634-413f-9a94-9ef7e9e49097}, !- Source Object
+  {4efc135c-a21e-4678-a8f8-844eedf91361}, !- Handle
+  {e1cc3018-c2a5-48d8-bc8e-e828ee542a97}, !- Name
+  {97803d60-67ed-48b0-ad67-9d49cca6e51f}, !- Source Object
   3,                                      !- Outlet Port
-  {1e333ce2-c09a-4704-bbb4-07fdbb704518}, !- Target Object
+  {f6a3ce39-9cdb-489e-9108-d6a76aa54fd6}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {ec59111a-2d42-45bf-bfe2-cc4ed2cc73b5}, !- Handle
+  {e82863a4-f3aa-4ba4-93ec-78b91ad2bc08}, !- Handle
   Node 163,                               !- Name
-  {db806288-7cb4-45d1-b04b-3c038f252db4}, !- Inlet Port
-  {9869013d-8e01-4019-828e-5ffc0f4132de}; !- Outlet Port
+  {de733b25-322c-4519-a4b2-ea581d944d3f}, !- Inlet Port
+  {588564cc-59e3-44ed-9439-c69907a85f95}; !- Outlet Port
 
 OS:Connection,
-  {db806288-7cb4-45d1-b04b-3c038f252db4}, !- Handle
-  {cb125e71-e029-427f-adac-4dff569ec912}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {de733b25-322c-4519-a4b2-ea581d944d3f}, !- Handle
+  {8f7b5092-f7ed-43ee-bde8-9ba1e6ad6ed1}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   9,                                      !- Outlet Port
-  {ec59111a-2d42-45bf-bfe2-cc4ed2cc73b5}, !- Target Object
+  {e82863a4-f3aa-4ba4-93ec-78b91ad2bc08}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {9869013d-8e01-4019-828e-5ffc0f4132de}, !- Handle
-  {af4b3624-e421-4d19-bbc0-a591ba5600ce}, !- Name
-  {ec59111a-2d42-45bf-bfe2-cc4ed2cc73b5}, !- Source Object
+  {588564cc-59e3-44ed-9439-c69907a85f95}, !- Handle
+  {0998d66c-8803-4817-b4cb-4fc0665ab95b}, !- Name
+  {e82863a4-f3aa-4ba4-93ec-78b91ad2bc08}, !- Source Object
   3,                                      !- Outlet Port
-  {45255f53-2b67-4fe8-8758-8f019536684a}, !- Target Object
+  {0442d587-a8e5-4fe5-9c02-eb1c04817d4a}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {9f04c94a-7e89-46dc-9651-a1a90d477de0}, !- Handle
-  {5679baaa-1f5e-46c3-8a5a-31ad3a4c53c7}, !- Name
-  {45255f53-2b67-4fe8-8758-8f019536684a}, !- Source Object
+  {992daf9f-2dc6-4a0e-963b-8139acb3badc}, !- Handle
+  {3222923f-f14a-4c18-b414-57f4d433f97c}, !- Name
+  {0442d587-a8e5-4fe5-9c02-eb1c04817d4a}, !- Source Object
   12,                                     !- Outlet Port
-  {3ab7e4a2-37dc-446e-934e-fd747cedfa40}, !- Target Object
+  {57eafb10-9113-4c86-bf14-e7ef76a28cdd}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {a57dd1cc-74a6-4606-83c2-00ed85046b81}, !- Handle
+  {96953bdf-c616-48bb-92f1-a37b360f4e0f}, !- Handle
   Air Terminal Single Duct VAV Reheat 9,  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {0cd68b81-16de-40d4-a972-af53f134a116}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {b2ed684d-f4ae-4928-9e36-f8101aed39c7}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {364b6d29-e8c2-477e-b8a1-74b495d04fdd}, !- Reheat Coil Name
+  {2676bf54-46cd-49d9-beb8-41ee37a09a32}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {c055a71f-4af3-464b-91e8-f28c6cb9d917}, !- Air Outlet Node Name
+  {756271b8-1444-47be-9fbf-a6186f2a8d25}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7777,13 +7785,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {364b6d29-e8c2-477e-b8a1-74b495d04fdd}, !- Handle
+  {2676bf54-46cd-49d9-beb8-41ee37a09a32}, !- Handle
   Coil Heating Water 11,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {1b334dd9-104e-4563-bd76-27568d8aa91c}, !- Water Inlet Node Name
-  {48c77bd2-6cb5-452c-9a75-e40cad99cee5}, !- Water Outlet Node Name
+  {ffdf1fcf-a67e-4617-878b-86d6b5e11aea}, !- Water Inlet Node Name
+  {a12f63ab-e9a9-436a-8897-7609192d0aa3}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7795,151 +7803,151 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {f5a9e513-22a7-44c9-a7c0-f2e2408b5373}, !- Handle
+  {0c6b3b33-8f0b-4b41-b547-f891a9b610e4}, !- Handle
   Node 164,                               !- Name
-  {38c516c4-49b4-41c6-a1f7-c719477055f2}, !- Inlet Port
-  {1b334dd9-104e-4563-bd76-27568d8aa91c}; !- Outlet Port
+  {b6f05ecb-d537-401c-901e-6d092208d28d}, !- Inlet Port
+  {ffdf1fcf-a67e-4617-878b-86d6b5e11aea}; !- Outlet Port
 
 OS:Connection,
-  {38c516c4-49b4-41c6-a1f7-c719477055f2}, !- Handle
-  {7d30a102-0c35-4803-9f5f-54d55a592325}, !- Name
-  {e9833739-0686-47b8-88a5-226ba7c98e20}, !- Source Object
+  {b6f05ecb-d537-401c-901e-6d092208d28d}, !- Handle
+  {7b7e1e4c-2640-433a-a363-556e0300b53a}, !- Name
+  {a77987af-feb7-4caf-ab5f-162b7ce99e35}, !- Source Object
   12,                                     !- Outlet Port
-  {f5a9e513-22a7-44c9-a7c0-f2e2408b5373}, !- Target Object
+  {0c6b3b33-8f0b-4b41-b547-f891a9b610e4}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {701053fd-d920-4338-9efd-5a3c65e9dd7a}, !- Handle
+  {e289e4f8-da50-43e1-9502-a2e0fa6e9820}, !- Handle
   Node 165,                               !- Name
-  {48c77bd2-6cb5-452c-9a75-e40cad99cee5}, !- Inlet Port
-  {eebcf3ea-79ee-401c-b759-d4467984d767}; !- Outlet Port
+  {a12f63ab-e9a9-436a-8897-7609192d0aa3}, !- Inlet Port
+  {4a71f1fb-4eb3-4743-80d1-3a37d49e80cb}; !- Outlet Port
 
 OS:Connection,
-  {1b334dd9-104e-4563-bd76-27568d8aa91c}, !- Handle
-  {53de4b7e-d7bb-48a9-9ff8-16c2896c04de}, !- Name
-  {f5a9e513-22a7-44c9-a7c0-f2e2408b5373}, !- Source Object
+  {ffdf1fcf-a67e-4617-878b-86d6b5e11aea}, !- Handle
+  {7c3120b3-f936-4027-8871-29f6f0a54aa5}, !- Name
+  {0c6b3b33-8f0b-4b41-b547-f891a9b610e4}, !- Source Object
   3,                                      !- Outlet Port
-  {364b6d29-e8c2-477e-b8a1-74b495d04fdd}, !- Target Object
+  {2676bf54-46cd-49d9-beb8-41ee37a09a32}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {48c77bd2-6cb5-452c-9a75-e40cad99cee5}, !- Handle
-  {f8eeebb5-7198-49d1-b6e2-faa4e322906b}, !- Name
-  {364b6d29-e8c2-477e-b8a1-74b495d04fdd}, !- Source Object
+  {a12f63ab-e9a9-436a-8897-7609192d0aa3}, !- Handle
+  {90302160-d887-423e-a02d-e17db6151a54}, !- Name
+  {2676bf54-46cd-49d9-beb8-41ee37a09a32}, !- Source Object
   6,                                      !- Outlet Port
-  {701053fd-d920-4338-9efd-5a3c65e9dd7a}, !- Target Object
+  {e289e4f8-da50-43e1-9502-a2e0fa6e9820}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {eebcf3ea-79ee-401c-b759-d4467984d767}, !- Handle
-  {b4837e85-ae26-492d-89a1-9d42b8bc0802}, !- Name
-  {701053fd-d920-4338-9efd-5a3c65e9dd7a}, !- Source Object
+  {4a71f1fb-4eb3-4743-80d1-3a37d49e80cb}, !- Handle
+  {9cd257f4-33e9-4d19-8970-9fa44dcfffc6}, !- Name
+  {e289e4f8-da50-43e1-9502-a2e0fa6e9820}, !- Source Object
   3,                                      !- Outlet Port
-  {a57326e7-9d69-4171-bbe2-de98a9540cc1}, !- Target Object
+  {0d422497-14b3-425f-9053-8214424ffc58}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Node,
-  {056249d9-a048-47c6-89ad-6256990b9a8c}, !- Handle
+  {80fbee53-cad4-4891-88bf-c1c485bc4c95}, !- Handle
   Node 166,                               !- Name
-  {c055a71f-4af3-464b-91e8-f28c6cb9d917}, !- Inlet Port
-  {17758b60-6c21-4612-84ee-fbc301e72fe6}; !- Outlet Port
+  {756271b8-1444-47be-9fbf-a6186f2a8d25}, !- Inlet Port
+  {2007d205-4ebd-4273-b930-ff7c3b9d56c5}; !- Outlet Port
 
 OS:Node,
-  {d1e78639-bd83-4131-bf58-1e02159dc0bd}, !- Handle
+  {a98c8fb0-e2c5-4b79-ab23-11cec05fde7d}, !- Handle
   Node 167,                               !- Name
-  {e7c93b9a-7437-4d52-b958-07adc8bfd68b}, !- Inlet Port
-  {bf83339a-61df-46d3-b85c-e963a5c3401f}; !- Outlet Port
+  {3512908d-c8d9-40d8-b71d-c93a3b339bd0}, !- Inlet Port
+  {ebe9da10-4d1d-4ef6-b853-b21c695dd0c5}; !- Outlet Port
 
 OS:Connection,
-  {17758b60-6c21-4612-84ee-fbc301e72fe6}, !- Handle
-  {6ed4efce-19c5-4cd3-b7a7-32b2efdad439}, !- Name
-  {056249d9-a048-47c6-89ad-6256990b9a8c}, !- Source Object
+  {2007d205-4ebd-4273-b930-ff7c3b9d56c5}, !- Handle
+  {0ef6ca6e-0f85-4e08-801d-f8ad394a12b4}, !- Name
+  {80fbee53-cad4-4891-88bf-c1c485bc4c95}, !- Source Object
   3,                                      !- Outlet Port
-  {1ca6b81d-2235-4acb-81a1-340ce4e2806a}, !- Target Object
+  {58eb42cf-bea0-4c2c-b544-97ce9e67f0e9}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {e7c93b9a-7437-4d52-b958-07adc8bfd68b}, !- Handle
-  {574ffdca-1903-4e4a-9b71-b3fda42196b1}, !- Name
-  {c23ee3d2-5aa7-49fe-9f99-2b1cd8737ea2}, !- Source Object
+  {3512908d-c8d9-40d8-b71d-c93a3b339bd0}, !- Handle
+  {4df897c9-3c5d-4e33-9665-1473bf66f94a}, !- Name
+  {1ed84698-ef20-454c-a2f3-757ec7a21171}, !- Source Object
   3,                                      !- Outlet Port
-  {d1e78639-bd83-4131-bf58-1e02159dc0bd}, !- Target Object
+  {a98c8fb0-e2c5-4b79-ab23-11cec05fde7d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {ffec35f9-7d65-431c-9026-f481c4c325a9}, !- Handle
+  {37298b2e-c471-4301-8697-c8237b6f6a2f}, !- Handle
   Node 168,                               !- Name
-  {4d024f13-5166-40d7-9d0c-4639bb3ea48b}, !- Inlet Port
-  {0cd68b81-16de-40d4-a972-af53f134a116}; !- Outlet Port
+  {fecdcc31-c0f3-452f-8dfb-cd66e65938c1}, !- Inlet Port
+  {b2ed684d-f4ae-4928-9e36-f8101aed39c7}; !- Outlet Port
 
 OS:Connection,
-  {4d024f13-5166-40d7-9d0c-4639bb3ea48b}, !- Handle
-  {5b4f7c4f-bc47-4ca7-9106-182ba0048268}, !- Name
-  {2b93adf9-c832-4467-a647-bcd572d01789}, !- Source Object
+  {fecdcc31-c0f3-452f-8dfb-cd66e65938c1}, !- Handle
+  {d8d751fa-166e-408b-86b3-89e48403481e}, !- Name
+  {f39a722b-ec0b-4c32-b676-f65f8a9ff363}, !- Source Object
   10,                                     !- Outlet Port
-  {ffec35f9-7d65-431c-9026-f481c4c325a9}, !- Target Object
+  {37298b2e-c471-4301-8697-c8237b6f6a2f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {0cd68b81-16de-40d4-a972-af53f134a116}, !- Handle
-  {bbac2054-8e30-437a-8d1c-291255ef974f}, !- Name
-  {ffec35f9-7d65-431c-9026-f481c4c325a9}, !- Source Object
+  {b2ed684d-f4ae-4928-9e36-f8101aed39c7}, !- Handle
+  {65f6b689-b198-4e11-a887-88af62b42c0d}, !- Name
+  {37298b2e-c471-4301-8697-c8237b6f6a2f}, !- Source Object
   3,                                      !- Outlet Port
-  {a57dd1cc-74a6-4606-83c2-00ed85046b81}, !- Target Object
+  {96953bdf-c616-48bb-92f1-a37b360f4e0f}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {c055a71f-4af3-464b-91e8-f28c6cb9d917}, !- Handle
-  {5f09fb21-a3da-4a5c-ac1a-cc2f2c311d1b}, !- Name
-  {a57dd1cc-74a6-4606-83c2-00ed85046b81}, !- Source Object
+  {756271b8-1444-47be-9fbf-a6186f2a8d25}, !- Handle
+  {133fb495-9b24-4b53-ad70-f106b4a2d636}, !- Name
+  {96953bdf-c616-48bb-92f1-a37b360f4e0f}, !- Source Object
   12,                                     !- Outlet Port
-  {056249d9-a048-47c6-89ad-6256990b9a8c}, !- Target Object
+  {80fbee53-cad4-4891-88bf-c1c485bc4c95}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {58de15ab-afba-498b-8086-9ba56a6df1b2}, !- Handle
+  {9ff2bdfd-8f94-47c1-80d0-ec0ff7370b33}, !- Handle
   Node 169,                               !- Name
-  {469f2973-e376-4115-aca5-e50bd6653d24}, !- Inlet Port
-  {90990327-befa-48cb-9bfd-59cdf0459fda}; !- Outlet Port
+  {0cb5743b-9e14-4aff-aab0-5e2dbc8a62d3}, !- Inlet Port
+  {dfd84259-b857-4daf-b3ac-a4a1748268a0}; !- Outlet Port
 
 OS:Connection,
-  {e49afaea-6321-4fb6-8e07-a6f176fae502}, !- Handle
-  {6e242f56-dc41-47b7-aecd-8f50c724faec}, !- Name
-  {10a1998b-f4c9-499d-a6fd-34f777bd7415}, !- Source Object
+  {3d864097-09b9-4449-8c9a-f66f619f2c85}, !- Handle
+  {939baa07-9c3a-4e9e-8273-576c72c2e89c}, !- Name
+  {fac4a905-d12a-4f7a-b68c-d03e472bea0a}, !- Source Object
   3,                                      !- Outlet Port
-  {c5243fcc-3139-4d7b-a5b0-3b7b711e0e28}, !- Target Object
+  {b013d9bb-6e7b-43b5-b933-8a3197525aac}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {469f2973-e376-4115-aca5-e50bd6653d24}, !- Handle
-  {f61d9b1e-cd4d-4f10-bde9-993d4a8266c5}, !- Name
-  {f6888b8b-7a06-4454-b283-9947d282069d}, !- Source Object
+  {0cb5743b-9e14-4aff-aab0-5e2dbc8a62d3}, !- Handle
+  {50fadf2b-97e5-4e95-8268-174eb2606d5a}, !- Name
+  {b8f5d8e3-c832-4f97-9096-15658f3433a9}, !- Source Object
   4,                                      !- Outlet Port
-  {58de15ab-afba-498b-8086-9ba56a6df1b2}, !- Target Object
+  {9ff2bdfd-8f94-47c1-80d0-ec0ff7370b33}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {90990327-befa-48cb-9bfd-59cdf0459fda}, !- Handle
-  {fd3a00a1-3233-4bcd-8b38-962d4816109f}, !- Name
-  {58de15ab-afba-498b-8086-9ba56a6df1b2}, !- Source Object
+  {dfd84259-b857-4daf-b3ac-a4a1748268a0}, !- Handle
+  {c84d43eb-02f0-4618-892a-d7dbe0d3de77}, !- Name
+  {9ff2bdfd-8f94-47c1-80d0-ec0ff7370b33}, !- Source Object
   3,                                      !- Outlet Port
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Target Object
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {dcbb997a-8e9b-4fd1-923d-2af7228fc00c}, !- Handle
+  {1a6c952c-ace3-44b9-83cb-baf543185497}, !- Handle
   Air Terminal Single Duct VAV Reheat 10, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {a31579ed-0ba0-4a1d-9928-fd3e960b3fbc}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {640da610-5aaf-46a1-a674-65048a367861}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {9afdb079-0b61-4e0c-b552-def70c1980f7}, !- Reheat Coil Name
+  {1f8e54c7-12d1-4fac-a963-c7f7074f6a22}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {bd55def4-adc3-49c8-95e5-69ffd978affe}, !- Air Outlet Node Name
+  {0af01b54-3106-46fa-8cb0-15decd6af85e}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -7948,13 +7956,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {9afdb079-0b61-4e0c-b552-def70c1980f7}, !- Handle
+  {1f8e54c7-12d1-4fac-a963-c7f7074f6a22}, !- Handle
   Coil Heating Water 12,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {30292ce9-69a1-48b4-8fcd-4892f77ccc7b}, !- Water Inlet Node Name
-  {5aef04ee-88f6-4182-8201-9243e655ea3c}, !- Water Outlet Node Name
+  {cbfd17b4-5914-405e-9068-877d51419879}, !- Water Inlet Node Name
+  {52f6826f-f62c-4287-a16a-e1a472d9b4cd}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -7966,129 +7974,129 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {f788b1a2-9db3-4961-9e94-d1aa5f69708e}, !- Handle
+  {2e979eed-ad23-4cd1-8fc1-9a80a4badf49}, !- Handle
   Node 170,                               !- Name
-  {e15734dd-822f-4fec-a6a8-a3396f91ba31}, !- Inlet Port
-  {30292ce9-69a1-48b4-8fcd-4892f77ccc7b}; !- Outlet Port
+  {1a51ba8b-cbf2-42ca-b052-475cd810a946}, !- Inlet Port
+  {cbfd17b4-5914-405e-9068-877d51419879}; !- Outlet Port
 
 OS:Connection,
-  {e15734dd-822f-4fec-a6a8-a3396f91ba31}, !- Handle
-  {67a36803-ab2a-4a70-94b5-ac5b695a1a5e}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {1a51ba8b-cbf2-42ca-b052-475cd810a946}, !- Handle
+  {5c523f8c-c8dc-4b7c-92e6-bb3040e925cd}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   6,                                      !- Outlet Port
-  {f788b1a2-9db3-4961-9e94-d1aa5f69708e}, !- Target Object
+  {2e979eed-ad23-4cd1-8fc1-9a80a4badf49}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {25eefa42-2258-4ee4-ab0b-6335a9866036}, !- Handle
+  {26c80857-69e1-4d1e-a399-3b00469b7f63}, !- Handle
   Node 171,                               !- Name
-  {5aef04ee-88f6-4182-8201-9243e655ea3c}, !- Inlet Port
-  {51051964-0414-408a-ad40-92188ffc4931}; !- Outlet Port
+  {52f6826f-f62c-4287-a16a-e1a472d9b4cd}, !- Inlet Port
+  {a491e700-0d90-4a8d-93dd-42ac6f76242b}; !- Outlet Port
 
 OS:Connection,
-  {30292ce9-69a1-48b4-8fcd-4892f77ccc7b}, !- Handle
-  {50994485-f8b9-482b-ab6e-bc88c1999864}, !- Name
-  {f788b1a2-9db3-4961-9e94-d1aa5f69708e}, !- Source Object
+  {cbfd17b4-5914-405e-9068-877d51419879}, !- Handle
+  {58f5e5b1-73a8-4a49-8d57-a44746e27a81}, !- Name
+  {2e979eed-ad23-4cd1-8fc1-9a80a4badf49}, !- Source Object
   3,                                      !- Outlet Port
-  {9afdb079-0b61-4e0c-b552-def70c1980f7}, !- Target Object
+  {1f8e54c7-12d1-4fac-a963-c7f7074f6a22}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {5aef04ee-88f6-4182-8201-9243e655ea3c}, !- Handle
-  {1984c9ab-d7cb-42a5-83b1-cd3f91b4ad33}, !- Name
-  {9afdb079-0b61-4e0c-b552-def70c1980f7}, !- Source Object
+  {52f6826f-f62c-4287-a16a-e1a472d9b4cd}, !- Handle
+  {04a63096-f084-496b-8016-04451b3abb46}, !- Name
+  {1f8e54c7-12d1-4fac-a963-c7f7074f6a22}, !- Source Object
   6,                                      !- Outlet Port
-  {25eefa42-2258-4ee4-ab0b-6335a9866036}, !- Target Object
+  {26c80857-69e1-4d1e-a399-3b00469b7f63}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {51051964-0414-408a-ad40-92188ffc4931}, !- Handle
-  {aaa1c15c-1c77-4e24-ab49-f23009acd95b}, !- Name
-  {25eefa42-2258-4ee4-ab0b-6335a9866036}, !- Source Object
+  {a491e700-0d90-4a8d-93dd-42ac6f76242b}, !- Handle
+  {a7d387dc-b9ec-43c8-b6cc-92b55a8011b7}, !- Name
+  {26c80857-69e1-4d1e-a399-3b00469b7f63}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Node,
-  {6bf17cb4-9591-43ce-88cd-cc2d6b796eb3}, !- Handle
+  {e2b164f2-efe4-44ab-ae1c-5efaf4e012ee}, !- Handle
   Node 172,                               !- Name
-  {bd55def4-adc3-49c8-95e5-69ffd978affe}, !- Inlet Port
-  {b56f6545-26db-4bd5-a801-c09c4685edfb}; !- Outlet Port
+  {0af01b54-3106-46fa-8cb0-15decd6af85e}, !- Inlet Port
+  {58b739f0-4622-4256-a5c5-d7b1ef5153eb}; !- Outlet Port
 
 OS:Node,
-  {a3cf73f8-0df9-4011-a436-b62b55731897}, !- Handle
+  {9bbc75bd-f223-4d85-a16b-21d871e0e564}, !- Handle
   Node 173,                               !- Name
-  {6ed4712b-d350-4b3e-8a5f-4889c01a0e8b}, !- Inlet Port
-  {8292e3f5-316e-4277-b97a-cfc59c3581e8}; !- Outlet Port
+  {3a7a574c-d4b1-4ea6-9a7e-8b2b812373e6}, !- Inlet Port
+  {1a89a622-f0f7-432e-9b71-c48220ea5501}; !- Outlet Port
 
 OS:Connection,
-  {b56f6545-26db-4bd5-a801-c09c4685edfb}, !- Handle
-  {2db81e4a-8b31-4cd6-800c-c36328741d83}, !- Name
-  {6bf17cb4-9591-43ce-88cd-cc2d6b796eb3}, !- Source Object
+  {58b739f0-4622-4256-a5c5-d7b1ef5153eb}, !- Handle
+  {d46a8e0a-f184-46de-ae1b-05c3535eddde}, !- Name
+  {e2b164f2-efe4-44ab-ae1c-5efaf4e012ee}, !- Source Object
   3,                                      !- Outlet Port
-  {aeac121c-c6ed-464b-9940-dbaf54f5bfde}, !- Target Object
+  {cf402869-4714-4cf1-885a-7a74464049fd}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {6ed4712b-d350-4b3e-8a5f-4889c01a0e8b}, !- Handle
-  {2651d22f-15a9-44a8-ae25-ec790db66c2b}, !- Name
-  {e2d252d0-fabd-4afb-b386-bc11c7618a04}, !- Source Object
+  {3a7a574c-d4b1-4ea6-9a7e-8b2b812373e6}, !- Handle
+  {90b6dcdf-ee42-40bc-a8f8-7872fa7ebadd}, !- Name
+  {ad7c48a9-7942-4555-ac3a-44c7a61df8a7}, !- Source Object
   4,                                      !- Outlet Port
-  {a3cf73f8-0df9-4011-a436-b62b55731897}, !- Target Object
+  {9bbc75bd-f223-4d85-a16b-21d871e0e564}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8292e3f5-316e-4277-b97a-cfc59c3581e8}, !- Handle
-  {9d055c0a-4587-43e9-a51a-e211330c1d4a}, !- Name
-  {a3cf73f8-0df9-4011-a436-b62b55731897}, !- Source Object
+  {1a89a622-f0f7-432e-9b71-c48220ea5501}, !- Handle
+  {7971dba4-747c-45d1-8cd2-b6cbcaaa7447}, !- Name
+  {9bbc75bd-f223-4d85-a16b-21d871e0e564}, !- Source Object
   3,                                      !- Outlet Port
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Target Object
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Node,
-  {41132dea-1ae3-4e3e-aab7-49771fe57d76}, !- Handle
+  {e9dedde1-eead-4af7-add6-f6490a446a36}, !- Handle
   Node 174,                               !- Name
-  {ca6c49ed-57c9-45b8-a039-1808ed247715}, !- Inlet Port
-  {a31579ed-0ba0-4a1d-9928-fd3e960b3fbc}; !- Outlet Port
+  {33a38d02-2200-4d84-a2dd-c1ccd42f07c1}, !- Inlet Port
+  {640da610-5aaf-46a1-a674-65048a367861}; !- Outlet Port
 
 OS:Connection,
-  {ca6c49ed-57c9-45b8-a039-1808ed247715}, !- Handle
-  {24291022-3bdf-4138-b203-cedc1191110b}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {33a38d02-2200-4d84-a2dd-c1ccd42f07c1}, !- Handle
+  {f77853d6-cbb7-4366-8400-26e74c312dab}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   4,                                      !- Outlet Port
-  {41132dea-1ae3-4e3e-aab7-49771fe57d76}, !- Target Object
+  {e9dedde1-eead-4af7-add6-f6490a446a36}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {a31579ed-0ba0-4a1d-9928-fd3e960b3fbc}, !- Handle
-  {147513c7-3488-46e3-9121-86ac4350df5b}, !- Name
-  {41132dea-1ae3-4e3e-aab7-49771fe57d76}, !- Source Object
+  {640da610-5aaf-46a1-a674-65048a367861}, !- Handle
+  {f88a42e2-670a-4d37-af90-a550344cdae7}, !- Name
+  {e9dedde1-eead-4af7-add6-f6490a446a36}, !- Source Object
   3,                                      !- Outlet Port
-  {dcbb997a-8e9b-4fd1-923d-2af7228fc00c}, !- Target Object
+  {1a6c952c-ace3-44b9-83cb-baf543185497}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {bd55def4-adc3-49c8-95e5-69ffd978affe}, !- Handle
-  {523e6ef7-7acb-4e89-9a94-96787a8e47ad}, !- Name
-  {dcbb997a-8e9b-4fd1-923d-2af7228fc00c}, !- Source Object
+  {0af01b54-3106-46fa-8cb0-15decd6af85e}, !- Handle
+  {bd21ffa8-e627-4a50-9a24-d4b742fb6cfc}, !- Name
+  {1a6c952c-ace3-44b9-83cb-baf543185497}, !- Source Object
   12,                                     !- Outlet Port
-  {6bf17cb4-9591-43ce-88cd-cc2d6b796eb3}, !- Target Object
+  {e2b164f2-efe4-44ab-ae1c-5efaf4e012ee}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {f0fc1da6-2680-4a2d-ac0e-7778af7590a1}, !- Handle
+  {a489e831-427b-455d-b53f-a279b504c703}, !- Handle
   Air Terminal Single Duct VAV Reheat 11, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {2c73e0ba-4e23-42c6-b328-a4c63ae22559}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {71297788-3bc7-417f-90cf-56637f1506ff}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {fa6dfdcf-33e3-4c69-9aae-041301100e1b}, !- Reheat Coil Name
+  {02477f01-bbcc-4e26-aa2f-7ff914b9abb1}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {1bd68d44-c976-46f4-b2c3-520dee1694ef}, !- Air Outlet Node Name
+  {cb58207e-7068-49ab-b47e-de57972cb720}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8097,13 +8105,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {fa6dfdcf-33e3-4c69-9aae-041301100e1b}, !- Handle
+  {02477f01-bbcc-4e26-aa2f-7ff914b9abb1}, !- Handle
   Coil Heating Water 13,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {b86e8fab-ec4d-43c3-a5be-0d25b30b20d2}, !- Water Inlet Node Name
-  {9ae1f1b6-c37c-4ef2-a54a-0ac4a37d433f}, !- Water Outlet Node Name
+  {e690906f-bf2d-4052-8258-870a844c46d4}, !- Water Inlet Node Name
+  {f5c12b7c-6a66-4f93-a0db-84c0c5ef2099}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8115,129 +8123,129 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {c396eedd-d43c-450e-88f3-149ef60fe597}, !- Handle
+  {e1466123-7c66-4d56-a69d-42411bbc9b66}, !- Handle
   Node 175,                               !- Name
-  {ef97fedc-1df9-47a3-8dee-50e1347e01dd}, !- Inlet Port
-  {b86e8fab-ec4d-43c3-a5be-0d25b30b20d2}; !- Outlet Port
+  {51ae1093-0806-453c-8a82-7f35a81f5f2d}, !- Inlet Port
+  {e690906f-bf2d-4052-8258-870a844c46d4}; !- Outlet Port
 
 OS:Connection,
-  {ef97fedc-1df9-47a3-8dee-50e1347e01dd}, !- Handle
-  {590394c4-fec4-40cd-9c16-4025301cd2fb}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {51ae1093-0806-453c-8a82-7f35a81f5f2d}, !- Handle
+  {fc182e2f-2e69-4fa1-8792-8ca934a9c1c0}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   7,                                      !- Outlet Port
-  {c396eedd-d43c-450e-88f3-149ef60fe597}, !- Target Object
+  {e1466123-7c66-4d56-a69d-42411bbc9b66}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {cdb22d14-0d15-4610-a68a-f468b30db639}, !- Handle
+  {984c261a-6fd7-441a-b73e-65a72e54e155}, !- Handle
   Node 176,                               !- Name
-  {9ae1f1b6-c37c-4ef2-a54a-0ac4a37d433f}, !- Inlet Port
-  {41386c16-6d4d-4321-8594-156b58d7b75d}; !- Outlet Port
+  {f5c12b7c-6a66-4f93-a0db-84c0c5ef2099}, !- Inlet Port
+  {1b9b96cf-dd6d-46fe-96fa-d200085ffd90}; !- Outlet Port
 
 OS:Connection,
-  {b86e8fab-ec4d-43c3-a5be-0d25b30b20d2}, !- Handle
-  {66b824ce-8bd0-4ddc-8f47-ec3b097d7397}, !- Name
-  {c396eedd-d43c-450e-88f3-149ef60fe597}, !- Source Object
+  {e690906f-bf2d-4052-8258-870a844c46d4}, !- Handle
+  {4f65d898-f0d8-4f0f-b9f2-3fbe41fd879d}, !- Name
+  {e1466123-7c66-4d56-a69d-42411bbc9b66}, !- Source Object
   3,                                      !- Outlet Port
-  {fa6dfdcf-33e3-4c69-9aae-041301100e1b}, !- Target Object
+  {02477f01-bbcc-4e26-aa2f-7ff914b9abb1}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {9ae1f1b6-c37c-4ef2-a54a-0ac4a37d433f}, !- Handle
-  {40a80ff5-fe79-49bc-836c-3879bc1883ed}, !- Name
-  {fa6dfdcf-33e3-4c69-9aae-041301100e1b}, !- Source Object
+  {f5c12b7c-6a66-4f93-a0db-84c0c5ef2099}, !- Handle
+  {d60db7e3-2e24-49d6-b9e9-b2c0a85d7bb8}, !- Name
+  {02477f01-bbcc-4e26-aa2f-7ff914b9abb1}, !- Source Object
   6,                                      !- Outlet Port
-  {cdb22d14-0d15-4610-a68a-f468b30db639}, !- Target Object
+  {984c261a-6fd7-441a-b73e-65a72e54e155}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {41386c16-6d4d-4321-8594-156b58d7b75d}, !- Handle
-  {c930e656-238d-4595-8745-79a310d27d4b}, !- Name
-  {cdb22d14-0d15-4610-a68a-f468b30db639}, !- Source Object
+  {1b9b96cf-dd6d-46fe-96fa-d200085ffd90}, !- Handle
+  {f197ed30-0d30-466a-86b5-030a6776b6f8}, !- Name
+  {984c261a-6fd7-441a-b73e-65a72e54e155}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Node,
-  {ebbbaede-064a-4eb7-bfa0-682dbd47e56c}, !- Handle
+  {41943278-b556-48fd-8c45-96a7b4c92071}, !- Handle
   Node 177,                               !- Name
-  {1bd68d44-c976-46f4-b2c3-520dee1694ef}, !- Inlet Port
-  {b6b81218-3ac0-4b12-90e9-fc382c71827d}; !- Outlet Port
+  {cb58207e-7068-49ab-b47e-de57972cb720}, !- Inlet Port
+  {ec11edbf-e901-4b0e-b796-431ad7183b79}; !- Outlet Port
 
 OS:Node,
-  {7d1e966e-78b5-4779-9591-d6ab1fb47dfa}, !- Handle
+  {d40a7488-16e7-459b-81d1-79bf065a0596}, !- Handle
   Node 178,                               !- Name
-  {e5d4a0f2-13bc-4f04-9896-4b0932728b9e}, !- Inlet Port
-  {aa41c35f-549f-4718-8578-50a190020456}; !- Outlet Port
+  {bd097d78-bed2-461e-9ebe-5228921b459f}, !- Inlet Port
+  {071c698a-631d-4958-9559-387ae9c4126d}; !- Outlet Port
 
 OS:Connection,
-  {b6b81218-3ac0-4b12-90e9-fc382c71827d}, !- Handle
-  {158f3557-9c98-4d99-90c1-735ef4fde2b9}, !- Name
-  {ebbbaede-064a-4eb7-bfa0-682dbd47e56c}, !- Source Object
+  {ec11edbf-e901-4b0e-b796-431ad7183b79}, !- Handle
+  {30feaeb2-87a4-4cdf-85c7-81a4e9d63ca8}, !- Name
+  {41943278-b556-48fd-8c45-96a7b4c92071}, !- Source Object
   3,                                      !- Outlet Port
-  {a3ae2cfe-592b-4de8-a162-12d5d60726a6}, !- Target Object
+  {f9cf39c5-f2b9-433a-8441-a27787b1837a}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {e5d4a0f2-13bc-4f04-9896-4b0932728b9e}, !- Handle
-  {eeb17158-f920-4b2e-a072-2bbd1b4d0c7a}, !- Name
-  {6cde623f-f7ab-4c23-95d7-ec8881d9f865}, !- Source Object
+  {bd097d78-bed2-461e-9ebe-5228921b459f}, !- Handle
+  {2c0b577a-efb5-42ba-933d-aa040cdf5023}, !- Name
+  {34e1d912-530c-4fbf-af8d-90ce615cb03d}, !- Source Object
   4,                                      !- Outlet Port
-  {7d1e966e-78b5-4779-9591-d6ab1fb47dfa}, !- Target Object
+  {d40a7488-16e7-459b-81d1-79bf065a0596}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {aa41c35f-549f-4718-8578-50a190020456}, !- Handle
-  {5fa8ae05-836e-4f04-a98e-13abde9e4ac3}, !- Name
-  {7d1e966e-78b5-4779-9591-d6ab1fb47dfa}, !- Source Object
+  {071c698a-631d-4958-9559-387ae9c4126d}, !- Handle
+  {af042cd5-e49c-427e-ad7f-9722f3d3dd1b}, !- Name
+  {d40a7488-16e7-459b-81d1-79bf065a0596}, !- Source Object
   3,                                      !- Outlet Port
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Target Object
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Node,
-  {183256e5-d5bd-4fb6-9c3f-21945c05f43b}, !- Handle
+  {d2b0a6df-3c25-4ede-9693-e03220d63e7a}, !- Handle
   Node 179,                               !- Name
-  {1206cff6-3cae-4a80-8184-f077c5be8d8c}, !- Inlet Port
-  {2c73e0ba-4e23-42c6-b328-a4c63ae22559}; !- Outlet Port
+  {74ae7993-7c54-4ff0-b6af-ef2cbd159222}, !- Inlet Port
+  {71297788-3bc7-417f-90cf-56637f1506ff}; !- Outlet Port
 
 OS:Connection,
-  {1206cff6-3cae-4a80-8184-f077c5be8d8c}, !- Handle
-  {6ad4eeb2-c43e-46f5-b2df-9c00eb276b56}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {74ae7993-7c54-4ff0-b6af-ef2cbd159222}, !- Handle
+  {88d035a7-0044-44d9-94e0-8a3840fb2aec}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   5,                                      !- Outlet Port
-  {183256e5-d5bd-4fb6-9c3f-21945c05f43b}, !- Target Object
+  {d2b0a6df-3c25-4ede-9693-e03220d63e7a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {2c73e0ba-4e23-42c6-b328-a4c63ae22559}, !- Handle
-  {8825ef1b-d672-48cc-a79d-eaf7edaf4401}, !- Name
-  {183256e5-d5bd-4fb6-9c3f-21945c05f43b}, !- Source Object
+  {71297788-3bc7-417f-90cf-56637f1506ff}, !- Handle
+  {9384cf6c-63d2-42e5-8572-0f5ca3b7883a}, !- Name
+  {d2b0a6df-3c25-4ede-9693-e03220d63e7a}, !- Source Object
   3,                                      !- Outlet Port
-  {f0fc1da6-2680-4a2d-ac0e-7778af7590a1}, !- Target Object
+  {a489e831-427b-455d-b53f-a279b504c703}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {1bd68d44-c976-46f4-b2c3-520dee1694ef}, !- Handle
-  {ff07760d-3188-4bd1-bffe-35c079d73e8c}, !- Name
-  {f0fc1da6-2680-4a2d-ac0e-7778af7590a1}, !- Source Object
+  {cb58207e-7068-49ab-b47e-de57972cb720}, !- Handle
+  {9095f821-1b0e-4754-af75-e0266257aa17}, !- Name
+  {a489e831-427b-455d-b53f-a279b504c703}, !- Source Object
   12,                                     !- Outlet Port
-  {ebbbaede-064a-4eb7-bfa0-682dbd47e56c}, !- Target Object
+  {41943278-b556-48fd-8c45-96a7b4c92071}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {fc8b6947-d84e-4ab4-be7b-3a17ba881b42}, !- Handle
+  {bd463d8b-30b8-4705-9440-f8ac8c4ba19f}, !- Handle
   Air Terminal Single Duct VAV Reheat 12, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {b32897a5-88ed-4037-9c66-44e0db59df6d}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {ae7340f8-d801-4c79-97c5-b68a90ce6d14}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {5eea7315-47d3-4f73-b214-0c22e03d8d3f}, !- Reheat Coil Name
+  {e7978a43-c1e1-412c-8f25-8fd435c304b1}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {41a8b2c7-4365-4179-b8b6-455d45efc0e5}, !- Air Outlet Node Name
+  {a24f0fcc-9b52-425d-a253-1ca97094d099}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8246,13 +8254,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {5eea7315-47d3-4f73-b214-0c22e03d8d3f}, !- Handle
+  {e7978a43-c1e1-412c-8f25-8fd435c304b1}, !- Handle
   Coil Heating Water 14,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {bef736b7-ec6c-4053-b92d-62882bb6f6f0}, !- Water Inlet Node Name
-  {8c7e46f4-1a5d-4914-9f5b-b01872bfd538}, !- Water Outlet Node Name
+  {ea8936cf-0a9a-4f50-abd0-2f4056466c34}, !- Water Inlet Node Name
+  {55ac0bb1-85d1-4c8d-b824-defc62abd2c6}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8264,129 +8272,129 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {1f1edc1c-c6bc-4932-a459-51ba240e9303}, !- Handle
+  {f8227462-b065-4980-a190-da4231bcabc0}, !- Handle
   Node 180,                               !- Name
-  {03e640fa-6b04-487a-9203-af11f621534a}, !- Inlet Port
-  {bef736b7-ec6c-4053-b92d-62882bb6f6f0}; !- Outlet Port
+  {48c66872-d7b1-4662-bb82-4c74386f7e88}, !- Inlet Port
+  {ea8936cf-0a9a-4f50-abd0-2f4056466c34}; !- Outlet Port
 
 OS:Connection,
-  {03e640fa-6b04-487a-9203-af11f621534a}, !- Handle
-  {75d78b69-dbfe-4414-ba32-e05713de8334}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {48c66872-d7b1-4662-bb82-4c74386f7e88}, !- Handle
+  {51680f83-cc6d-4666-9312-a0ec195d6d64}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   8,                                      !- Outlet Port
-  {1f1edc1c-c6bc-4932-a459-51ba240e9303}, !- Target Object
+  {f8227462-b065-4980-a190-da4231bcabc0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {039e519b-1c75-4eaa-9682-cff8f0ed9c9a}, !- Handle
+  {d17a0529-76b8-423a-9a14-3ee00f03a2a3}, !- Handle
   Node 181,                               !- Name
-  {8c7e46f4-1a5d-4914-9f5b-b01872bfd538}, !- Inlet Port
-  {19c67d46-f739-422b-933e-fab090eb0b57}; !- Outlet Port
+  {55ac0bb1-85d1-4c8d-b824-defc62abd2c6}, !- Inlet Port
+  {5fe15c42-d441-4be3-9bac-c4c6212707e5}; !- Outlet Port
 
 OS:Connection,
-  {bef736b7-ec6c-4053-b92d-62882bb6f6f0}, !- Handle
-  {8e5f1dc5-14f9-457a-bf7a-01cefe104d7c}, !- Name
-  {1f1edc1c-c6bc-4932-a459-51ba240e9303}, !- Source Object
+  {ea8936cf-0a9a-4f50-abd0-2f4056466c34}, !- Handle
+  {93ee95a4-e29d-4cd2-9bfe-e1d97b018a14}, !- Name
+  {f8227462-b065-4980-a190-da4231bcabc0}, !- Source Object
   3,                                      !- Outlet Port
-  {5eea7315-47d3-4f73-b214-0c22e03d8d3f}, !- Target Object
+  {e7978a43-c1e1-412c-8f25-8fd435c304b1}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {8c7e46f4-1a5d-4914-9f5b-b01872bfd538}, !- Handle
-  {60f0fada-1bd4-4397-8cac-ccacd329fbff}, !- Name
-  {5eea7315-47d3-4f73-b214-0c22e03d8d3f}, !- Source Object
+  {55ac0bb1-85d1-4c8d-b824-defc62abd2c6}, !- Handle
+  {401c4616-5f92-4137-bcb7-dbe815723025}, !- Name
+  {e7978a43-c1e1-412c-8f25-8fd435c304b1}, !- Source Object
   6,                                      !- Outlet Port
-  {039e519b-1c75-4eaa-9682-cff8f0ed9c9a}, !- Target Object
+  {d17a0529-76b8-423a-9a14-3ee00f03a2a3}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {19c67d46-f739-422b-933e-fab090eb0b57}, !- Handle
-  {6e52eaa6-30bf-4442-9bb7-e432e3c7a5fd}, !- Name
-  {039e519b-1c75-4eaa-9682-cff8f0ed9c9a}, !- Source Object
+  {5fe15c42-d441-4be3-9bac-c4c6212707e5}, !- Handle
+  {01c8f1bb-4407-4328-b010-df0585e4fd99}, !- Name
+  {d17a0529-76b8-423a-9a14-3ee00f03a2a3}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Node,
-  {1ca7f6aa-7660-4cd0-b10c-75407b60eb29}, !- Handle
+  {cecb8a24-fd34-4ec8-87d7-85a44ad2ad63}, !- Handle
   Node 182,                               !- Name
-  {41a8b2c7-4365-4179-b8b6-455d45efc0e5}, !- Inlet Port
-  {e375068c-c518-4085-89f5-602a0d5b44b0}; !- Outlet Port
+  {a24f0fcc-9b52-425d-a253-1ca97094d099}, !- Inlet Port
+  {4fa7d102-f1d8-426b-be27-8794a810685f}; !- Outlet Port
 
 OS:Node,
-  {3a59733b-6968-4332-a5c4-20bcdcf53cb8}, !- Handle
+  {3639f211-f48f-4fb3-9203-8435cf6752fb}, !- Handle
   Node 183,                               !- Name
-  {29566d72-e7b7-4815-862c-a5c5b5867846}, !- Inlet Port
-  {9df485fc-6d70-41d3-9a74-0a875583aa1b}; !- Outlet Port
+  {8d000667-2431-4993-b258-3b2d4b7eb697}, !- Inlet Port
+  {30379c3f-32d8-4b61-bb6d-507010487fb3}; !- Outlet Port
 
 OS:Connection,
-  {e375068c-c518-4085-89f5-602a0d5b44b0}, !- Handle
-  {9eb24f94-6948-4ca0-be80-5d90758bee73}, !- Name
-  {1ca7f6aa-7660-4cd0-b10c-75407b60eb29}, !- Source Object
+  {4fa7d102-f1d8-426b-be27-8794a810685f}, !- Handle
+  {6ae25bd2-d3d9-419f-9f9e-2e90e1d9c302}, !- Name
+  {cecb8a24-fd34-4ec8-87d7-85a44ad2ad63}, !- Source Object
   3,                                      !- Outlet Port
-  {ed966860-1232-4cea-a353-bc9278caa407}, !- Target Object
+  {3f08aa56-9494-4c79-b410-53887ea5b9e6}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {29566d72-e7b7-4815-862c-a5c5b5867846}, !- Handle
-  {87adafaa-698b-4481-bc4c-191a996da2ec}, !- Name
-  {2dc6338d-d0c4-4b49-a80f-60ac3fa78931}, !- Source Object
+  {8d000667-2431-4993-b258-3b2d4b7eb697}, !- Handle
+  {cdec7094-534d-4c9e-aeb3-07a3b235653d}, !- Name
+  {ba7d211e-dc53-45ab-b570-f7e48508ea4f}, !- Source Object
   4,                                      !- Outlet Port
-  {3a59733b-6968-4332-a5c4-20bcdcf53cb8}, !- Target Object
+  {3639f211-f48f-4fb3-9203-8435cf6752fb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {9df485fc-6d70-41d3-9a74-0a875583aa1b}, !- Handle
-  {f124579d-1fd3-4da4-8710-88951fc9e345}, !- Name
-  {3a59733b-6968-4332-a5c4-20bcdcf53cb8}, !- Source Object
+  {30379c3f-32d8-4b61-bb6d-507010487fb3}, !- Handle
+  {de77b963-380d-4bda-8214-a1643522f95e}, !- Name
+  {3639f211-f48f-4fb3-9203-8435cf6752fb}, !- Source Object
   3,                                      !- Outlet Port
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Target Object
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Node,
-  {e58ee855-0c7d-46bf-9ffd-a587b8d8c135}, !- Handle
+  {7c064bc1-bf47-4f19-8157-1070d7817f4e}, !- Handle
   Node 184,                               !- Name
-  {edf49465-954d-4eae-abd1-b3001bcf82fa}, !- Inlet Port
-  {b32897a5-88ed-4037-9c66-44e0db59df6d}; !- Outlet Port
+  {f22400f7-5bfc-48f8-b9b2-5cb2ab706456}, !- Inlet Port
+  {ae7340f8-d801-4c79-97c5-b68a90ce6d14}; !- Outlet Port
 
 OS:Connection,
-  {edf49465-954d-4eae-abd1-b3001bcf82fa}, !- Handle
-  {e71910a9-1c8f-41dd-8dcc-0d003d84b6f3}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {f22400f7-5bfc-48f8-b9b2-5cb2ab706456}, !- Handle
+  {4d5576bc-8774-47c6-826f-3d726ee3cf7f}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   6,                                      !- Outlet Port
-  {e58ee855-0c7d-46bf-9ffd-a587b8d8c135}, !- Target Object
+  {7c064bc1-bf47-4f19-8157-1070d7817f4e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b32897a5-88ed-4037-9c66-44e0db59df6d}, !- Handle
-  {a898efad-43e8-423d-9e91-a331f28fc66e}, !- Name
-  {e58ee855-0c7d-46bf-9ffd-a587b8d8c135}, !- Source Object
+  {ae7340f8-d801-4c79-97c5-b68a90ce6d14}, !- Handle
+  {0609c557-55ba-4762-aced-74bf802233c3}, !- Name
+  {7c064bc1-bf47-4f19-8157-1070d7817f4e}, !- Source Object
   3,                                      !- Outlet Port
-  {fc8b6947-d84e-4ab4-be7b-3a17ba881b42}, !- Target Object
+  {bd463d8b-30b8-4705-9440-f8ac8c4ba19f}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {41a8b2c7-4365-4179-b8b6-455d45efc0e5}, !- Handle
-  {f7b68bd2-c6f1-4b00-9788-89e343ffcd0e}, !- Name
-  {fc8b6947-d84e-4ab4-be7b-3a17ba881b42}, !- Source Object
+  {a24f0fcc-9b52-425d-a253-1ca97094d099}, !- Handle
+  {751a628b-dc71-47ca-92d8-796549c5a9bd}, !- Name
+  {bd463d8b-30b8-4705-9440-f8ac8c4ba19f}, !- Source Object
   12,                                     !- Outlet Port
-  {1ca7f6aa-7660-4cd0-b10c-75407b60eb29}, !- Target Object
+  {cecb8a24-fd34-4ec8-87d7-85a44ad2ad63}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {5fe3590f-5597-4755-99ef-c16a20497832}, !- Handle
+  {3d9fe5d9-ef4b-43f0-ba88-e0428002fe46}, !- Handle
   Air Terminal Single Duct VAV Reheat 13, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {67e86169-b021-4fc4-ad46-8f90a9c09d66}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {c12815ef-9290-4b48-8267-2e8794c23329}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {d9a0ab6f-78d5-4429-9d31-aa59a40ae98a}, !- Reheat Coil Name
+  {4cfcdd25-2742-4d47-bfc6-6193926b4d5a}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {cccae0de-22ac-43a3-839b-48274165930d}, !- Air Outlet Node Name
+  {b3db1ebc-6ff9-4f69-ac71-6de6bf5eeec8}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8395,13 +8403,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {d9a0ab6f-78d5-4429-9d31-aa59a40ae98a}, !- Handle
+  {4cfcdd25-2742-4d47-bfc6-6193926b4d5a}, !- Handle
   Coil Heating Water 15,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {f758a630-7972-406e-b1d1-a4a3fbc4b33b}, !- Water Inlet Node Name
-  {b0b724d3-b2c2-45a7-b82e-22b36692aaac}, !- Water Outlet Node Name
+  {3d57e01e-f0ad-437d-ba0c-42033f5cceaa}, !- Water Inlet Node Name
+  {fb1429ef-9bca-4fb6-ad8a-002367df3e6f}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8413,121 +8421,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {aa8eb2e6-e57d-467e-b146-eced790bea44}, !- Handle
+  {4c47c160-e3f3-4f3d-860e-343f5f7c9aa0}, !- Handle
   Node 185,                               !- Name
-  {87e898cb-2722-4c18-a167-5f32fd837b9d}, !- Inlet Port
-  {f758a630-7972-406e-b1d1-a4a3fbc4b33b}; !- Outlet Port
+  {2aa13d57-c038-4a54-b5be-e4266cee36ed}, !- Inlet Port
+  {3d57e01e-f0ad-437d-ba0c-42033f5cceaa}; !- Outlet Port
 
 OS:Connection,
-  {87e898cb-2722-4c18-a167-5f32fd837b9d}, !- Handle
-  {f9080270-c203-411e-bdea-a505139c2226}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {2aa13d57-c038-4a54-b5be-e4266cee36ed}, !- Handle
+  {9a96fc7b-825d-41fc-b67d-9cb968694639}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   9,                                      !- Outlet Port
-  {aa8eb2e6-e57d-467e-b146-eced790bea44}, !- Target Object
+  {4c47c160-e3f3-4f3d-860e-343f5f7c9aa0}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {4605e762-dea0-487b-aac8-cbbe25d6a9f9}, !- Handle
+  {13ccab8a-1524-4941-9216-40ecf37ced3f}, !- Handle
   Node 186,                               !- Name
-  {b0b724d3-b2c2-45a7-b82e-22b36692aaac}, !- Inlet Port
-  {b6207458-cd8c-4ccc-af5e-7d7a3ace66ac}; !- Outlet Port
+  {fb1429ef-9bca-4fb6-ad8a-002367df3e6f}, !- Inlet Port
+  {bb11889f-1edb-4d65-b774-75ae18cb8c59}; !- Outlet Port
 
 OS:Connection,
-  {f758a630-7972-406e-b1d1-a4a3fbc4b33b}, !- Handle
-  {1ca421b9-5040-4f17-879f-7b7aca9154c1}, !- Name
-  {aa8eb2e6-e57d-467e-b146-eced790bea44}, !- Source Object
+  {3d57e01e-f0ad-437d-ba0c-42033f5cceaa}, !- Handle
+  {98c31f7d-597c-4e6d-9dad-d4af23628ed5}, !- Name
+  {4c47c160-e3f3-4f3d-860e-343f5f7c9aa0}, !- Source Object
   3,                                      !- Outlet Port
-  {d9a0ab6f-78d5-4429-9d31-aa59a40ae98a}, !- Target Object
+  {4cfcdd25-2742-4d47-bfc6-6193926b4d5a}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {b0b724d3-b2c2-45a7-b82e-22b36692aaac}, !- Handle
-  {a910f5f6-373b-4a9f-844d-d6606c0d93cc}, !- Name
-  {d9a0ab6f-78d5-4429-9d31-aa59a40ae98a}, !- Source Object
+  {fb1429ef-9bca-4fb6-ad8a-002367df3e6f}, !- Handle
+  {5157d11c-56fd-4ddc-b5e4-8bf34e908b66}, !- Name
+  {4cfcdd25-2742-4d47-bfc6-6193926b4d5a}, !- Source Object
   6,                                      !- Outlet Port
-  {4605e762-dea0-487b-aac8-cbbe25d6a9f9}, !- Target Object
+  {13ccab8a-1524-4941-9216-40ecf37ced3f}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b6207458-cd8c-4ccc-af5e-7d7a3ace66ac}, !- Handle
-  {05d53df4-7beb-4532-8aec-56339d37edb2}, !- Name
-  {4605e762-dea0-487b-aac8-cbbe25d6a9f9}, !- Source Object
+  {bb11889f-1edb-4d65-b774-75ae18cb8c59}, !- Handle
+  {2a40067c-e5ed-4a73-8266-ec118bccc310}, !- Name
+  {13ccab8a-1524-4941-9216-40ecf37ced3f}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   9;                                      !- Inlet Port
 
 OS:Node,
-  {4868f7c4-aec6-491e-8b2a-43182232e11d}, !- Handle
+  {ce27e2bc-6a18-42ee-901d-c711364b72ea}, !- Handle
   Node 187,                               !- Name
-  {cccae0de-22ac-43a3-839b-48274165930d}, !- Inlet Port
-  {31a5a8d0-ab3b-4a0a-a8b6-e704b962b516}; !- Outlet Port
+  {b3db1ebc-6ff9-4f69-ac71-6de6bf5eeec8}, !- Inlet Port
+  {32e7c499-12ed-4140-a23d-6fc88fbb8cee}; !- Outlet Port
 
 OS:Node,
-  {63c513f9-fb8e-43a9-a515-ee1e4228e2d7}, !- Handle
+  {8d5219e9-e81a-46a1-8008-bc568d00785d}, !- Handle
   Node 188,                               !- Name
-  {bdc4ff6e-5b5b-4f4d-afef-d7f9805ef5fa}, !- Inlet Port
-  {a002338c-9340-4212-90bb-80f412217d51}; !- Outlet Port
+  {6613156e-369c-4080-a3ef-8e1f57f6356e}, !- Inlet Port
+  {6365c974-5c69-42bf-8da4-489b401e039b}; !- Outlet Port
 
 OS:Connection,
-  {31a5a8d0-ab3b-4a0a-a8b6-e704b962b516}, !- Handle
-  {2cba17b7-ae9b-4580-951c-5d75f1ee7e00}, !- Name
-  {4868f7c4-aec6-491e-8b2a-43182232e11d}, !- Source Object
+  {32e7c499-12ed-4140-a23d-6fc88fbb8cee}, !- Handle
+  {ef184153-3f9c-4612-851c-dfc9b771b4b3}, !- Name
+  {ce27e2bc-6a18-42ee-901d-c711364b72ea}, !- Source Object
   3,                                      !- Outlet Port
-  {b170267c-aa2a-4cab-b508-4f08913dcb06}, !- Target Object
+  {e6c35a45-e312-4899-b164-f90bc07b1f8c}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {bdc4ff6e-5b5b-4f4d-afef-d7f9805ef5fa}, !- Handle
-  {46ea32a4-62b9-4e3d-82b3-29685bd05702}, !- Name
-  {b4efd025-13e6-447a-b284-f912d5c35ae8}, !- Source Object
+  {6613156e-369c-4080-a3ef-8e1f57f6356e}, !- Handle
+  {e664a9f9-ca34-45f0-a98e-c88d63e9ef17}, !- Name
+  {211feab5-a8be-4eae-9a23-92893c02fd56}, !- Source Object
   4,                                      !- Outlet Port
-  {63c513f9-fb8e-43a9-a515-ee1e4228e2d7}, !- Target Object
+  {8d5219e9-e81a-46a1-8008-bc568d00785d}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {2d476c2c-55f0-465c-81bb-7cbb7b246c95}, !- Handle
+  {de09b297-8550-4d2a-942d-a8a1366a5b30}, !- Handle
   Node 189,                               !- Name
-  {62d56964-2496-4825-b9ae-b26ae1b0398d}, !- Inlet Port
-  {67e86169-b021-4fc4-ad46-8f90a9c09d66}; !- Outlet Port
+  {219465cc-5c09-40ec-9f2d-b581f387cac0}, !- Inlet Port
+  {c12815ef-9290-4b48-8267-2e8794c23329}; !- Outlet Port
 
 OS:Connection,
-  {62d56964-2496-4825-b9ae-b26ae1b0398d}, !- Handle
-  {64758fe7-3f9d-4182-af71-5e9dd6224677}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {219465cc-5c09-40ec-9f2d-b581f387cac0}, !- Handle
+  {da80a7c8-b29a-4773-9d59-ffcac9d9b1e9}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   7,                                      !- Outlet Port
-  {2d476c2c-55f0-465c-81bb-7cbb7b246c95}, !- Target Object
+  {de09b297-8550-4d2a-942d-a8a1366a5b30}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {67e86169-b021-4fc4-ad46-8f90a9c09d66}, !- Handle
-  {1790802c-0040-4f99-b235-18129e04d805}, !- Name
-  {2d476c2c-55f0-465c-81bb-7cbb7b246c95}, !- Source Object
+  {c12815ef-9290-4b48-8267-2e8794c23329}, !- Handle
+  {23ea5749-d509-4c61-85c0-b7918bc09df0}, !- Name
+  {de09b297-8550-4d2a-942d-a8a1366a5b30}, !- Source Object
   3,                                      !- Outlet Port
-  {5fe3590f-5597-4755-99ef-c16a20497832}, !- Target Object
+  {3d9fe5d9-ef4b-43f0-ba88-e0428002fe46}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {cccae0de-22ac-43a3-839b-48274165930d}, !- Handle
-  {78df1042-af93-4b00-ad87-8b9dd2086c56}, !- Name
-  {5fe3590f-5597-4755-99ef-c16a20497832}, !- Source Object
+  {b3db1ebc-6ff9-4f69-ac71-6de6bf5eeec8}, !- Handle
+  {8f1e6e58-2f4f-4c4d-a90e-292880038655}, !- Name
+  {3d9fe5d9-ef4b-43f0-ba88-e0428002fe46}, !- Source Object
   12,                                     !- Outlet Port
-  {4868f7c4-aec6-491e-8b2a-43182232e11d}, !- Target Object
+  {ce27e2bc-6a18-42ee-901d-c711364b72ea}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {2dce302f-47fa-41d9-886b-3bea9d341580}, !- Handle
+  {86e8b49e-ba9c-4d1c-a155-e8d2e2701476}, !- Handle
   Air Terminal Single Duct VAV Reheat 14, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {ce0afa68-cee9-4075-b795-a77025fd36ef}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {78597713-3c1b-40d5-a0a6-c2660c4715e7}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {a0943306-72e8-484a-bb04-0a752aa957e4}, !- Reheat Coil Name
+  {d076d662-6804-4068-bdb7-9d7a2ea6d7ab}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {fe78cb4c-7354-4253-96ea-2f299ff8ffdc}, !- Air Outlet Node Name
+  {51c23164-40d4-4916-a8b0-3e853d3ff234}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8536,13 +8544,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {a0943306-72e8-484a-bb04-0a752aa957e4}, !- Handle
+  {d076d662-6804-4068-bdb7-9d7a2ea6d7ab}, !- Handle
   Coil Heating Water 16,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {e302501e-b48b-4737-9f32-6c54d86aac35}, !- Water Inlet Node Name
-  {6c2f092e-50fb-4acf-be90-d28796819880}, !- Water Outlet Node Name
+  {a91160b8-6163-4c4b-b492-b86a14e793d5}, !- Water Inlet Node Name
+  {bd08029d-0798-44c4-819c-6b7d54e1c4cc}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8554,121 +8562,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {6a658564-59a4-41a2-90d4-7f93add20985}, !- Handle
+  {7cfe7351-9eca-49ee-954c-85260e1099ad}, !- Handle
   Node 190,                               !- Name
-  {e663dc16-03f3-4577-bb31-9fd53061b3cf}, !- Inlet Port
-  {e302501e-b48b-4737-9f32-6c54d86aac35}; !- Outlet Port
+  {75ff64a1-0646-41fc-8eca-7a372c33432c}, !- Inlet Port
+  {a91160b8-6163-4c4b-b492-b86a14e793d5}; !- Outlet Port
 
 OS:Connection,
-  {e663dc16-03f3-4577-bb31-9fd53061b3cf}, !- Handle
-  {ba32c785-3b16-4d28-b8b4-c3e776aab3c9}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {75ff64a1-0646-41fc-8eca-7a372c33432c}, !- Handle
+  {8b61a6d8-c1e6-4096-936a-e0234cd51d4b}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   10,                                     !- Outlet Port
-  {6a658564-59a4-41a2-90d4-7f93add20985}, !- Target Object
+  {7cfe7351-9eca-49ee-954c-85260e1099ad}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {c6eca3f9-4503-45f9-abac-cc781961054d}, !- Handle
+  {beb62656-43da-4ca8-8a50-9369ed5b0f1a}, !- Handle
   Node 191,                               !- Name
-  {6c2f092e-50fb-4acf-be90-d28796819880}, !- Inlet Port
-  {46511e3b-8748-4dec-904f-dbc9084d16d6}; !- Outlet Port
+  {bd08029d-0798-44c4-819c-6b7d54e1c4cc}, !- Inlet Port
+  {15c34fd4-fb56-46ac-9dcf-2835806f715e}; !- Outlet Port
 
 OS:Connection,
-  {e302501e-b48b-4737-9f32-6c54d86aac35}, !- Handle
-  {ffe39138-0da0-4ffc-96e6-654b032b43fb}, !- Name
-  {6a658564-59a4-41a2-90d4-7f93add20985}, !- Source Object
+  {a91160b8-6163-4c4b-b492-b86a14e793d5}, !- Handle
+  {bf14bdad-7cb1-458d-a028-aca75c8afc75}, !- Name
+  {7cfe7351-9eca-49ee-954c-85260e1099ad}, !- Source Object
   3,                                      !- Outlet Port
-  {a0943306-72e8-484a-bb04-0a752aa957e4}, !- Target Object
+  {d076d662-6804-4068-bdb7-9d7a2ea6d7ab}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {6c2f092e-50fb-4acf-be90-d28796819880}, !- Handle
-  {c9e0e617-b2a9-4e31-91fb-dea67d73a025}, !- Name
-  {a0943306-72e8-484a-bb04-0a752aa957e4}, !- Source Object
+  {bd08029d-0798-44c4-819c-6b7d54e1c4cc}, !- Handle
+  {0be0c6fe-fda1-4e58-bd69-95fd966faab4}, !- Name
+  {d076d662-6804-4068-bdb7-9d7a2ea6d7ab}, !- Source Object
   6,                                      !- Outlet Port
-  {c6eca3f9-4503-45f9-abac-cc781961054d}, !- Target Object
+  {beb62656-43da-4ca8-8a50-9369ed5b0f1a}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {46511e3b-8748-4dec-904f-dbc9084d16d6}, !- Handle
-  {3da477e0-f49e-4d06-a492-1dc4d6bd1090}, !- Name
-  {c6eca3f9-4503-45f9-abac-cc781961054d}, !- Source Object
+  {15c34fd4-fb56-46ac-9dcf-2835806f715e}, !- Handle
+  {9ef2ff82-c02b-4311-9216-3341280b90ba}, !- Name
+  {beb62656-43da-4ca8-8a50-9369ed5b0f1a}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   10;                                     !- Inlet Port
 
 OS:Node,
-  {f44ea3da-39ad-4233-b3b0-290eccc52aeb}, !- Handle
+  {7e9168a6-6613-4d11-b5b2-60f554302d41}, !- Handle
   Node 192,                               !- Name
-  {fe78cb4c-7354-4253-96ea-2f299ff8ffdc}, !- Inlet Port
-  {bcb65551-0237-44ac-a1e8-d02e9b06367e}; !- Outlet Port
+  {51c23164-40d4-4916-a8b0-3e853d3ff234}, !- Inlet Port
+  {575bf6f9-b28e-492e-b925-508e04a57710}; !- Outlet Port
 
 OS:Node,
-  {49afa578-3a21-4558-b3f4-ef13ac1f0854}, !- Handle
+  {d72a342c-5aad-4702-b7da-d49d822bb679}, !- Handle
   Node 193,                               !- Name
-  {2c67799d-9119-44c8-a599-ec35f558a519}, !- Inlet Port
-  {cebcb196-cdf0-4620-8856-a96e94f3e188}; !- Outlet Port
+  {d723631a-dee2-437f-9892-658aae6973d5}, !- Inlet Port
+  {9c1332cd-2834-494b-bcc9-506beb91c450}; !- Outlet Port
 
 OS:Connection,
-  {bcb65551-0237-44ac-a1e8-d02e9b06367e}, !- Handle
-  {db478343-919c-4e41-99ed-1f412759970e}, !- Name
-  {f44ea3da-39ad-4233-b3b0-290eccc52aeb}, !- Source Object
+  {575bf6f9-b28e-492e-b925-508e04a57710}, !- Handle
+  {d9a2ef5e-c5ce-423d-b560-c01597300416}, !- Name
+  {7e9168a6-6613-4d11-b5b2-60f554302d41}, !- Source Object
   3,                                      !- Outlet Port
-  {1d75dadb-55ec-4edd-b070-8265f6db36f0}, !- Target Object
+  {cf354f66-ffe3-484b-a97f-674aa2d1a9ca}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {2c67799d-9119-44c8-a599-ec35f558a519}, !- Handle
-  {0123e446-4bee-4138-b8b0-cf58b206ef07}, !- Name
-  {0d0c9790-59a6-4355-96d6-bc692c51f054}, !- Source Object
+  {d723631a-dee2-437f-9892-658aae6973d5}, !- Handle
+  {c75f2b1a-cdfd-4dd4-b9bf-d7e141b73c29}, !- Name
+  {ae8f18cb-499a-47ef-8c94-1e994eac29f1}, !- Source Object
   4,                                      !- Outlet Port
-  {49afa578-3a21-4558-b3f4-ef13ac1f0854}, !- Target Object
+  {d72a342c-5aad-4702-b7da-d49d822bb679}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {bef0edd4-bb23-4129-9ead-d029064df4bb}, !- Handle
+  {f9afed02-3797-4f75-9e87-1621de1cc256}, !- Handle
   Node 194,                               !- Name
-  {9be4cd62-c3d8-4259-a94c-efd53ce23877}, !- Inlet Port
-  {ce0afa68-cee9-4075-b795-a77025fd36ef}; !- Outlet Port
+  {2ca091e6-baad-453e-bac5-a7d9fe0ac5e9}, !- Inlet Port
+  {78597713-3c1b-40d5-a0a6-c2660c4715e7}; !- Outlet Port
 
 OS:Connection,
-  {9be4cd62-c3d8-4259-a94c-efd53ce23877}, !- Handle
-  {91cf1fb2-3356-4e88-9e45-475b3075467b}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {2ca091e6-baad-453e-bac5-a7d9fe0ac5e9}, !- Handle
+  {174378b5-18c0-41ea-b012-9b3b8c184735}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   8,                                      !- Outlet Port
-  {bef0edd4-bb23-4129-9ead-d029064df4bb}, !- Target Object
+  {f9afed02-3797-4f75-9e87-1621de1cc256}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {ce0afa68-cee9-4075-b795-a77025fd36ef}, !- Handle
-  {b26d9ea9-68e0-4d37-b2ed-d6d7664b4be8}, !- Name
-  {bef0edd4-bb23-4129-9ead-d029064df4bb}, !- Source Object
+  {78597713-3c1b-40d5-a0a6-c2660c4715e7}, !- Handle
+  {158d9a7c-09d9-430e-8e6f-e91c52a97cea}, !- Name
+  {f9afed02-3797-4f75-9e87-1621de1cc256}, !- Source Object
   3,                                      !- Outlet Port
-  {2dce302f-47fa-41d9-886b-3bea9d341580}, !- Target Object
+  {86e8b49e-ba9c-4d1c-a155-e8d2e2701476}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {fe78cb4c-7354-4253-96ea-2f299ff8ffdc}, !- Handle
-  {1971fdeb-bc60-48ab-932c-3b9259c6c741}, !- Name
-  {2dce302f-47fa-41d9-886b-3bea9d341580}, !- Source Object
+  {51c23164-40d4-4916-a8b0-3e853d3ff234}, !- Handle
+  {e24cd84e-a7a4-4e92-b57e-c2489c5783c6}, !- Name
+  {86e8b49e-ba9c-4d1c-a155-e8d2e2701476}, !- Source Object
   12,                                     !- Outlet Port
-  {f44ea3da-39ad-4233-b3b0-290eccc52aeb}, !- Target Object
+  {7e9168a6-6613-4d11-b5b2-60f554302d41}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {c726d2ef-209e-41b1-b97b-eb49e2c5877f}, !- Handle
+  {d30a8304-23e2-49e4-89a3-71e151d7d0a0}, !- Handle
   Air Terminal Single Duct VAV Reheat 15, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {bd5ae1f6-4ae3-4d7e-9fda-eb4934afba16}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {a49674b4-f6c6-4811-9b04-3a9799dcf48a}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {e7945749-a032-4915-a500-33c844ae1745}, !- Reheat Coil Name
+  {d5ac8bd2-d9fd-4dde-a5f6-49cdee42b7e6}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {b9457cfb-8520-40ad-b7fd-56b6bb3b347e}, !- Air Outlet Node Name
+  {f066760f-243c-44e2-8d90-c84782908f58}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8677,13 +8685,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {e7945749-a032-4915-a500-33c844ae1745}, !- Handle
+  {d5ac8bd2-d9fd-4dde-a5f6-49cdee42b7e6}, !- Handle
   Coil Heating Water 17,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {e40a73a1-97e0-4b01-b497-d25d80a814b9}, !- Water Inlet Node Name
-  {30eb9508-af83-43b5-98ad-be9969cecd73}, !- Water Outlet Node Name
+  {1c744c3d-5a95-425e-b1d4-9879275a0b7e}, !- Water Inlet Node Name
+  {b74e72d1-c9f2-4367-a189-945a60d6562d}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8695,121 +8703,121 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {234c28c3-0ba0-4196-845b-f4bd6b420c21}, !- Handle
+  {837b8d6e-895d-4a4a-9f07-679c11ade158}, !- Handle
   Node 195,                               !- Name
-  {45b5b821-1f5f-49b8-94e4-b4bec62ace52}, !- Inlet Port
-  {e40a73a1-97e0-4b01-b497-d25d80a814b9}; !- Outlet Port
+  {ae7e397d-199a-42bd-bea0-283cf5a6a8ff}, !- Inlet Port
+  {1c744c3d-5a95-425e-b1d4-9879275a0b7e}; !- Outlet Port
 
 OS:Connection,
-  {45b5b821-1f5f-49b8-94e4-b4bec62ace52}, !- Handle
-  {367d4c41-f794-47a4-ad95-5fcf8aee0bf7}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {ae7e397d-199a-42bd-bea0-283cf5a6a8ff}, !- Handle
+  {1f25864d-e6b7-479b-90a7-8b8bf36bb4bc}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   11,                                     !- Outlet Port
-  {234c28c3-0ba0-4196-845b-f4bd6b420c21}, !- Target Object
+  {837b8d6e-895d-4a4a-9f07-679c11ade158}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {5e8ebe09-46bd-4448-b22f-18b607c3ca31}, !- Handle
+  {93c7ef1f-81e5-473c-bbad-d7f07f874e50}, !- Handle
   Node 196,                               !- Name
-  {30eb9508-af83-43b5-98ad-be9969cecd73}, !- Inlet Port
-  {978dd3ff-d7f4-4102-ab67-fbe26637e62f}; !- Outlet Port
+  {b74e72d1-c9f2-4367-a189-945a60d6562d}, !- Inlet Port
+  {594597e3-b455-408d-81fd-a1013d6c3988}; !- Outlet Port
 
 OS:Connection,
-  {e40a73a1-97e0-4b01-b497-d25d80a814b9}, !- Handle
-  {e1434980-2663-4c19-8eae-af7ae2374f17}, !- Name
-  {234c28c3-0ba0-4196-845b-f4bd6b420c21}, !- Source Object
+  {1c744c3d-5a95-425e-b1d4-9879275a0b7e}, !- Handle
+  {6c50616d-e634-4551-9d97-bb841435b4e8}, !- Name
+  {837b8d6e-895d-4a4a-9f07-679c11ade158}, !- Source Object
   3,                                      !- Outlet Port
-  {e7945749-a032-4915-a500-33c844ae1745}, !- Target Object
+  {d5ac8bd2-d9fd-4dde-a5f6-49cdee42b7e6}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {30eb9508-af83-43b5-98ad-be9969cecd73}, !- Handle
-  {b31567d7-682f-45aa-89e1-dc66ad74303e}, !- Name
-  {e7945749-a032-4915-a500-33c844ae1745}, !- Source Object
+  {b74e72d1-c9f2-4367-a189-945a60d6562d}, !- Handle
+  {ca6896ec-6aaa-41fc-9572-c1c6e9d3aaa9}, !- Name
+  {d5ac8bd2-d9fd-4dde-a5f6-49cdee42b7e6}, !- Source Object
   6,                                      !- Outlet Port
-  {5e8ebe09-46bd-4448-b22f-18b607c3ca31}, !- Target Object
+  {93c7ef1f-81e5-473c-bbad-d7f07f874e50}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {978dd3ff-d7f4-4102-ab67-fbe26637e62f}, !- Handle
-  {19626557-c195-4630-a42b-4bbaafc6e04e}, !- Name
-  {5e8ebe09-46bd-4448-b22f-18b607c3ca31}, !- Source Object
+  {594597e3-b455-408d-81fd-a1013d6c3988}, !- Handle
+  {23d044b1-e081-4fdd-a6f9-d7a3f4fe69e1}, !- Name
+  {93c7ef1f-81e5-473c-bbad-d7f07f874e50}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   11;                                     !- Inlet Port
 
 OS:Node,
-  {28669767-a293-4c3c-b034-1d1a8be0dbc8}, !- Handle
+  {32c77057-5e7b-4fed-8125-e4de31adba14}, !- Handle
   Node 197,                               !- Name
-  {b9457cfb-8520-40ad-b7fd-56b6bb3b347e}, !- Inlet Port
-  {4be526ea-b730-4b96-875d-eec3194c8ff2}; !- Outlet Port
+  {f066760f-243c-44e2-8d90-c84782908f58}, !- Inlet Port
+  {1edf3c07-f9d5-465e-8b32-cd0f18c932c4}; !- Outlet Port
 
 OS:Node,
-  {3f589aad-5ea1-44ec-bda5-d18e2149e3bb}, !- Handle
+  {96269e61-dae4-446c-891a-40c9c372cf21}, !- Handle
   Node 198,                               !- Name
-  {bece3946-8c39-4875-bbbf-0ab8f163b41b}, !- Inlet Port
-  {f09c8ff9-ea4c-4dce-9ec6-44204be7bf0b}; !- Outlet Port
+  {f56c75db-0fee-4519-b369-4550f6c6a460}, !- Inlet Port
+  {1ba76c1a-b3a3-484c-be03-60237ef38362}; !- Outlet Port
 
 OS:Connection,
-  {4be526ea-b730-4b96-875d-eec3194c8ff2}, !- Handle
-  {99e72709-7904-4188-a2d9-d92c198c0da7}, !- Name
-  {28669767-a293-4c3c-b034-1d1a8be0dbc8}, !- Source Object
+  {1edf3c07-f9d5-465e-8b32-cd0f18c932c4}, !- Handle
+  {5c45454a-03ac-484e-899a-682baf420663}, !- Name
+  {32c77057-5e7b-4fed-8125-e4de31adba14}, !- Source Object
   3,                                      !- Outlet Port
-  {805427ed-6ecb-4c7b-92f5-17fb93368acb}, !- Target Object
+  {c65ba217-31bb-4b57-a5a1-d1b8712ec70c}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {bece3946-8c39-4875-bbbf-0ab8f163b41b}, !- Handle
-  {fa23837b-480d-4d4c-994d-2a33d742012b}, !- Name
-  {1ac43259-f634-413f-9a94-9ef7e9e49097}, !- Source Object
+  {f56c75db-0fee-4519-b369-4550f6c6a460}, !- Handle
+  {92710378-08c1-4a4f-9d31-62058ac31741}, !- Name
+  {97803d60-67ed-48b0-ad67-9d49cca6e51f}, !- Source Object
   4,                                      !- Outlet Port
-  {3f589aad-5ea1-44ec-bda5-d18e2149e3bb}, !- Target Object
+  {96269e61-dae4-446c-891a-40c9c372cf21}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {f6faef33-c817-4452-a5fb-655066b2591c}, !- Handle
+  {d4a69bf3-7622-4913-92d9-c7e7950015fb}, !- Handle
   Node 199,                               !- Name
-  {6c04e586-8cea-478c-a677-3f8cbb5f4f3d}, !- Inlet Port
-  {bd5ae1f6-4ae3-4d7e-9fda-eb4934afba16}; !- Outlet Port
+  {963e0a81-7f03-4534-9b04-de1275e0e43c}, !- Inlet Port
+  {a49674b4-f6c6-4811-9b04-3a9799dcf48a}; !- Outlet Port
 
 OS:Connection,
-  {6c04e586-8cea-478c-a677-3f8cbb5f4f3d}, !- Handle
-  {eb9e19c1-eb2d-4fc1-b3f2-7522634153fb}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {963e0a81-7f03-4534-9b04-de1275e0e43c}, !- Handle
+  {6fe91159-3714-4d96-ab2d-fccea5abef3b}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   9,                                      !- Outlet Port
-  {f6faef33-c817-4452-a5fb-655066b2591c}, !- Target Object
+  {d4a69bf3-7622-4913-92d9-c7e7950015fb}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {bd5ae1f6-4ae3-4d7e-9fda-eb4934afba16}, !- Handle
-  {ae94998f-40f5-4c74-8b5b-06b31914574b}, !- Name
-  {f6faef33-c817-4452-a5fb-655066b2591c}, !- Source Object
+  {a49674b4-f6c6-4811-9b04-3a9799dcf48a}, !- Handle
+  {3af54ac6-6b61-43d6-b181-5abf97d72588}, !- Name
+  {d4a69bf3-7622-4913-92d9-c7e7950015fb}, !- Source Object
   3,                                      !- Outlet Port
-  {c726d2ef-209e-41b1-b97b-eb49e2c5877f}, !- Target Object
+  {d30a8304-23e2-49e4-89a3-71e151d7d0a0}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {b9457cfb-8520-40ad-b7fd-56b6bb3b347e}, !- Handle
-  {8237eac1-3862-42f5-bde3-b2fb59f9e4ab}, !- Name
-  {c726d2ef-209e-41b1-b97b-eb49e2c5877f}, !- Source Object
+  {f066760f-243c-44e2-8d90-c84782908f58}, !- Handle
+  {fb718890-fa7a-4e08-a1cb-4340578ab15b}, !- Name
+  {d30a8304-23e2-49e4-89a3-71e151d7d0a0}, !- Source Object
   12,                                     !- Outlet Port
-  {28669767-a293-4c3c-b034-1d1a8be0dbc8}, !- Target Object
+  {32c77057-5e7b-4fed-8125-e4de31adba14}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirTerminal:SingleDuct:VAV:Reheat,
-  {a14a36b0-44d0-4c50-8fb1-41c8ac341e5b}, !- Handle
+  {c48da182-3ab3-4ee5-9c9b-028cbd6d7aa7}, !- Handle
   Air Terminal Single Duct VAV Reheat 16, !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
-  {b88f5b94-6ba2-4f64-9ab4-120c76c2d5fe}, !- Air Inlet Node Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
+  {f009d71f-a03a-4209-a96f-22c988b886d4}, !- Air Inlet Node Name
   AutoSize,                               !- Maximum Air Flow Rate {m3/s}
   Constant,                               !- Zone Minimum Air Flow Input Method
   0.3,                                    !- Constant Minimum Air Flow Fraction
   0,                                      !- Fixed Minimum Air Flow Rate {m3/s}
   ,                                       !- Minimum Air Flow Fraction Schedule Name
-  {513d4756-6450-44d3-bec3-4b9b60c4dce9}, !- Reheat Coil Name
+  {bb19dc2e-0416-432b-addc-6169e5a0cef1}, !- Reheat Coil Name
   AutoSize,                               !- Maximum Hot Water or Steam Flow Rate {m3/s}
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
-  {4a25b482-3b68-4b5d-8a62-b12e3c2a576b}, !- Air Outlet Node Name
+  {a309cab5-6052-4cdf-86d8-ba605ad0bef4}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
   Normal,                                 !- Damper Heating Action
   AutoSize,                               !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
@@ -8818,13 +8826,13 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   No;                                     !- Control For Outdoor Air
 
 OS:Coil:Heating:Water,
-  {513d4756-6450-44d3-bec3-4b9b60c4dce9}, !- Handle
+  {bb19dc2e-0416-432b-addc-6169e5a0cef1}, !- Handle
   Coil Heating Water 18,                  !- Name
-  {b83b2d2f-bcea-4d9e-9d3a-80aa78f69ab9}, !- Availability Schedule Name
+  {9fe65593-fc8b-4d73-b514-a440b15d0125}, !- Availability Schedule Name
   ,                                       !- U-Factor Times Area Value {W/K}
   ,                                       !- Maximum Water Flow Rate {m3/s}
-  {f89217ec-369c-45c7-83cc-78a889ea5a6d}, !- Water Inlet Node Name
-  {ab10579d-ac4a-4884-8d4e-a61c8e9fd52b}, !- Water Outlet Node Name
+  {e3d7c3a7-f6f1-4ba7-817b-6fa0b9f89ca1}, !- Water Inlet Node Name
+  {0e66ddd2-500e-4568-805f-45b75c60aed7}, !- Water Outlet Node Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   ,                                       !- Performance Input Method
@@ -8836,509 +8844,509 @@ OS:Coil:Heating:Water,
   ;                                       !- Rated Ratio for Air and Water Convection
 
 OS:Node,
-  {3061433b-a905-446e-9699-2eafdf4a8f66}, !- Handle
+  {5ad3df86-3a23-426d-aa64-70e34d34f56c}, !- Handle
   Node 200,                               !- Name
-  {1540095d-b2cf-4b4d-ad03-27188c3bf055}, !- Inlet Port
-  {f89217ec-369c-45c7-83cc-78a889ea5a6d}; !- Outlet Port
+  {79a38c81-9ae9-443b-b24a-dc410870a41d}, !- Inlet Port
+  {e3d7c3a7-f6f1-4ba7-817b-6fa0b9f89ca1}; !- Outlet Port
 
 OS:Connection,
-  {1540095d-b2cf-4b4d-ad03-27188c3bf055}, !- Handle
-  {c7a63af5-d321-456d-afeb-d88a446c685d}, !- Name
-  {b4348447-9f38-4eb1-9f86-2c71fabbd02c}, !- Source Object
+  {79a38c81-9ae9-443b-b24a-dc410870a41d}, !- Handle
+  {0c8b2a48-3f82-4457-a64d-146d81c91d52}, !- Name
+  {fe6b7e86-6646-49dc-893e-6e0c72c3436f}, !- Source Object
   12,                                     !- Outlet Port
-  {3061433b-a905-446e-9699-2eafdf4a8f66}, !- Target Object
+  {5ad3df86-3a23-426d-aa64-70e34d34f56c}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {41254d91-4da6-46c3-911b-76f128be45c8}, !- Handle
+  {1f6e4735-2c67-49c3-a479-d820833a8f02}, !- Handle
   Node 201,                               !- Name
-  {ab10579d-ac4a-4884-8d4e-a61c8e9fd52b}, !- Inlet Port
-  {8bbafbc2-6ec1-4da8-bbc8-0cb45c7d547b}; !- Outlet Port
+  {0e66ddd2-500e-4568-805f-45b75c60aed7}, !- Inlet Port
+  {a722af56-46d6-4ba7-8161-dfa02ec565c6}; !- Outlet Port
 
 OS:Connection,
-  {f89217ec-369c-45c7-83cc-78a889ea5a6d}, !- Handle
-  {bf3b7437-b1e6-4f56-b516-931430d74998}, !- Name
-  {3061433b-a905-446e-9699-2eafdf4a8f66}, !- Source Object
+  {e3d7c3a7-f6f1-4ba7-817b-6fa0b9f89ca1}, !- Handle
+  {4c2ea7bd-a4cb-4b02-9365-adfeaaafe167}, !- Name
+  {5ad3df86-3a23-426d-aa64-70e34d34f56c}, !- Source Object
   3,                                      !- Outlet Port
-  {513d4756-6450-44d3-bec3-4b9b60c4dce9}, !- Target Object
+  {bb19dc2e-0416-432b-addc-6169e5a0cef1}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {ab10579d-ac4a-4884-8d4e-a61c8e9fd52b}, !- Handle
-  {6316a610-a001-43a0-b41a-308c46519eaf}, !- Name
-  {513d4756-6450-44d3-bec3-4b9b60c4dce9}, !- Source Object
+  {0e66ddd2-500e-4568-805f-45b75c60aed7}, !- Handle
+  {3de4d04d-07c5-4e6b-ad4a-8f99f9201292}, !- Name
+  {bb19dc2e-0416-432b-addc-6169e5a0cef1}, !- Source Object
   6,                                      !- Outlet Port
-  {41254d91-4da6-46c3-911b-76f128be45c8}, !- Target Object
+  {1f6e4735-2c67-49c3-a479-d820833a8f02}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {8bbafbc2-6ec1-4da8-bbc8-0cb45c7d547b}, !- Handle
-  {492547f4-b7bf-496d-ac98-894f4a973250}, !- Name
-  {41254d91-4da6-46c3-911b-76f128be45c8}, !- Source Object
+  {a722af56-46d6-4ba7-8161-dfa02ec565c6}, !- Handle
+  {8c8c5019-ba21-40d8-9a3d-5b9922e6605f}, !- Name
+  {1f6e4735-2c67-49c3-a479-d820833a8f02}, !- Source Object
   3,                                      !- Outlet Port
-  {1f5cda16-74b6-4a28-94e9-6e9a2b6cacce}, !- Target Object
+  {42ae1bc2-7a32-482b-bd3c-629429e73dcc}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:Node,
-  {b532fb9e-ee72-4c68-bb3e-09e1315fe771}, !- Handle
+  {f3a1c869-3d7c-4042-8b1d-9b76e0458e3e}, !- Handle
   Node 202,                               !- Name
-  {4a25b482-3b68-4b5d-8a62-b12e3c2a576b}, !- Inlet Port
-  {0827fea0-34de-4b63-bb1d-32d7524a5e1d}; !- Outlet Port
+  {a309cab5-6052-4cdf-86d8-ba605ad0bef4}, !- Inlet Port
+  {8094879a-be03-40f9-b7b8-03b3f214806e}; !- Outlet Port
 
 OS:Node,
-  {5fa642e3-3bbb-4dd6-9281-01dca9f7e416}, !- Handle
+  {1a7f32da-ace2-46a1-8e66-92f763432fc3}, !- Handle
   Node 203,                               !- Name
-  {b36db72d-b790-4b35-b513-a7449eacaae0}, !- Inlet Port
-  {df6ed520-aef6-467a-aac7-eda21ea4d92a}; !- Outlet Port
+  {6627cf59-9509-47d8-a2b9-1c6593c99675}, !- Inlet Port
+  {bdfd8360-3372-45ee-8051-70eae5c09c73}; !- Outlet Port
 
 OS:Connection,
-  {0827fea0-34de-4b63-bb1d-32d7524a5e1d}, !- Handle
-  {b75fa990-42b1-40d8-bfca-af5f71652b02}, !- Name
-  {b532fb9e-ee72-4c68-bb3e-09e1315fe771}, !- Source Object
+  {8094879a-be03-40f9-b7b8-03b3f214806e}, !- Handle
+  {ae646de9-2646-4000-86a4-11b95ea0ecff}, !- Name
+  {f3a1c869-3d7c-4042-8b1d-9b76e0458e3e}, !- Source Object
   3,                                      !- Outlet Port
-  {1ca6b81d-2235-4acb-81a1-340ce4e2806a}, !- Target Object
+  {58eb42cf-bea0-4c2c-b544-97ce9e67f0e9}, !- Target Object
   4;                                      !- Inlet Port
 
 OS:Connection,
-  {b36db72d-b790-4b35-b513-a7449eacaae0}, !- Handle
-  {2eed7912-d703-42fe-bb05-de099d1cccdc}, !- Name
-  {c23ee3d2-5aa7-49fe-9f99-2b1cd8737ea2}, !- Source Object
+  {6627cf59-9509-47d8-a2b9-1c6593c99675}, !- Handle
+  {11722441-765f-44ce-9301-5c419b368c1c}, !- Name
+  {1ed84698-ef20-454c-a2f3-757ec7a21171}, !- Source Object
   4,                                      !- Outlet Port
-  {5fa642e3-3bbb-4dd6-9281-01dca9f7e416}, !- Target Object
+  {1a7f32da-ace2-46a1-8e66-92f763432fc3}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Node,
-  {d673d7e4-a229-4e1a-b6ae-288e3b7f8394}, !- Handle
+  {472dd2d3-9260-46d6-bffc-51d9f65cef55}, !- Handle
   Node 204,                               !- Name
-  {ce00a0a3-c2b7-450f-8658-ac303b832efc}, !- Inlet Port
-  {b88f5b94-6ba2-4f64-9ab4-120c76c2d5fe}; !- Outlet Port
+  {0dc5cf0e-8c79-4282-8617-6c1eae974a93}, !- Inlet Port
+  {f009d71f-a03a-4209-a96f-22c988b886d4}; !- Outlet Port
 
 OS:Connection,
-  {ce00a0a3-c2b7-450f-8658-ac303b832efc}, !- Handle
-  {515d2526-096a-4916-8bbd-8d9fd3339583}, !- Name
-  {c4ad8ecd-44ae-42dd-9a3c-f31d0b43d99d}, !- Source Object
+  {0dc5cf0e-8c79-4282-8617-6c1eae974a93}, !- Handle
+  {adf76915-2071-43e8-815f-caa1734c1c9c}, !- Name
+  {eef86f1f-f9e2-4099-9dd4-05191b64480e}, !- Source Object
   10,                                     !- Outlet Port
-  {d673d7e4-a229-4e1a-b6ae-288e3b7f8394}, !- Target Object
+  {472dd2d3-9260-46d6-bffc-51d9f65cef55}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {b88f5b94-6ba2-4f64-9ab4-120c76c2d5fe}, !- Handle
-  {1c0b6545-e079-4e8d-ac91-3a5d76527de4}, !- Name
-  {d673d7e4-a229-4e1a-b6ae-288e3b7f8394}, !- Source Object
+  {f009d71f-a03a-4209-a96f-22c988b886d4}, !- Handle
+  {12c1f844-0b69-4599-b4c4-9d95773c5847}, !- Name
+  {472dd2d3-9260-46d6-bffc-51d9f65cef55}, !- Source Object
   3,                                      !- Outlet Port
-  {a14a36b0-44d0-4c50-8fb1-41c8ac341e5b}, !- Target Object
+  {c48da182-3ab3-4ee5-9c9b-028cbd6d7aa7}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {4a25b482-3b68-4b5d-8a62-b12e3c2a576b}, !- Handle
-  {50bd127d-db2b-4d95-887f-658dd5b143a6}, !- Name
-  {a14a36b0-44d0-4c50-8fb1-41c8ac341e5b}, !- Source Object
+  {a309cab5-6052-4cdf-86d8-ba605ad0bef4}, !- Handle
+  {81a08d64-132f-4396-8055-86685bed7408}, !- Name
+  {c48da182-3ab3-4ee5-9c9b-028cbd6d7aa7}, !- Source Object
   12,                                     !- Outlet Port
-  {b532fb9e-ee72-4c68-bb3e-09e1315fe771}, !- Target Object
+  {f3a1c869-3d7c-4042-8b1d-9b76e0458e3e}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:AirLoopHVAC:ReturnPlenum,
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Handle
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Handle
   Air Loop HVAC Return Plenum 1,          !- Name
-  {6b5a38ac-7c88-413a-af8c-cba2eb056bb5}, !- ThermalZone
-  {9ae620a9-9df0-4beb-a114-f0d6d93b1f37}, !- Outlet Node
+  {3d7bb672-5650-4a2d-bd85-724bb823d07c}, !- ThermalZone
+  {609d2c0f-fb23-4069-b436-735c05e4c1a3}, !- Outlet Node
   ,                                       !- Induced Air Outlet Port List
-  {b6abd7f9-9bae-4501-a2e6-f11cb4d1974a}, !- Inlet Node 1
-  {1c9aaadc-256c-4671-b89f-d5b12729a411}, !- Inlet Node 2
-  {54e76f14-2659-4e64-a718-f9a6231ffb40}, !- Inlet Node 3
-  {bc8de337-17b9-47ec-8cf2-50f51b50ecfc}, !- Inlet Node 4
-  {27c16f95-f186-4ba8-8ef6-f515fb9b3b10}, !- Inlet Node 5
-  {129ef53b-cdef-4685-9f8a-57868d81783d}, !- Inlet Node 6
-  {34a3d02f-dba1-4e3e-b679-061d5c0f4123}, !- Inlet Node 7
-  {bf83339a-61df-46d3-b85c-e963a5c3401f}; !- Inlet Node 8
+  {6d3126d0-b075-4219-8195-bf1d21d3e65c}, !- Inlet Node 1
+  {b66e0f13-4960-4773-a86a-2769ebe11b67}, !- Inlet Node 2
+  {20c301d1-0c91-4afe-9755-379024d76969}, !- Inlet Node 3
+  {8d428648-b1ef-4467-adac-20605cbd42b1}, !- Inlet Node 4
+  {4a82b16b-05b4-4e3e-8369-5e6d9e8e8fe7}, !- Inlet Node 5
+  {0477092e-3b6d-4227-b47b-85868507cec0}, !- Inlet Node 6
+  {16008e55-3a70-413d-9f7b-f27228cf721a}, !- Inlet Node 7
+  {ebe9da10-4d1d-4ef6-b853-b21c695dd0c5}; !- Inlet Node 8
 
 OS:Node,
-  {76fdf9db-1997-4755-9177-03b8b394efa3}, !- Handle
+  {ca9e9e2b-b371-4988-a894-52d1389e3c5b}, !- Handle
   Node 206,                               !- Name
-  {9ae620a9-9df0-4beb-a114-f0d6d93b1f37}, !- Inlet Port
-  {dc251d28-8264-4f5d-b7bc-8fcbf5da56aa}; !- Outlet Port
+  {609d2c0f-fb23-4069-b436-735c05e4c1a3}, !- Inlet Port
+  {fc13eb40-488b-4a4b-909c-fb46a7d5e5bd}; !- Outlet Port
 
 OS:Connection,
-  {b6abd7f9-9bae-4501-a2e6-f11cb4d1974a}, !- Handle
-  {bf8e676f-248e-41dc-98cd-5799c7e6400e}, !- Name
-  {dccb2b67-82ad-4224-8f98-a7b88a3698d2}, !- Source Object
+  {6d3126d0-b075-4219-8195-bf1d21d3e65c}, !- Handle
+  {ec6c29f3-d6e6-4551-99a9-381c99a72ca4}, !- Name
+  {ceb873e0-6ced-400a-a29f-28a015e14e5c}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {9ae620a9-9df0-4beb-a114-f0d6d93b1f37}, !- Handle
-  {bcb8f9e6-80f5-4182-b75d-ec64e5e3533a}, !- Name
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Source Object
+  {609d2c0f-fb23-4069-b436-735c05e4c1a3}, !- Handle
+  {f26b10f9-b4fc-4732-9c00-f4dd086915a0}, !- Name
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Source Object
   3,                                      !- Outlet Port
-  {76fdf9db-1997-4755-9177-03b8b394efa3}, !- Target Object
+  {ca9e9e2b-b371-4988-a894-52d1389e3c5b}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {dc251d28-8264-4f5d-b7bc-8fcbf5da56aa}, !- Handle
-  {f43ca50f-d3e1-41ab-8283-4f43ab33cb81}, !- Name
-  {76fdf9db-1997-4755-9177-03b8b394efa3}, !- Source Object
+  {fc13eb40-488b-4a4b-909c-fb46a7d5e5bd}, !- Handle
+  {f9f4f0a1-dd1f-45b7-8478-32710f18c960}, !- Name
+  {ca9e9e2b-b371-4988-a894-52d1389e3c5b}, !- Source Object
   3,                                      !- Outlet Port
-  {8e7e4c46-65c2-4f3d-8c47-714e87868182}, !- Target Object
+  {df72a029-e0f9-4916-9896-f4f03c08c3bb}, !- Target Object
   3;                                      !- Inlet Port
 
 OS:Connection,
-  {1c9aaadc-256c-4671-b89f-d5b12729a411}, !- Handle
-  {ac96c1df-1098-4147-9d51-99fe5ede5ee9}, !- Name
-  {ed3de5f1-1f64-42a9-abbf-f4c15bdd2e81}, !- Source Object
+  {b66e0f13-4960-4773-a86a-2769ebe11b67}, !- Handle
+  {fd82471b-6856-4168-b526-b2eafd70dd52}, !- Name
+  {28411a87-2b1d-4aac-9a3e-05f86658903d}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Connection,
-  {54e76f14-2659-4e64-a718-f9a6231ffb40}, !- Handle
-  {6489a377-d6e7-4c6d-969c-d90fbf888754}, !- Name
-  {4237dfe8-731d-4129-a671-be330ff86590}, !- Source Object
+  {20c301d1-0c91-4afe-9755-379024d76969}, !- Handle
+  {bc6e3b98-f77b-4aab-902c-1d5970f1eeeb}, !- Name
+  {ce4586fd-e05d-402a-a503-4cfac5cad066}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Connection,
-  {bc8de337-17b9-47ec-8cf2-50f51b50ecfc}, !- Handle
-  {e4081f5d-64a2-4bac-8004-f1917615491c}, !- Name
-  {ea637f2a-c138-498f-ba2a-16610db82248}, !- Source Object
+  {8d428648-b1ef-4467-adac-20605cbd42b1}, !- Handle
+  {1798cf92-281b-4d4a-bfad-86eaf915c025}, !- Name
+  {273b8de4-bd8e-49ea-bef0-8db30bb20e6c}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Connection,
-  {27c16f95-f186-4ba8-8ef6-f515fb9b3b10}, !- Handle
-  {d89c2605-fc96-4234-a789-71fa67a96df4}, !- Name
-  {dcda9a31-84d4-44e4-8d3a-6061ec8b9d46}, !- Source Object
+  {4a82b16b-05b4-4e3e-8369-5e6d9e8e8fe7}, !- Handle
+  {b113a7cc-4663-42c8-b393-05b211e392fe}, !- Name
+  {640bea84-4f69-4a46-aa94-0af5d92f920a}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   9;                                      !- Inlet Port
 
 OS:Connection,
-  {129ef53b-cdef-4685-9f8a-57868d81783d}, !- Handle
-  {bf9f73e1-649e-4b06-ba08-c007b54ac329}, !- Name
-  {077e5d59-c682-4352-bcd0-c1c6d7952c7c}, !- Source Object
+  {0477092e-3b6d-4227-b47b-85868507cec0}, !- Handle
+  {9fb72e68-670e-40c0-b086-d27561a974df}, !- Name
+  {50eabb1d-14cc-4441-8c53-fb1d0b6e9820}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   10;                                     !- Inlet Port
 
 OS:Connection,
-  {34a3d02f-dba1-4e3e-b679-061d5c0f4123}, !- Handle
-  {6ba87d9a-2ff6-4280-be99-c0a8bf0e9205}, !- Name
-  {1e333ce2-c09a-4704-bbb4-07fdbb704518}, !- Source Object
+  {16008e55-3a70-413d-9f7b-f27228cf721a}, !- Handle
+  {7d98dd01-eadc-4469-b997-c02bf8f4cb00}, !- Name
+  {f6a3ce39-9cdb-489e-9108-d6a76aa54fd6}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   11;                                     !- Inlet Port
 
 OS:Connection,
-  {bf83339a-61df-46d3-b85c-e963a5c3401f}, !- Handle
-  {d16ff514-c608-4978-a49f-8aced015dd3d}, !- Name
-  {d1e78639-bd83-4131-bf58-1e02159dc0bd}, !- Source Object
+  {ebe9da10-4d1d-4ef6-b853-b21c695dd0c5}, !- Handle
+  {2b39d1c2-5c4e-4c2c-b603-3871234fe8e2}, !- Name
+  {a98c8fb0-e2c5-4b79-ab23-11cec05fde7d}, !- Source Object
   3,                                      !- Outlet Port
-  {c7cf0e61-e101-4b71-9af2-d3e73399ad43}, !- Target Object
+  {7bc4b04b-ad05-48b8-97c8-ca027298ed74}, !- Target Object
   12;                                     !- Inlet Port
 
 OS:AirLoopHVAC:ReturnPlenum,
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Handle
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Handle
   Air Loop HVAC Return Plenum 2,          !- Name
-  {4bc64cb7-b2d8-4590-9109-518ca80905ca}, !- ThermalZone
-  {221eda4c-40c4-4759-981f-b46df01a873f}, !- Outlet Node
+  {54861a32-007b-42ff-8229-2ea64b538c06}, !- ThermalZone
+  {29869a42-a98d-4f43-92e7-00a0b73b4134}, !- Outlet Node
   ,                                       !- Induced Air Outlet Port List
-  {a002338c-9340-4212-90bb-80f412217d51}, !- Inlet Node 1
-  {cebcb196-cdf0-4620-8856-a96e94f3e188}, !- Inlet Node 2
-  {f09c8ff9-ea4c-4dce-9ec6-44204be7bf0b}, !- Inlet Node 3
-  {df6ed520-aef6-467a-aac7-eda21ea4d92a}; !- Inlet Node 4
+  {6365c974-5c69-42bf-8da4-489b401e039b}, !- Inlet Node 1
+  {9c1332cd-2834-494b-bcc9-506beb91c450}, !- Inlet Node 2
+  {1ba76c1a-b3a3-484c-be03-60237ef38362}, !- Inlet Node 3
+  {bdfd8360-3372-45ee-8051-70eae5c09c73}; !- Inlet Node 4
 
 OS:Node,
-  {eb16b794-3092-405b-ae1a-7b78ab047fa8}, !- Handle
+  {b9f501f0-5f02-44d8-83b4-c7187e936dde}, !- Handle
   Node 207,                               !- Name
-  {221eda4c-40c4-4759-981f-b46df01a873f}, !- Inlet Port
-  {745f97e3-6f7e-481a-8c65-30658aec43b1}; !- Outlet Port
+  {29869a42-a98d-4f43-92e7-00a0b73b4134}, !- Inlet Port
+  {31db07bb-e62f-4398-ae0b-c012fc57b548}; !- Outlet Port
 
 OS:Connection,
-  {a002338c-9340-4212-90bb-80f412217d51}, !- Handle
-  {9ad20c50-9d06-47e8-997c-9b94cf292b14}, !- Name
-  {63c513f9-fb8e-43a9-a515-ee1e4228e2d7}, !- Source Object
+  {6365c974-5c69-42bf-8da4-489b401e039b}, !- Handle
+  {d34087ad-d938-4b9e-bab3-0994a09d0be0}, !- Name
+  {8d5219e9-e81a-46a1-8008-bc568d00785d}, !- Source Object
   3,                                      !- Outlet Port
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Target Object
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Target Object
   5;                                      !- Inlet Port
 
 OS:Connection,
-  {221eda4c-40c4-4759-981f-b46df01a873f}, !- Handle
-  {677b8135-ee1f-4bdd-abc0-db74c129a501}, !- Name
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Source Object
+  {29869a42-a98d-4f43-92e7-00a0b73b4134}, !- Handle
+  {1469d746-64a3-4aef-afa7-a2520c9c059e}, !- Name
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Source Object
   3,                                      !- Outlet Port
-  {eb16b794-3092-405b-ae1a-7b78ab047fa8}, !- Target Object
+  {b9f501f0-5f02-44d8-83b4-c7187e936dde}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
-  {745f97e3-6f7e-481a-8c65-30658aec43b1}, !- Handle
-  {1cb9d1ad-0fb9-4485-abc9-21cbc5fc5319}, !- Name
-  {eb16b794-3092-405b-ae1a-7b78ab047fa8}, !- Source Object
+  {31db07bb-e62f-4398-ae0b-c012fc57b548}, !- Handle
+  {61ac5919-1594-47cc-833d-15ef3b1a98a8}, !- Name
+  {b9f501f0-5f02-44d8-83b4-c7187e936dde}, !- Source Object
   3,                                      !- Outlet Port
-  {b865f62f-b6ed-4410-86ea-d25ca6f326fa}, !- Target Object
+  {83b5c5d6-98f6-4a5a-b398-64d846a3e5f4}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Connection,
-  {cebcb196-cdf0-4620-8856-a96e94f3e188}, !- Handle
-  {3df10fb5-dfb5-471b-86b9-e3d9495a0cc9}, !- Name
-  {49afa578-3a21-4558-b3f4-ef13ac1f0854}, !- Source Object
+  {9c1332cd-2834-494b-bcc9-506beb91c450}, !- Handle
+  {dabf8a90-655c-4b67-ab9a-3506fa46b6f5}, !- Name
+  {d72a342c-5aad-4702-b7da-d49d822bb679}, !- Source Object
   3,                                      !- Outlet Port
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Target Object
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Target Object
   6;                                      !- Inlet Port
 
 OS:Connection,
-  {f09c8ff9-ea4c-4dce-9ec6-44204be7bf0b}, !- Handle
-  {647f1290-a6f0-4475-b3e9-186c99ae08cf}, !- Name
-  {3f589aad-5ea1-44ec-bda5-d18e2149e3bb}, !- Source Object
+  {1ba76c1a-b3a3-484c-be03-60237ef38362}, !- Handle
+  {4abfb07b-d73b-4558-936d-1a6c4c82b657}, !- Name
+  {96269e61-dae4-446c-891a-40c9c372cf21}, !- Source Object
   3,                                      !- Outlet Port
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Target Object
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Target Object
   7;                                      !- Inlet Port
 
 OS:Connection,
-  {df6ed520-aef6-467a-aac7-eda21ea4d92a}, !- Handle
-  {2f2b4375-8e60-462f-ac9c-bb8d3186fc44}, !- Name
-  {5fa642e3-3bbb-4dd6-9281-01dca9f7e416}, !- Source Object
+  {bdfd8360-3372-45ee-8051-70eae5c09c73}, !- Handle
+  {e2e7d617-d680-4a09-a2ba-6bd9c6a62007}, !- Name
+  {1a7f32da-ace2-46a1-8e66-92f763432fc3}, !- Source Object
   3,                                      !- Outlet Port
-  {de4eac45-d5e2-4a98-b5cd-e3770371a8d4}, !- Target Object
+  {42136d93-9807-4c88-88b7-6eae239f74df}, !- Target Object
   8;                                      !- Inlet Port
 
 OS:Schedule:Ruleset,
-  {15034576-497d-48c5-9507-18d2c94141b5}, !- Handle
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}, !- Handle
   Cooling Sch,                            !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {080cd5bb-71b2-44c5-b2dd-f41b97ed2407}; !- Default Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {621c6ef4-7b5a-482f-8bad-e4be76b5fe43}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {080cd5bb-71b2-44c5-b2dd-f41b97ed2407}, !- Handle
+  {621c6ef4-7b5a-482f-8bad-e4be76b5fe43}, !- Handle
   Cooling Sch Default,                    !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   28;                                     !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Handle
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Handle
   Heating Sch,                            !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
-  {84889879-fcce-4e5d-8c3c-e22c7e378e93}; !- Default Day Schedule Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
+  {1915881b-9c2b-4572-aba7-2f52e0b10abf}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {84889879-fcce-4e5d-8c3c-e22c7e378e93}, !- Handle
+  {1915881b-9c2b-4572-aba7-2f52e0b10abf}, !- Handle
   Heating Sch Default,                    !- Name
-  {fc20190b-0537-41a7-80ae-42e947d0b072}, !- Schedule Type Limits Name
+  {532ec9dd-d30e-491e-89d4-a924209d1f17}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   24;                                     !- Value Until Time 1
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {c32c9e89-a66a-4a92-b035-51881c6ad791}, !- Handle
+  {5796930f-d244-4993-96af-8a7010732ffd}, !- Handle
   Thermostat Setpoint Dual Setpoint 1,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {3c255959-cbc8-44f9-b9d4-62195cf87fe7}, !- Handle
+  {b72f7b35-1fff-4314-87f3-ddc70172ec54}, !- Handle
   Thermostat Setpoint Dual Setpoint 2,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {3266a68f-7518-4315-bc1c-57d216934f63}, !- Handle
+  {666e6b34-167c-441e-8b2f-3e86cb0aad48}, !- Handle
   Thermostat Setpoint Dual Setpoint 3,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {09efc2f1-fe33-4a4b-88f1-9e9764c0a3d1}, !- Handle
+  {86eecd91-4331-4a62-ada4-b5b659b7d0bb}, !- Handle
   Thermostat Setpoint Dual Setpoint 4,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {6b18e723-d965-489d-9e1a-930789957c11}, !- Handle
+  {c2a75eb6-7265-43a8-90b2-cab24787e3e5}, !- Handle
   Thermostat Setpoint Dual Setpoint 5,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {b01772e4-95e5-45eb-a03c-46afab05b355}, !- Handle
+  {60d5d0a2-91ed-48d1-b865-5d8722e7bc9e}, !- Handle
   Thermostat Setpoint Dual Setpoint 6,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {3cc4c6f2-d1bf-47fe-a7ab-b48de16e66f3}, !- Handle
+  {e45fa8a2-bdbc-4b32-a825-540271662638}, !- Handle
   Thermostat Setpoint Dual Setpoint 7,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {faa32c87-f1be-4f63-92c1-342a577894ec}, !- Handle
+  {e3e4a44f-074c-4f6d-b5ed-52ee5b723e23}, !- Handle
   Thermostat Setpoint Dual Setpoint 8,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {1d763b01-359a-4edb-8c83-72d3bb2ca90e}, !- Handle
+  {356844db-5f5d-43b9-b872-97ff40956ddd}, !- Handle
   Thermostat Setpoint Dual Setpoint 9,    !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:ThermostatSetpoint:DualSetpoint,
-  {291ea040-e8c3-4fad-9906-345fca45c424}, !- Handle
+  {346c0ace-0539-4ce1-a5a7-8413438ac986}, !- Handle
   Thermostat Setpoint Dual Setpoint 10,   !- Name
-  {9f37710b-8a89-4b7f-a2a0-9dbe1b7fccb8}, !- Heating Setpoint Temperature Schedule Name
-  {15034576-497d-48c5-9507-18d2c94141b5}; !- Cooling Setpoint Temperature Schedule Name
+  {fcc4c41b-967c-432f-817a-7da194440b2f}, !- Heating Setpoint Temperature Schedule Name
+  {fcea0a2b-ff0a-40a6-b07f-67563a6de273}; !- Cooling Setpoint Temperature Schedule Name
 
 OS:DefaultConstructionSet,
-  {f13f0f11-9b93-4dab-b18d-0b842e96cc1a}, ! Handle
+  {1d74602b-b85b-49d6-8d75-fd7b9534b33f}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_ConstSet, ! Name
-  {9cbfcb5b-ce3f-4c93-9bdd-dd6edb81260d}, ! Default Exterior Surface Constructions Name
-  {a84c936c-08c8-4c9a-a6a5-0bee86098a30}, ! Default Interior Surface Constructions Name
-  {6c520c08-f701-437e-8cdf-f0b9e2817a41}, ! Default Ground Contact Surface Constructions Name
-  {4a3d2086-37ea-4fb3-8b2b-33ce1daba0bf}, ! Default Exterior SubSurface Constructions Name
-  {3e7f6bea-55d9-47b3-988a-1c04b264cfa7}, ! Default Interior SubSurface Constructions Name
-  {5c52fc23-18d0-4ac0-a0f5-f1b52d980a5e}, ! Interior Partition Construction Name
+  {89a83028-d4b5-4864-b35e-bfbff7dca6ce}, ! Default Exterior Surface Constructions Name
+  {82c5c702-fcc9-4d69-9f54-0150de9a644c}, ! Default Interior Surface Constructions Name
+  {15d8cc5c-4f17-414c-bb68-a500b97a1082}, ! Default Ground Contact Surface Constructions Name
+  {b9574320-0aa3-4307-8698-49c5436b3016}, ! Default Exterior SubSurface Constructions Name
+  {b5e0d185-2016-4be1-87b0-3305b8714ba1}, ! Default Interior SubSurface Constructions Name
+  {79a2814a-fc3c-4748-8ce7-8116fff686f2}, ! Interior Partition Construction Name
   ,                                       ! Space Shading Construction Name
   ,                                       ! Building Shading Construction Name
   ;                                       ! Site Shading Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {9cbfcb5b-ce3f-4c93-9bdd-dd6edb81260d}, ! Handle
+  {89a83028-d4b5-4864-b35e-bfbff7dca6ce}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSurfCons, ! Name
-  {58295649-4a97-4821-b780-e70aa2324adc}, ! Floor Construction Name
-  {58e91e80-4fe3-43a1-9155-671365cee4af}, ! Wall Construction Name
-  {a2769560-bb78-43ad-af0e-fa1a59ffed1c}; ! Roof Ceiling Construction Name
+  {5e3aa991-967f-4ec0-9ab4-6a10c0f75a2e}, ! Floor Construction Name
+  {50185663-1ff6-4f72-9d11-94627e761a43}, ! Wall Construction Name
+  {eca3bd83-0c9c-43fb-a216-4e3be53841a6}; ! Roof Ceiling Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {a84c936c-08c8-4c9a-a6a5-0bee86098a30}, ! Handle
+  {82c5c702-fcc9-4d69-9f54-0150de9a644c}, ! Handle
   000_Interior_DefSurfCons,               ! Name
-  {f4da270c-ee0a-4977-9b83-944b8e5ced8c}, ! Floor Construction Name
-  {6ca0a978-bb80-4442-a0c3-e55b360d1fef}, ! Wall Construction Name
-  {a990e78c-b406-43cb-8576-a39ef86d901f}; ! Roof Ceiling Construction Name
+  {a6674fe0-a0e5-41fd-9c73-d1df9b7ad91f}, ! Floor Construction Name
+  {14777b54-2abb-44e4-8e5d-7cd4aff9f00f}, ! Wall Construction Name
+  {eb7a0d96-a4bf-4ed1-a395-ddeab900474f}; ! Roof Ceiling Construction Name
 
 OS:DefaultSurfaceConstructions,
-  {6c520c08-f701-437e-8cdf-f0b9e2817a41}, ! Handle
+  {15d8cc5c-4f17-414c-bb68-a500b97a1082}, ! Handle
   000_Ground_DefSurfCons,                 ! Name
-  {58295649-4a97-4821-b780-e70aa2324adc}, ! Floor Construction Name
-  {58295649-4a97-4821-b780-e70aa2324adc}, ! Wall Construction Name
-  {58295649-4a97-4821-b780-e70aa2324adc}; ! Roof Ceiling Construction Name
+  {5e3aa991-967f-4ec0-9ab4-6a10c0f75a2e}, ! Floor Construction Name
+  {5e3aa991-967f-4ec0-9ab4-6a10c0f75a2e}, ! Wall Construction Name
+  {5e3aa991-967f-4ec0-9ab4-6a10c0f75a2e}; ! Roof Ceiling Construction Name
 
 OS:DefaultSubSurfaceConstructions,
-  {4a3d2086-37ea-4fb3-8b2b-33ce1daba0bf}, ! Handle
+  {b9574320-0aa3-4307-8698-49c5436b3016}, ! Handle
   ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSubCons, ! Name
-  {e11d2cad-54a5-40e2-9d22-159d9abfdc20}, ! Fixed Window Construction Name
-  {e11d2cad-54a5-40e2-9d22-159d9abfdc20}, ! Operable Window Construction Name
-  {b7a8c994-2d32-4a03-9333-16b266cd797d}, ! Door Construction Name
-  {18c9f1c7-14fe-4e65-bfef-f21c5c540258}, ! Glass Door Construction Name
+  {cfcaf391-2fe0-49b6-a966-edecf3b61057}, ! Fixed Window Construction Name
+  {cfcaf391-2fe0-49b6-a966-edecf3b61057}, ! Operable Window Construction Name
+  {4513850c-c8f8-4599-a545-b68c573a2468}, ! Door Construction Name
+  {afce8e7f-c3ab-49ec-ab5e-40e0055778e6}, ! Glass Door Construction Name
   ,                                       ! Overhead Door Construction Name
-  {18c9f1c7-14fe-4e65-bfef-f21c5c540258}, ! Skylight Construction Name
-  {54694db0-4505-4491-9f42-55020f399cf4}, ! Tubular Daylight Dome Construction Name
-  {54694db0-4505-4491-9f42-55020f399cf4}; ! Tubular Daylight Diffuser Construction Name
+  {afce8e7f-c3ab-49ec-ab5e-40e0055778e6}, ! Skylight Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}, ! Tubular Daylight Dome Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}; ! Tubular Daylight Diffuser Construction Name
 
 OS:DefaultSubSurfaceConstructions,
-  {3e7f6bea-55d9-47b3-988a-1c04b264cfa7}, ! Handle
+  {b5e0d185-2016-4be1-87b0-3305b8714ba1}, ! Handle
   000_Interior_DefSubCons,                ! Name
-  {54694db0-4505-4491-9f42-55020f399cf4}, ! Fixed Window Construction Name
-  {54694db0-4505-4491-9f42-55020f399cf4}, ! Operable Window Construction Name
-  {cfb7e402-8b67-4cde-a79a-c0cb7f4e7d56}, ! Door Construction Name
-  {18c9f1c7-14fe-4e65-bfef-f21c5c540258}, ! Glass Door Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}, ! Fixed Window Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}, ! Operable Window Construction Name
+  {c47d695e-2655-45a7-bf5e-16ba6774a86c}, ! Door Construction Name
+  {afce8e7f-c3ab-49ec-ab5e-40e0055778e6}, ! Glass Door Construction Name
   ,                                       ! Overhead Door Construction Name
-  {18c9f1c7-14fe-4e65-bfef-f21c5c540258}, ! Skylight Construction Name
-  {54694db0-4505-4491-9f42-55020f399cf4}, ! Tubular Daylight Dome Construction Name
-  {54694db0-4505-4491-9f42-55020f399cf4}; ! Tubular Daylight Diffuser Construction Name
+  {afce8e7f-c3ab-49ec-ab5e-40e0055778e6}, ! Skylight Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}, ! Tubular Daylight Dome Construction Name
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}; ! Tubular Daylight Diffuser Construction Name
 
 OS:Construction,
-  {5c52fc23-18d0-4ac0-a0f5-f1b52d980a5e}, ! Handle
+  {79a2814a-fc3c-4748-8ce7-8116fff686f2}, ! Handle
   000_Interior Partition,                 ! Name
   ,                                       ! Surface Rendering Name
-  {fbbe100a-e8e4-4a01-9ced-e2407f3773d7}; ! Layer 1
+  {9b7ffffc-ff10-411f-9e04-c9eb6fc843fe}; ! Layer 1
 
 OS:Construction,
-  {58295649-4a97-4821-b780-e70aa2324adc}, ! Handle
+  {5e3aa991-967f-4ec0-9ab4-6a10c0f75a2e}, ! Handle
   000_ExtSlabCarpet_4in_ClimateZone 1-8,  ! Name
   ,                                       ! Surface Rendering Name
-  {91ae9fa2-289e-4efb-8756-4aab04ae9284}, ! Layer 1
-  {1c94ef53-864c-4cc2-9bb2-d9ab85b0a7cb}; ! Layer 2
+  {2c46d603-75a7-4919-b183-2e24850ec43c}, ! Layer 1
+  {902fb6c3-8431-4f33-9937-d96e89e0cc17}; ! Layer 2
 
 OS:Construction,
-  {58e91e80-4fe3-43a1-9155-671365cee4af}, ! Handle
+  {50185663-1ff6-4f72-9d11-94627e761a43}, ! Handle
   ASHRAE_189.1-2009_ExtWall_SteelFrame_ClimateZone 4-8, ! Name
   ,                                       ! Surface Rendering Name
-  {cc42dae7-e2c0-4b6e-8594-7ce1bd9bd5d9}, ! Layer 1
-  {3a444f22-ae9d-42e6-9e3d-0480b6dce61b}, ! Layer 2
-  {f958c429-e2f1-4ddf-86bb-47cd3f9c564f}; ! Layer 3
+  {dbe7962d-8aee-4752-8428-8a8c4913373d}, ! Layer 1
+  {e74aeb9c-aaad-4463-8210-c97bf3adbae7}, ! Layer 2
+  {a69c2e91-ef89-4149-8d86-7afdbc214fd4}; ! Layer 3
 
 OS:Construction,
-  {a2769560-bb78-43ad-af0e-fa1a59ffed1c}, ! Handle
+  {eca3bd83-0c9c-43fb-a216-4e3be53841a6}, ! Handle
   ASHRAE_189.1-2009_ExtRoof_IEAD_ClimateZone 2-5, ! Name
   ,                                       ! Surface Rendering Name
-  {dd72b851-fbeb-44ed-9659-6dccc4f9d8ac}, ! Layer 1
-  {c94088b1-3d05-45ae-8f2d-871e9081d4de}, ! Layer 2
-  {6242cc1f-926c-4a13-bffe-e3d1c8ad9583}; ! Layer 3
+  {bc5b2ec9-5180-49c7-993a-69cf72ecb606}, ! Layer 1
+  {cbcade16-672d-4e9f-85b1-4d9e72e7859e}, ! Layer 2
+  {331660d9-8872-476d-92cf-474984e9e384}; ! Layer 3
 
 OS:Construction,
-  {f4da270c-ee0a-4977-9b83-944b8e5ced8c}, ! Handle
+  {a6674fe0-a0e5-41fd-9c73-d1df9b7ad91f}, ! Handle
   000_Interior Floor,                     ! Name
   ,                                       ! Surface Rendering Name
-  {263359a4-cdc2-4582-b542-750b5f2859b9}, ! Layer 1
-  {5f861002-84d4-45d4-b535-e978e8580da9}, ! Layer 2
-  {55d5ff72-00be-4fc2-8fb5-917ca904cbab}; ! Layer 3
+  {1767fff2-2408-4bdc-b0f7-17d115670d5b}, ! Layer 1
+  {8b4b98e1-f9c6-40b0-951c-0253a780162b}, ! Layer 2
+  {c1f1ba5f-e637-43ed-9057-af6e53ea7b62}; ! Layer 3
 
 OS:Construction,
-  {6ca0a978-bb80-4442-a0c3-e55b360d1fef}, ! Handle
+  {14777b54-2abb-44e4-8e5d-7cd4aff9f00f}, ! Handle
   000_Interior Wall,                      ! Name
   ,                                       ! Surface Rendering Name
-  {0ae80f9f-c216-42f3-b429-2ca0fddf4276}, ! Layer 1
-  {05e1bbc5-a802-41c9-b680-2571ffdee41a}, ! Layer 2
-  {0ae80f9f-c216-42f3-b429-2ca0fddf4276}; ! Layer 3
+  {da1a84a6-12d8-45ce-8886-1d7bcaeb9a2b}, ! Layer 1
+  {c12b544c-de41-4b42-89d3-8204a8e8f112}, ! Layer 2
+  {da1a84a6-12d8-45ce-8886-1d7bcaeb9a2b}; ! Layer 3
 
 OS:Construction,
-  {a990e78c-b406-43cb-8576-a39ef86d901f}, ! Handle
+  {eb7a0d96-a4bf-4ed1-a395-ddeab900474f}, ! Handle
   000_Interior Ceiling,                   ! Name
   ,                                       ! Surface Rendering Name
-  {55d5ff72-00be-4fc2-8fb5-917ca904cbab}, ! Layer 1
-  {5f861002-84d4-45d4-b535-e978e8580da9}, ! Layer 2
-  {263359a4-cdc2-4582-b542-750b5f2859b9}; ! Layer 3
+  {c1f1ba5f-e637-43ed-9057-af6e53ea7b62}, ! Layer 1
+  {8b4b98e1-f9c6-40b0-951c-0253a780162b}, ! Layer 2
+  {1767fff2-2408-4bdc-b0f7-17d115670d5b}; ! Layer 3
 
 OS:Construction,
-  {e11d2cad-54a5-40e2-9d22-159d9abfdc20}, ! Handle
+  {cfcaf391-2fe0-49b6-a966-edecf3b61057}, ! Handle
   ASHRAE_189.1-2009_ExtWindow_ClimateZone 4-5, ! Name
   ,                                       ! Surface Rendering Name
-  {a94d22e4-46bb-4e2a-a8b3-250acfec470c}; ! Layer 1
+  {44aaa92c-8a07-4144-ad4c-474959beeaca}; ! Layer 1
 
 OS:Construction,
-  {b7a8c994-2d32-4a03-9333-16b266cd797d}, ! Handle
+  {4513850c-c8f8-4599-a545-b68c573a2468}, ! Handle
   000_Exterior Door,                      ! Name
   ,                                       ! Surface Rendering Name
-  {ab972fc2-8067-43c5-b99a-4bdd5d42d041}, ! Layer 1
-  {58d73ce5-ea3a-4241-97ca-3d4cc072781d}; ! Layer 2
+  {8881be84-9dcf-4150-90b6-b14ea2ae276d}, ! Layer 1
+  {ad03c6dd-fc4c-4ea2-9273-f1bfce5e57f1}; ! Layer 2
 
 OS:Construction,
-  {18c9f1c7-14fe-4e65-bfef-f21c5c540258}, ! Handle
+  {afce8e7f-c3ab-49ec-ab5e-40e0055778e6}, ! Handle
   000_Exterior Window,                    ! Name
   ,                                       ! Surface Rendering Name
-  {c7fa541e-9091-42d2-9818-8cc11f6c9b64}, ! Layer 1
-  {c492178b-aa26-42d8-bc10-4364cb2a106f}, ! Layer 2
-  {c7fa541e-9091-42d2-9818-8cc11f6c9b64}; ! Layer 3
+  {c34e6af7-2f0e-4322-99c5-56a054919c6b}, ! Layer 1
+  {6409ec0e-19fa-4cb3-9bb4-717674e5f668}, ! Layer 2
+  {c34e6af7-2f0e-4322-99c5-56a054919c6b}; ! Layer 3
 
 OS:Construction,
-  {54694db0-4505-4491-9f42-55020f399cf4}, ! Handle
+  {4d368b36-a48b-48c9-bf89-1a3247177d8b}, ! Handle
   000_Interior Window,                    ! Name
   ,                                       ! Surface Rendering Name
-  {c7fa541e-9091-42d2-9818-8cc11f6c9b64}; ! Layer 1
+  {c34e6af7-2f0e-4322-99c5-56a054919c6b}; ! Layer 1
 
 OS:Construction,
-  {cfb7e402-8b67-4cde-a79a-c0cb7f4e7d56}, ! Handle
+  {c47d695e-2655-45a7-bf5e-16ba6774a86c}, ! Handle
   000_Interior Door,                      ! Name
   ,                                       ! Surface Rendering Name
-  {fbbe100a-e8e4-4a01-9ced-e2407f3773d7}; ! Layer 1
+  {9b7ffffc-ff10-411f-9e04-c9eb6fc843fe}; ! Layer 1
 
 OS:Material,
-  {fbbe100a-e8e4-4a01-9ced-e2407f3773d7}, ! Handle
+  {9b7ffffc-ff10-411f-9e04-c9eb6fc843fe}, ! Handle
   000_G05 25mm wood,                      ! Name
   MediumSmooth,                           ! Roughness
   0.025399999999999999,                   ! Thickness
@@ -9347,7 +9355,7 @@ OS:Material,
   1630;                                   ! Specific Heat
 
 OS:Material,
-  {91ae9fa2-289e-4efb-8756-4aab04ae9284}, ! Handle
+  {2c46d603-75a7-4919-b183-2e24850ec43c}, ! Handle
   MAT-CC05 4 HW CONCRETE,                 ! Name
   Rough,                                  ! Roughness
   0.1016,                                 ! Thickness
@@ -9359,7 +9367,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material:NoMass,
-  {1c94ef53-864c-4cc2-9bb2-d9ab85b0a7cb}, ! Handle
+  {902fb6c3-8431-4f33-9937-d96e89e0cc17}, ! Handle
   CP02 CARPET PAD,                        ! Name
   VeryRough,                              ! Roughness
   0.2165,                                 ! Thermal Resistance
@@ -9368,7 +9376,7 @@ OS:Material:NoMass,
   0.80000000000000004;                    ! Visible Absorptance
 
 OS:Material:NoMass,
-  {cc42dae7-e2c0-4b6e-8594-7ce1bd9bd5d9}, ! Handle
+  {dbe7962d-8aee-4752-8428-8a8c4913373d}, ! Handle
   MAT-SHEATH,                             ! Name
   Rough,                                  ! Roughness
   0.36259999999999998,                    ! Thermal Resistance
@@ -9377,7 +9385,7 @@ OS:Material:NoMass,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {3a444f22-ae9d-42e6-9e3d-0480b6dce61b}, ! Handle
+  {e74aeb9c-aaad-4463-8210-c97bf3adbae7}, ! Handle
   Wall Insulation [39],                   ! Name
   MediumRough,                            ! Roughness
   0.11840000000000001,                    ! Thickness
@@ -9389,7 +9397,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {f958c429-e2f1-4ddf-86bb-47cd3f9c564f}, ! Handle
+  {a69c2e91-ef89-4149-8d86-7afdbc214fd4}, ! Handle
   1/2IN Gypsum,                           ! Name
   Smooth,                                 ! Roughness
   0.012699999999999999,                   ! Thickness
@@ -9401,7 +9409,7 @@ OS:Material,
   0.92000000000000004;                    ! Visible Absorptance
 
 OS:Material,
-  {dd72b851-fbeb-44ed-9659-6dccc4f9d8ac}, ! Handle
+  {bc5b2ec9-5180-49c7-993a-69cf72ecb606}, ! Handle
   Roof Membrane,                          ! Name
   VeryRough,                              ! Roughness
   0.0094999999999999998,                  ! Thickness
@@ -9413,7 +9421,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {c94088b1-3d05-45ae-8f2d-871e9081d4de}, ! Handle
+  {cbcade16-672d-4e9f-85b1-4d9e72e7859e}, ! Handle
   Roof Insulation [21],                   ! Name
   MediumRough,                            ! Roughness
   0.21049999999999999,                    ! Thickness
@@ -9425,7 +9433,7 @@ OS:Material,
   0.69999999999999996;                    ! Visible Absorptance
 
 OS:Material,
-  {6242cc1f-926c-4a13-bffe-e3d1c8ad9583}, ! Handle
+  {331660d9-8872-476d-92cf-474984e9e384}, ! Handle
   Metal Decking,                          ! Name
   MediumSmooth,                           ! Roughness
   0.0015,                                 ! Thickness
@@ -9437,7 +9445,7 @@ OS:Material,
   0.29999999999999999;                    ! Visible Absorptance
 
 OS:Material,
-  {263359a4-cdc2-4582-b542-750b5f2859b9}, ! Handle
+  {1767fff2-2408-4bdc-b0f7-17d115670d5b}, ! Handle
   000_F16 Acoustic tile,                  ! Name
   MediumSmooth,                           ! Roughness
   0.019099999999999999,                   ! Thickness
@@ -9446,12 +9454,12 @@ OS:Material,
   590;                                    ! Specific Heat
 
 OS:Material:AirGap,
-  {5f861002-84d4-45d4-b535-e978e8580da9}, ! Handle
+  {8b4b98e1-f9c6-40b0-951c-0253a780162b}, ! Handle
   000_F05 Ceiling air space resistance,   ! Name
   0.17999999999999999;                    ! Thermal Resistance
 
 OS:Material,
-  {55d5ff72-00be-4fc2-8fb5-917ca904cbab}, ! Handle
+  {c1f1ba5f-e637-43ed-9057-af6e53ea7b62}, ! Handle
   000_M11 100mm lightweight concrete,     ! Name
   MediumRough,                            ! Roughness
   0.1016,                                 ! Thickness
@@ -9460,7 +9468,7 @@ OS:Material,
   840;                                    ! Specific Heat
 
 OS:Material,
-  {0ae80f9f-c216-42f3-b429-2ca0fddf4276}, ! Handle
+  {da1a84a6-12d8-45ce-8886-1d7bcaeb9a2b}, ! Handle
   000_G01a 19mm gypsum board,             ! Name
   MediumSmooth,                           ! Roughness
   0.019,                                  ! Thickness
@@ -9469,12 +9477,12 @@ OS:Material,
   1090;                                   ! Specific Heat
 
 OS:Material:AirGap,
-  {05e1bbc5-a802-41c9-b680-2571ffdee41a}, ! Handle
+  {c12b544c-de41-4b42-89d3-8204a8e8f112}, ! Handle
   000_F04 Wall air space resistance,      ! Name
   0.14999999999999999;                    ! Thermal Resistance
 
 OS:WindowMaterial:Glazing,
-  {a94d22e4-46bb-4e2a-a8b3-250acfec470c}, ! Handle
+  {44aaa92c-8a07-4144-ad4c-474959beeaca}, ! Handle
   Theoretical Glass [207],                ! Name
   SpectralAverage,                        ! Optical Data Type
   ,                                       ! Window Glass Spectral Data Set Name
@@ -9493,7 +9501,7 @@ OS:WindowMaterial:Glazing,
   No;                                     ! Solar Diffusing
 
 OS:Material,
-  {ab972fc2-8067-43c5-b99a-4bdd5d42d041}, ! Handle
+  {8881be84-9dcf-4150-90b6-b14ea2ae276d}, ! Handle
   000_F08 Metal surface,                  ! Name
   Smooth,                                 ! Roughness
   0.00080000000000000004,                 ! Thickness
@@ -9502,7 +9510,7 @@ OS:Material,
   500;                                    ! Specific Heat
 
 OS:Material,
-  {58d73ce5-ea3a-4241-97ca-3d4cc072781d}, ! Handle
+  {ad03c6dd-fc4c-4ea2-9273-f1bfce5e57f1}, ! Handle
   000_I01 25mm insulation board,          ! Name
   MediumRough,                            ! Roughness
   0.025399999999999999,                   ! Thickness
@@ -9511,7 +9519,7 @@ OS:Material,
   1210;                                   ! Specific Heat
 
 OS:WindowMaterial:Glazing,
-  {c7fa541e-9091-42d2-9818-8cc11f6c9b64}, ! Handle
+  {c34e6af7-2f0e-4322-99c5-56a054919c6b}, ! Handle
   000_Clear 3mm,                          ! Name
   SpectralAverage,                        ! Optical Data Type
   ,                                       ! Window Glass Spectral Data Set Name
@@ -9530,65 +9538,65 @@ OS:WindowMaterial:Glazing,
   ;                                       ! Solar Diffusing
 
 OS:WindowMaterial:Gas,
-  {c492178b-aa26-42d8-bc10-4364cb2a106f}, ! Handle
+  {6409ec0e-19fa-4cb3-9bb4-717674e5f668}, ! Handle
   000_Air 13mm,                           ! Name
   Air,                                    ! Gas Type
   0.012699999999999999;                   ! Thickness
 
 OS:Building,
-  {c4e40708-ab70-4d8d-9ba4-25c2a51b017e}, !- Handle
+  {ad9d26ac-d69a-4a7b-85c4-752537b85473}, !- Handle
   Building 1,                             !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Space Type Name
-  {f13f0f11-9b93-4dab-b18d-0b842e96cc1a}, !- Default Construction Set Name
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Space Type Name
+  {1d74602b-b85b-49d6-8d75-fd7b9534b33f}, !- Default Construction Set Name
   ;                                       !- Default Schedule Set Name
 
 OS:Construction,
-  {33c367f9-3f7b-42af-873f-b0f8fb2c8614}, ! Handle
+  {db1b05fd-cf5b-42d1-8580-81ff4915c732}, ! Handle
   Air_Wall,                               ! Name
   ,                                       ! Surface Rendering Name
-  {ee6ac1dc-5ec9-4b6f-91de-3404f50645c5}; ! Layer 1
+  {1c1e413d-5c14-45b2-86b2-48a969d063b8}; ! Layer 1
 
 OS:Material:AirWall,
-  {ee6ac1dc-5ec9-4b6f-91de-3404f50645c5}, ! Handle
+  {1c1e413d-5c14-45b2-86b2-48a969d063b8}, ! Handle
   OS:Material:AirWall 1;                  ! Name
 
 OS:SpaceType,
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Handle
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Handle
   Baseline Model Space Type,              !- Name
   ,                                       !- Default Construction Set Name
-  {a501acfa-dc7b-4703-ba4b-5802650ad404}, !- Default Schedule Set Name
+  {6bfa43db-b9ae-4a9d-9289-b181b2a13e3c}, !- Default Schedule Set Name
   ,                                       !- Group Rendering Name
-  {7c244ef7-65f9-4c8d-bc61-7b5c96a996ee}; !- Design Specification Outdoor Air Object Name
+  {8574a5c9-2929-460b-a798-0168e5e80e0b}; !- Design Specification Outdoor Air Object Name
 
 OS:DefaultScheduleSet,
-  {a501acfa-dc7b-4703-ba4b-5802650ad404}, !- Handle
+  {6bfa43db-b9ae-4a9d-9289-b181b2a13e3c}, !- Handle
   Baseline Model Schedule Set,            !- Name
   ,                                       !- Hours of Operation Schedule Name
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Number of People Schedule Name
-  {be01a31f-9cd5-4a28-95da-c7cc11ed0bc4}, !- People Activity Level Schedule Name
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Lighting Schedule Name
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Electric Equipment Schedule Name
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Number of People Schedule Name
+  {2c4bac37-ea73-41ef-b7ed-864503bd01a6}, !- People Activity Level Schedule Name
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Lighting Schedule Name
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Electric Equipment Schedule Name
   ,                                       !- Gas Equipment Schedule Name
   ,                                       !- Hot Water Equipment Schedule Name
-  {b02f56eb-c302-406d-9183-7db2b4538597}, !- Infiltration Schedule Name
+  {79ea8a2e-783b-48c6-b19a-e7bdc5f237cf}, !- Infiltration Schedule Name
   ,                                       !- Steam Equipment Schedule Name
   ;                                       !- Other Equipment Schedule Name
 
 OS:Schedule:Ruleset,
-  {b02f56eb-c302-406d-9183-7db2b4538597}, !- Handle
+  {79ea8a2e-783b-48c6-b19a-e7bdc5f237cf}, !- Handle
   Baseline Model Infiltration Schedule,   !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
-  {baffb291-9a03-4aa3-a104-946406e297ec}, !- Default Day Schedule Name
-  {02582623-5b84-4d69-b607-d2b9bcc0be06}, !- Summer Design Day Schedule Name
-  {9fe0726c-58c4-46ca-bd90-c29e7fa125e8}; !- Winter Design Day Schedule Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
+  {2c9d582f-e37d-4d87-ba14-2a8b246d8d2d}, !- Default Day Schedule Name
+  {06754037-1c96-4fbd-95b2-245319764f18}, !- Summer Design Day Schedule Name
+  {3e508431-a6a7-45cb-b473-65872f2e0122}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {baffb291-9a03-4aa3-a104-946406e297ec}, !- Handle
+  {2c9d582f-e37d-4d87-ba14-2a8b246d8d2d}, !- Handle
   Baseline Model Infiltration Schedule Schedule All Days, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -9601,7 +9609,7 @@ OS:Schedule:Day,
   1;                                      !- Value Until Time 3
 
 OS:Schedule:Day,
-  {01d09638-b8aa-4adf-b749-f818804acc18}, !- Handle
+  {b681d8d8-dbd7-4c90-ac90-6d6dcf7c098d}, !- Handle
   Schedule Day 2,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -9610,16 +9618,16 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {9fe0726c-58c4-46ca-bd90-c29e7fa125e8}, !- Handle
+  {3e508431-a6a7-45cb-b473-65872f2e0122}, !- Handle
   Baseline Model Infiltration Schedule Winter Design Day, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {f4899e88-b833-44d4-a38b-9bb852c0bd18}, !- Handle
+  {5d4db7cd-87fa-4bda-a721-64ecadc3327d}, !- Handle
   Schedule Day 3,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -9628,33 +9636,33 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {02582623-5b84-4d69-b607-d2b9bcc0be06}, !- Handle
+  {06754037-1c96-4fbd-95b2-245319764f18}, !- Handle
   Baseline Model Infiltration Schedule Summer Design Day, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:ScheduleTypeLimits,
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Handle
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Handle
   Fractional,                             !- Name
   0,                                      !- Lower Limit Value
   1,                                      !- Upper Limit Value
   Continuous;                             !- Numeric Type
 
 OS:Schedule:Ruleset,
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Handle
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Handle
   Baseline Model People Lights and Equipment Schedule, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
-  {fa3e0a8f-541f-4696-9f30-9d757b65fe02}, !- Default Day Schedule Name
-  {0f585b87-4399-433f-a7ce-6af0e2e49bbb}, !- Summer Design Day Schedule Name
-  {c565e980-523f-4793-ac7f-0d2499ce1e78}; !- Winter Design Day Schedule Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
+  {ef7d3192-f892-45e7-856d-fc0038567726}, !- Default Day Schedule Name
+  {83bb12ad-7fcb-4835-af5a-bee5a1d45dbc}, !- Summer Design Day Schedule Name
+  {56011209-854a-4ba4-9b6c-67dfb699fd56}; !- Winter Design Day Schedule Name
 
 OS:Schedule:Day,
-  {fa3e0a8f-541f-4696-9f30-9d757b65fe02}, !- Handle
+  {ef7d3192-f892-45e7-856d-fc0038567726}, !- Handle
   Baseline Model People Lights and Equipment Schedule Schedule Week Day, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -9688,7 +9696,7 @@ OS:Schedule:Day,
   0.05;                                   !- Value Until Time 10
 
 OS:Schedule:Day,
-  {7af0f852-10b4-4ad0-99af-66477928cabc}, !- Handle
+  {52b0ed8e-0b9e-43c0-8791-0d9284ba8ba9}, !- Handle
   Schedule Day 4,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -9697,16 +9705,16 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {c565e980-523f-4793-ac7f-0d2499ce1e78}, !- Handle
+  {56011209-854a-4ba4-9b6c-67dfb699fd56}, !- Handle
   Baseline Model People Lights and Equipment Schedule Winter Design Day, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {b8359fae-d84c-423e-a3a9-b48422d289f5}, !- Handle
+  {6458aa86-b584-4f29-96c2-e6f003ade9bd}, !- Handle
   Schedule Day 5,                         !- Name
   ,                                       !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
@@ -9715,20 +9723,20 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Day,
-  {0f585b87-4399-433f-a7ce-6af0e2e49bbb}, !- Handle
+  {83bb12ad-7fcb-4835-af5a-bee5a1d45dbc}, !- Handle
   Baseline Model People Lights and Equipment Schedule Summer Design Day, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   1;                                      !- Value Until Time 1
 
 OS:Schedule:Rule,
-  {e457b327-bac8-4718-bb64-1de03f3441b7}, !- Handle
+  {101c6a41-7cdf-447e-afaa-597ebe582e75}, !- Handle
   Baseline Model People Lights and Equipment Schedule Saturday Rule, !- Name
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Schedule Ruleset Name
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Schedule Ruleset Name
   1,                                      !- Rule Order
-  {fd6c5ad4-8118-4376-a3a7-705a27572360}, !- Day Schedule Name
+  {679c5a3b-cc7e-4773-8d2d-5d52e68143e4}, !- Day Schedule Name
   ,                                       !- Apply Sunday
   ,                                       !- Apply Monday
   ,                                       !- Apply Tuesday
@@ -9738,9 +9746,9 @@ OS:Schedule:Rule,
   Yes;                                    !- Apply Saturday
 
 OS:Schedule:Day,
-  {fd6c5ad4-8118-4376-a3a7-705a27572360}, !- Handle
+  {679c5a3b-cc7e-4773-8d2d-5d52e68143e4}, !- Handle
   Baseline Model People Lights and Equipment Schedule Saturday, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   6,                                      !- Hour 1
   0,                                      !- Minute 1
@@ -9759,39 +9767,39 @@ OS:Schedule:Day,
   0;                                      !- Value Until Time 5
 
 OS:Schedule:Rule,
-  {4383cb40-87e2-4565-ae85-b15b85857e83}, !- Handle
+  {80356599-7f01-4d3f-9819-76f4af1cba71}, !- Handle
   Baseline Model People Lights and Equipment Schedule Sunday Rule, !- Name
-  {d4da8418-e550-4f66-b3d9-9e383f3a3381}, !- Schedule Ruleset Name
+  {84d69729-5a49-4b87-8b08-d4937862cbbd}, !- Schedule Ruleset Name
   0,                                      !- Rule Order
-  {4a65d50a-479a-4d89-bf13-4df294d7e8df}, !- Day Schedule Name
+  {a7222b9a-038f-4dcb-989f-4f14fff4b17d}, !- Day Schedule Name
   Yes;                                    !- Apply Sunday
 
 OS:Schedule:Day,
-  {4a65d50a-479a-4d89-bf13-4df294d7e8df}, !- Handle
+  {a7222b9a-038f-4dcb-989f-4f14fff4b17d}, !- Handle
   Baseline Model People Lights and Equipment Schedule Schedule Sunday, !- Name
-  {07e191be-55b2-4081-9a4e-191428afe67b}, !- Schedule Type Limits Name
+  {5bdf954f-27cc-4648-8900-e180bd52700f}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   0;                                      !- Value Until Time 1
 
 OS:Schedule:Ruleset,
-  {be01a31f-9cd5-4a28-95da-c7cc11ed0bc4}, !- Handle
+  {2c4bac37-ea73-41ef-b7ed-864503bd01a6}, !- Handle
   Baseline Model People Activity Schedule, !- Name
-  {911a57a8-7339-487e-afd4-b296ee45eb96}, !- Schedule Type Limits Name
-  {0a4e6a40-ca13-4f58-afee-7e000df3237e}; !- Default Day Schedule Name
+  {4b534592-c29a-4000-86c9-eba3414a4b08}, !- Schedule Type Limits Name
+  {5692ca17-6ef0-4739-b267-636f07c27af0}; !- Default Day Schedule Name
 
 OS:Schedule:Day,
-  {0a4e6a40-ca13-4f58-afee-7e000df3237e}, !- Handle
+  {5692ca17-6ef0-4739-b267-636f07c27af0}, !- Handle
   Baseline Model People Activity Schedule Default, !- Name
-  {911a57a8-7339-487e-afd4-b296ee45eb96}, !- Schedule Type Limits Name
+  {4b534592-c29a-4000-86c9-eba3414a4b08}, !- Schedule Type Limits Name
   ,                                       !- Interpolate to Timestep
   24,                                     !- Hour 1
   0,                                      !- Minute 1
   120;                                    !- Value Until Time 1
 
 OS:ScheduleTypeLimits,
-  {911a57a8-7339-487e-afd4-b296ee45eb96}, !- Handle
+  {4b534592-c29a-4000-86c9-eba3414a4b08}, !- Handle
   ActivityLevel,                          !- Name
   0,                                      !- Lower Limit Value
   ,                                       !- Upper Limit Value
@@ -9799,7 +9807,7 @@ OS:ScheduleTypeLimits,
   ActivityLevel;                          !- Unit Type
 
 OS:DesignSpecification:OutdoorAir,
-  {7c244ef7-65f9-4c8d-bc61-7b5c96a996ee}, !- Handle
+  {8574a5c9-2929-460b-a798-0168e5e80e0b}, !- Handle
   Baseline Model OA,                      !- Name
   Sum,                                    !- Outdoor Air Method
   0.009438948864,                         !- Outdoor Air Flow per Person {m3/s-person}
@@ -9809,9 +9817,9 @@ OS:DesignSpecification:OutdoorAir,
   ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
 
 OS:SpaceInfiltration:DesignFlowRate,
-  {1d5701af-f5ce-461d-a9e8-243a734525ff}, !- Handle
+  {16c1db7e-bb5f-4cbf-9850-881532b272ab}, !- Handle
   Baseline Model Infiltration,            !- Name
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Space or SpaceType Name
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
   ,                                       !- Design Flow Rate {m3/s}
@@ -9824,7 +9832,7 @@ OS:SpaceInfiltration:DesignFlowRate,
   ;                                       !- Velocity Squared Term Coefficient
 
 OS:People:Definition,
-  {cb785fa2-a20e-4d20-bdd6-03a2c8d0486b}, !- Handle
+  {e5dfa56d-cb67-4914-9369-f008c806c7d1}, !- Handle
   Baseline Model People Definition,       !- Name
   People/Area,                            !- Number of People Calculation Method
   ,                                       !- Number of People {people}
@@ -9833,10 +9841,10 @@ OS:People:Definition,
   0.3;                                    !- Fraction Radiant
 
 OS:People,
-  {6eb5144a-1bdf-4594-88b8-b1a7ab691c70}, !- Handle
+  {4f8c62df-b7e3-411f-b5e1-252db988407e}, !- Handle
   Baseline Model People,                  !- Name
-  {cb785fa2-a20e-4d20-bdd6-03a2c8d0486b}, !- People Definition Name
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Space or SpaceType Name
+  {e5dfa56d-cb67-4914-9369-f008c806c7d1}, !- People Definition Name
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Space or SpaceType Name
   ,                                       !- Number of People Schedule Name
   ,                                       !- Activity Level Schedule Name
   ,                                       !- Surface Name/Angle Factor List Name
@@ -9846,7 +9854,7 @@ OS:People,
   1;                                      !- Multiplier
 
 OS:Lights:Definition,
-  {70c55e79-4a3f-4b1d-9014-34faac64e90d}, !- Handle
+  {a838a692-e5e7-4414-abd5-07c53bd4e522}, !- Handle
   Baseline Model Lights Definition,       !- Name
   Watts/Area,                             !- Design Level Calculation Method
   ,                                       !- Lighting Level {W}
@@ -9854,17 +9862,17 @@ OS:Lights:Definition,
   ;                                       !- Watts per Person {W/person}
 
 OS:Lights,
-  {d208e8fe-f1fc-4034-8b97-661f3d812f71}, !- Handle
+  {f1472995-baa0-46f7-9110-43d9ac6072a9}, !- Handle
   Baseline Model Lights,                  !- Name
-  {70c55e79-4a3f-4b1d-9014-34faac64e90d}, !- Lights Definition Name
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Space or SpaceType Name
+  {a838a692-e5e7-4414-abd5-07c53bd4e522}, !- Lights Definition Name
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   1,                                      !- Fraction Replaceable
   ,                                       !- Multiplier
   General;                                !- End-Use Subcategory
 
 OS:ElectricEquipment:Definition,
-  {b3d0655d-2b55-4da8-9e02-0669a3b7223a}, !- Handle
+  {9df4694a-1532-4398-9ab4-ef39c12d338d}, !- Handle
   Baseline Model Electric Equipment Definition, !- Name
   Watts/Area,                             !- Design Level Calculation Method
   ,                                       !- Design Level {W}
@@ -9872,16 +9880,38 @@ OS:ElectricEquipment:Definition,
   ;                                       !- Watts per Person {W/person}
 
 OS:ElectricEquipment,
-  {046f8179-d019-409f-adee-1391ab2f5187}, !- Handle
+  {edc42c01-4fe3-4f3c-85ac-78426aad49b2}, !- Handle
   Baseline Model Electric Equipment,      !- Name
-  {b3d0655d-2b55-4da8-9e02-0669a3b7223a}, !- Electric Equipment Definition Name
-  {f819f212-5784-4849-beaa-51ccded6a73b}, !- Space or SpaceType Name
+  {9df4694a-1532-4398-9ab4-ef39c12d338d}, !- Electric Equipment Definition Name
+  {b84a85bb-0973-40e2-b45a-4bf8bca130f9}, !- Space or SpaceType Name
   ,                                       !- Schedule Name
   ,                                       !- Multiplier
   General;                                !- End-Use Subcategory
 
 OS:SizingPeriod:DesignDay,
-  {9a4e6636-b4fb-4637-88ba-b03fce8142a4}, !- Handle
+  {e58d396d-8aa6-412a-ad36-90d822d16204}, !- Handle
+  Chicago Ohare Intl Ap Ann Htg 99.6% Condns DB, !- Name
+  -20,                                    !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  -20,                                    !- Humidity Indicating Conditions at Maximum Dry-Bulb
+  98934,                                  !- Barometric Pressure {Pa}
+  4.9,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  0,                                      !- Rain Indicator
+  0,                                      !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  0,                                      !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Indicating Type
+  ,                                       !- Humidity Indicating Day Schedule Name
+  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:SizingPeriod:DesignDay,
+  {aa972f1d-67c0-43cb-ade4-89717bcee97e}, !- Handle
   Chicago Ohare Intl Ap Ann Clg .4% Condns DB=>MWB, !- Name
   33.3,                                   !- Maximum Dry-Bulb Temperature {C}
   10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
@@ -9906,30 +9936,8 @@ OS:SizingPeriod:DesignDay,
   0.455,                                  !- ASHRAE Taub {dimensionless}
   2.05;                                   !- ASHRAE Taud {dimensionless}
 
-OS:SizingPeriod:DesignDay,
-  {398e239d-3b68-417a-ba45-9d9eb08caeaf}, !- Handle
-  Chicago Ohare Intl Ap Ann Htg 99.6% Condns DB, !- Name
-  -20,                                    !- Maximum Dry-Bulb Temperature {C}
-  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  -20,                                    !- Humidity Indicating Conditions at Maximum Dry-Bulb
-  98934,                                  !- Barometric Pressure {Pa}
-  4.9,                                    !- Wind Speed {m/s}
-  270,                                    !- Wind Direction {deg}
-  0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
-  21,                                     !- Day of Month
-  1,                                      !- Month
-  WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
-  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
-  ASHRAEClearSky;                         !- Solar Model Indicator
-
 OS:SimulationControl,
-  {497152c9-8e1f-477d-bfca-aea1a87fc762}, !- Handle
+  {2df3c62f-b31f-461b-8ed0-5a6d11d17539}, !- Handle
   ,                                       !- Do Zone Sizing Calculation
   ,                                       !- Do System Sizing Calculation
   ,                                       !- Do Plant Sizing Calculation
@@ -9937,6 +9945,6 @@ OS:SimulationControl,
   Yes;                                    !- Run Simulation for Weather File Run Periods
 
 OS:Timestep,
-  {919770e0-0764-47b4-8a04-bc7fee09dfed}, !- Handle
+  {22f60696-b117-42bd-a68f-73ef5dd3ee76}, !- Handle
   4;                                      !- Number of Timesteps per Hour
 

--- a/model/simulationtests/schedule_file.osm
+++ b/model/simulationtests/schedule_file.osm
@@ -1,0 +1,8137 @@
+
+OS:Version,
+  {6db68a01-c4d0-4577-aaed-6b3cea100041}, !- Handle
+  2.7.0;                                  !- Version Identifier
+
+OS:BuildingStory,
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Handle
+  Story 1,                                !- Name
+  0,                                      !- Nominal Z Coordinate {m}
+  4,                                      !- Nominal Floor to Floor Height {m}
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ;                                       !- Group Rendering Name
+
+OS:Space,
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Handle
+  Story 1 West Perimeter Space,           !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Building Story Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}; !- Thermal Zone Name
+
+OS:Surface,
+  {b0fca224-8823-48e1-a8ac-4461ba6dd1c7}, !- Handle
+  Surface 1,                              !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f8dd0deb-ec2f-4079-bfcc-73d4c9eaee27}, !- Handle
+  Surface 2,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 50, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {6a518ea9-24ed-4329-8b39-0d98042ed0c8}, !- Handle
+  Surface 3,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {18ee4080-f959-405f-b169-4b125863b45f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1e736e2b-1c0f-4510-ad55-928c4fca1542}, !- Handle
+  Surface 4,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {e5e207a4-1840-41bc-a6d9-2c8703448d7c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {5d72e6da-f1ee-4837-a8f9-d6c74d165dc6}, !- Handle
+  Surface 5,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {70f0c7d7-11f0-4229-83e6-18c07e159c1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ff290be8-e615-4560-9b8a-f035133a4280}, !- Handle
+  Surface 6,                              !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {37b1a240-2f66-4d39-8f7a-c5f5c0c8bb22}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a48a4cb9-5612-43a1-808b-8e8f61e8d175}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 47, 4,                               !- X,Y,Z Vertex 2 {m}
+  0, 50, 4,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Handle
+  Story 1 North Perimeter Space,          !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  3,                                      !- X Origin {m}
+  47,                                     !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Building Story Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}; !- Thermal Zone Name
+
+OS:Surface,
+  {b309a34c-23d9-4afc-917a-8615416fabf4}, !- Handle
+  Surface 7,                              !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  -3, 3, 0,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4c21fe1a-1959-475d-b2e1-40b6d145dac2}, !- Handle
+  Surface 8,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  -3, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {8469db77-83c2-4b07-9dd2-528ff56030f7}, !- Handle
+  Surface 9,                              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {14f2afe8-38d6-4399-acc8-9551ff368116}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {10efcd9d-3644-4699-9bd2-64fd86d30fec}, !- Handle
+  Surface 10,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {d155d4f9-9424-41db-b792-232710379a72}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {18ee4080-f959-405f-b169-4b125863b45f}, !- Handle
+  Surface 11,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6a518ea9-24ed-4329-8b39-0d98042ed0c8}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  -3, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  -3, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a5d6e2a6-64d5-43cb-b1a8-b7917fd9d278}, !- Handle
+  Surface 12,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {40e0b900-e266-4c50-a38d-1d49025cfb35}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {40602bcf-0fcc-42a3-b052-9f0b2c12c115}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  94, 0, 4,                               !- X,Y,Z Vertex 2 {m}
+  97, 3, 4,                               !- X,Y,Z Vertex 3 {m}
+  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Handle
+  Story 1 East Perimeter Space,           !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  97,                                     !- X Origin {m}
+  3,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Building Story Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}; !- Thermal Zone Name
+
+OS:Surface,
+  {8522a014-5699-4884-b607-6bd5a5e307d2}, !- Handle
+  Surface 13,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 0,                               !- X,Y,Z Vertex 1 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a7659f94-99bf-4ef6-a195-406885a777b9}, !- Handle
+  Surface 14,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, -3, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {490f0077-d940-4d6a-9c6b-ce3fc5129942}, !- Handle
+  Surface 15,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {e17c8bd0-aac7-4b36-9ec7-8cba36668e43}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4f4e9b54-23d0-4f7d-9579-433e50ce52c6}, !- Handle
+  Surface 16,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {de3e829a-e47d-4fb7-9d9d-9fa62df52976}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {14f2afe8-38d6-4399-acc8-9551ff368116}, !- Handle
+  Surface 17,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {8469db77-83c2-4b07-9dd2-528ff56030f7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0f339a30-6ac8-41ae-8811-36514eb5f97f}, !- Handle
+  Surface 18,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {35df17fe-dc88-4211-96d7-c95c5e0e4d90}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {292dfbfc-90c2-41cb-ba14-38936617c472}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 0, 4,                                !- X,Y,Z Vertex 2 {m}
+  3, -3, 4,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Handle
+  Story 1 South Perimeter Space,          !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Building Story Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}; !- Thermal Zone Name
+
+OS:Surface,
+  {9bd3eb54-df3c-4910-8a47-f1878db373a9}, !- Handle
+  Surface 19,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  100, 0, 0,                              !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f51653e3-934b-480a-80e5-6b664b2f4f3f}, !- Handle
+  Surface 20,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  100, 0, 0,                              !- X,Y,Z Vertex 3 {m}
+  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {70f0c7d7-11f0-4229-83e6-18c07e159c1a}, !- Handle
+  Surface 21,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {5d72e6da-f1ee-4837-a8f9-d6c74d165dc6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {863a2caf-a847-407f-938b-fcf296906f82}, !- Handle
+  Surface 22,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {7e12c6b0-b711-408a-b64a-6503ddc95a7a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {e17c8bd0-aac7-4b36-9ec7-8cba36668e43}, !- Handle
+  Surface 23,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {490f0077-d940-4d6a-9c6b-ce3fc5129942}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  100, 0, 4,                              !- X,Y,Z Vertex 1 {m}
+  100, 0, 0,                              !- X,Y,Z Vertex 2 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {3cddeb2f-dfc3-4026-a05a-a69a356610db}, !- Handle
+  Surface 24,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {01afdfe8-41c5-4330-a454-bf83efe6d7a0}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {56804c11-7f6e-4542-8df3-6833f85f443a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 3, 4,                                !- X,Y,Z Vertex 2 {m}
+  0, 0, 4,                                !- X,Y,Z Vertex 3 {m}
+  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Handle
+  Story 1 Core Space,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  3,                                      !- X Origin {m}
+  3,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  {9856d718-ca3a-4c1d-a325-29d8e8d28599}, !- Building Story Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}; !- Thermal Zone Name
+
+OS:Surface,
+  {ebadb5e7-c303-43b9-92ba-182dd9423e75}, !- Handle
+  Surface 25,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
+  94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {e5e207a4-1840-41bc-a6d9-2c8703448d7c}, !- Handle
+  Surface 26,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1e736e2b-1c0f-4510-ad55-928c4fca1542}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {d155d4f9-9424-41db-b792-232710379a72}, !- Handle
+  Surface 27,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {10efcd9d-3644-4699-9bd2-64fd86d30fec}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 44, 4,                              !- X,Y,Z Vertex 1 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 2 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {de3e829a-e47d-4fb7-9d9d-9fa62df52976}, !- Handle
+  Surface 28,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4f4e9b54-23d0-4f7d-9579-433e50ce52c6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
+  94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {7e12c6b0-b711-408a-b64a-6503ddc95a7a}, !- Handle
+  Surface 29,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {863a2caf-a847-407f-938b-fcf296906f82}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0e8aa32f-fb05-4470-9e34-c017536af1f4}, !- Handle
+  Surface 30,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {1a44d5e9-ea66-4a8e-8d2c-56c4b7148323}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {eb4bb665-2217-4331-84f3-b0b179e0523f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 44, 4,                              !- X,Y,Z Vertex 2 {m}
+  0, 44, 4,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:BuildingStory,
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Handle
+  Story 2,                                !- Name
+  4,                                      !- Nominal Z Coordinate {m}
+  4,                                      !- Nominal Floor to Floor Height {m}
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ;                                       !- Group Rendering Name
+
+OS:Space,
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Handle
+  Story 2 West Perimeter Space,           !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  4,                                      !- Z Origin {m}
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Building Story Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}; !- Thermal Zone Name
+
+OS:Surface,
+  {a48a4cb9-5612-43a1-808b-8e8f61e8d175}, !- Handle
+  Surface 31,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {ff290be8-e615-4560-9b8a-f035133a4280}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 3, 0;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {36641ebf-802a-4d0b-8244-b3f1a4309b9c}, !- Handle
+  Surface 32,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 50, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {7c28bfa8-2549-4dae-9edc-09308d4adc38}, !- Handle
+  Surface 33,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {acb25d45-d090-48c5-989a-9a7890788e74}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 50, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 50, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a93f8ce6-d2d4-44f0-b1af-fd3db9db65ec}, !- Handle
+  Surface 34,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {eae5a741-78f1-4a1b-ac55-f9d437203a8b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ced1ec2b-2191-4277-aede-ecf0d41fa59b}, !- Handle
+  Surface 35,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6612b662-fa28-4c42-b557-dffd496e6a67}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {9cd5baba-1508-4ae3-a4ac-022095b0e045}, !- Handle
+  Surface 36,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {7db6b74b-1f72-4f42-9110-36fe3a453531}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 47, 4,                               !- X,Y,Z Vertex 2 {m}
+  0, 50, 4,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Handle
+  Story 2 North Perimeter Space,          !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  3,                                      !- X Origin {m}
+  47,                                     !- Y Origin {m}
+  4,                                      !- Z Origin {m}
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Building Story Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}; !- Thermal Zone Name
+
+OS:Surface,
+  {40602bcf-0fcc-42a3-b052-9f0b2c12c115}, !- Handle
+  Surface 37,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a5d6e2a6-64d5-43cb-b1a8-b7917fd9d278}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  -3, 3, 0,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {96b20eed-d318-45a3-857f-7b6d87b5b015}, !- Handle
+  Surface 38,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  -3, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {064fa11c-66ff-4592-bb4c-5c330ebe7a50}, !- Handle
+  Surface 39,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {85e316e0-a065-4c4a-923a-4f153f12a302}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {2875241c-0c2b-4cd7-8b09-4304d501b37b}, !- Handle
+  Surface 40,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {8c404ea8-2b4e-428c-b00a-8e1942da2391}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {acb25d45-d090-48c5-989a-9a7890788e74}, !- Handle
+  Surface 41,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {7c28bfa8-2549-4dae-9edc-09308d4adc38}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  -3, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  -3, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {9f1fd48d-c930-47a7-9270-38e8699b00cc}, !- Handle
+  Surface 42,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {aee2fa6a-2053-43cf-a76c-0baab26dc0ea}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  94, 0, 4,                               !- X,Y,Z Vertex 2 {m}
+  97, 3, 4,                               !- X,Y,Z Vertex 3 {m}
+  -3, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Handle
+  Story 2 East Perimeter Space,           !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  97,                                     !- X Origin {m}
+  3,                                      !- Y Origin {m}
+  4,                                      !- Z Origin {m}
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Building Story Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}; !- Thermal Zone Name
+
+OS:Surface,
+  {292dfbfc-90c2-41cb-ba14-38936617c472}, !- Handle
+  Surface 43,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0f339a30-6ac8-41ae-8811-36514eb5f97f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 0,                               !- X,Y,Z Vertex 1 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 44, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {3d83a5af-e289-44b7-a36b-07c0f3846185}, !- Handle
+  Surface 44,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, -3, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1a4a2df1-09a9-453c-b69e-6aacdce14424}, !- Handle
+  Surface 45,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {b19c37d9-f6cc-4188-9c36-e7ddcf8f0373}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, -3, 0,                               !- X,Y,Z Vertex 3 {m}
+  3, -3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {d9f095c2-b50a-40be-bb90-2008062d6971}, !- Handle
+  Surface 46,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {ea966561-b387-4980-b8ff-4504a4751742}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {85e316e0-a065-4c4a-923a-4f153f12a302}, !- Handle
+  Surface 47,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {064fa11c-66ff-4592-bb4c-5c330ebe7a50}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 47, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 47, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1c12cfe0-4db6-486c-bea1-5de8ca0bad99}, !- Handle
+  Surface 48,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {8140c6de-6af4-4c81-844f-2685db801cee}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 0, 4,                                !- X,Y,Z Vertex 2 {m}
+  3, -3, 4,                               !- X,Y,Z Vertex 3 {m}
+  3, 47, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Handle
+  Story 2 South Perimeter Space,          !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  4,                                      !- Z Origin {m}
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Building Story Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}; !- Thermal Zone Name
+
+OS:Surface,
+  {56804c11-7f6e-4542-8df3-6833f85f443a}, !- Handle
+  Surface 49,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {3cddeb2f-dfc3-4026-a05a-a69a356610db}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  100, 0, 0,                              !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  97, 3, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a12b7c6c-9a2d-4a02-a5d5-fa839b1ecccf}, !- Handle
+  Surface 50,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  100, 0, 0,                              !- X,Y,Z Vertex 3 {m}
+  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {6612b662-fa28-4c42-b557-dffd496e6a67}, !- Handle
+  Surface 51,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {ced1ec2b-2191-4277-aede-ecf0d41fa59b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  3, 3, 4,                                !- X,Y,Z Vertex 1 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {6ef965e1-2041-4df9-8fa8-7abf7d776124}, !- Handle
+  Surface 52,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a5351280-5b37-40d6-b0a3-a3e56b05421d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 2 {m}
+  3, 3, 0,                                !- X,Y,Z Vertex 3 {m}
+  3, 3, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {b19c37d9-f6cc-4188-9c36-e7ddcf8f0373}, !- Handle
+  Surface 53,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1a4a2df1-09a9-453c-b69e-6aacdce14424}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  100, 0, 4,                              !- X,Y,Z Vertex 1 {m}
+  100, 0, 0,                              !- X,Y,Z Vertex 2 {m}
+  97, 3, 0,                               !- X,Y,Z Vertex 3 {m}
+  97, 3, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ea86ff87-0751-4db8-8b1f-b6ffa074ea6c}, !- Handle
+  Surface 54,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {775a574f-d72c-4ce9-9a10-9e547d58f04f}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  97, 3, 4,                               !- X,Y,Z Vertex 1 {m}
+  3, 3, 4,                                !- X,Y,Z Vertex 2 {m}
+  0, 0, 4,                                !- X,Y,Z Vertex 3 {m}
+  100, 0, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Space,
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Handle
+  Story 2 Core Space,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  -0,                                     !- Direction of Relative North {deg}
+  3,                                      !- X Origin {m}
+  3,                                      !- Y Origin {m}
+  4,                                      !- Z Origin {m}
+  {c962f202-c98f-4ee7-8fac-ebe9553b3172}, !- Building Story Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}; !- Thermal Zone Name
+
+OS:Surface,
+  {eb4bb665-2217-4331-84f3-b0b179e0523f}, !- Handle
+  Surface 55,                             !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0e8aa32f-fb05-4470-9e34-c017536af1f4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
+  94, 0, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {eae5a741-78f1-4a1b-ac55-f9d437203a8b}, !- Handle
+  Surface 56,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a93f8ce6-d2d4-44f0-b1af-fd3db9db65ec}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 44, 4,                               !- X,Y,Z Vertex 1 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {8c404ea8-2b4e-428c-b00a-8e1942da2391}, !- Handle
+  Surface 57,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {2875241c-0c2b-4cd7-8b09-4304d501b37b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 44, 4,                              !- X,Y,Z Vertex 1 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 2 {m}
+  0, 44, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 44, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ea966561-b387-4980-b8ff-4504a4751742}, !- Handle
+  Surface 58,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {d9f095c2-b50a-40be-bb90-2008062d6971}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 2 {m}
+  94, 44, 0,                              !- X,Y,Z Vertex 3 {m}
+  94, 44, 4;                              !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a5351280-5b37-40d6-b0a3-a3e56b05421d}, !- Handle
+  Surface 59,                             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6ef965e1-2041-4df9-8fa8-7abf7d776124}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 4,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  94, 0, 0,                               !- X,Y,Z Vertex 3 {m}
+  94, 0, 4;                               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {79c6ce3e-5ebd-463c-90be-6629cad3469b}, !- Handle
+  Surface 60,                             !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {bfec0f2a-97e4-4131-ae5d-34d3d8385a18}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  94, 0, 4,                               !- X,Y,Z Vertex 1 {m}
+  94, 44, 4,                              !- X,Y,Z Vertex 2 {m}
+  0, 44, 4,                               !- X,Y,Z Vertex 3 {m}
+  0, 0, 4;                                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- Handle
+  Story 1 Core Thermal Zone,              !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {2843a47f-9d1b-4cc9-a3fa-affd0a3bef39}, !- Zone Air Inlet Port List
+  {95a73835-afb1-4f1a-b9af-78eee69c7595}, !- Zone Air Exhaust Port List
+  {6449cc62-0852-43c0-a4f7-615879c8ef1f}, !- Zone Air Node Name
+  {a352b1e4-5e4c-4ab1-9599-76b40a86fcc8}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {4eb27ebf-9f00-4959-923e-69dc2ecad705}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {29d6ccec-af66-4672-8324-98f0692c4ad3}, !- Handle
+  Node 1,                                 !- Name
+  {6449cc62-0852-43c0-a4f7-615879c8ef1f}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {6449cc62-0852-43c0-a4f7-615879c8ef1f}, !- Handle
+  {85fc62a7-62a6-4550-bf16-5d9fab195cbf}, !- Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- Source Object
+  11,                                     !- Outlet Port
+  {29d6ccec-af66-4672-8324-98f0692c4ad3}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {2843a47f-9d1b-4cc9-a3fa-affd0a3bef39}, !- Handle
+  {942b305f-0765-42be-9601-ff634f41fb7c}, !- Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- HVAC Component
+  {fa153a84-fa19-48e3-85a0-fa9a38ba36a3}; !- Port 1
+
+OS:PortList,
+  {95a73835-afb1-4f1a-b9af-78eee69c7595}, !- Handle
+  {40424d9b-b193-4720-b8e3-aa9d5ae840a8}, !- Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}; !- HVAC Component
+
+OS:PortList,
+  {a352b1e4-5e4c-4ab1-9599-76b40a86fcc8}, !- Handle
+  {6c7c38c1-7fda-46a2-87fb-135cd3eab458}, !- Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- HVAC Component
+  {c67a7145-06a6-496a-ad9f-382fc7327182}; !- Port 1
+
+OS:Sizing:Zone,
+  {98c782d4-0b03-47b4-af4a-5f2fa690f136}, !- Handle
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {e6d751e8-66ce-4456-b01e-916338dc677e}, !- Handle
+  Zone HVAC Equipment List 1,             !- Name
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {e78e6fec-c27d-4739-81d7-37264f8b8620}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- Handle
+  Story 1 East Perimeter Thermal Zone,    !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {18fe0af3-63f0-48e6-a4db-3e3f2ea37e3c}, !- Zone Air Inlet Port List
+  {4855fc32-e070-4dd5-a59b-d9c405889cda}, !- Zone Air Exhaust Port List
+  {ec4b011e-0da1-4dfd-9de1-433a5d625e98}, !- Zone Air Node Name
+  {97d73549-c1a6-487d-9a66-7a7c75bebf3a}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {04e5a183-e49a-4d06-9d48-e4590475bd5b}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {6cdb6ae3-9669-4b27-b9ef-b9577634651d}, !- Handle
+  Node 2,                                 !- Name
+  {ec4b011e-0da1-4dfd-9de1-433a5d625e98}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {ec4b011e-0da1-4dfd-9de1-433a5d625e98}, !- Handle
+  {7282ca84-2fd1-44f9-a7a7-bb83de571bf5}, !- Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- Source Object
+  11,                                     !- Outlet Port
+  {6cdb6ae3-9669-4b27-b9ef-b9577634651d}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {18fe0af3-63f0-48e6-a4db-3e3f2ea37e3c}, !- Handle
+  {d7455f1e-b5a0-42c5-9d27-7c149b37f3fe}, !- Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- HVAC Component
+  {c015e6df-8a94-4719-bda9-e768324c3430}; !- Port 1
+
+OS:PortList,
+  {4855fc32-e070-4dd5-a59b-d9c405889cda}, !- Handle
+  {2ee36ad8-e0fe-4207-8954-fd87335b28d4}, !- Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}; !- HVAC Component
+
+OS:PortList,
+  {97d73549-c1a6-487d-9a66-7a7c75bebf3a}, !- Handle
+  {49fcf903-0c59-4f6c-832d-b1d2b1f61302}, !- Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- HVAC Component
+  {147cda33-b1be-4bf3-8f23-9895587d99d9}; !- Port 1
+
+OS:Sizing:Zone,
+  {946b3728-ca95-40f7-8447-37cb2414bbba}, !- Handle
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {dc4b2aa9-db64-41a8-b4a7-9891cacaf963}, !- Handle
+  Zone HVAC Equipment List 2,             !- Name
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {255d2fc1-fd88-49cc-bda0-064637cb454c}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- Handle
+  Story 1 North Perimeter Thermal Zone,   !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {ee9db51b-2647-4267-ac53-531835fe4e7f}, !- Zone Air Inlet Port List
+  {dc2a016d-4714-464e-8957-76452de3500e}, !- Zone Air Exhaust Port List
+  {7bc70fd4-96de-4910-ba78-0064bad7b605}, !- Zone Air Node Name
+  {ffcdb616-0a69-4458-99d5-7f5f97328ba8}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {79d75e60-251d-4902-bc0b-d00388361c85}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {282e1bec-68cb-437f-885e-622f56923888}, !- Handle
+  Node 3,                                 !- Name
+  {7bc70fd4-96de-4910-ba78-0064bad7b605}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {7bc70fd4-96de-4910-ba78-0064bad7b605}, !- Handle
+  {179f8916-979c-446e-85da-f6c9d3f2cbd0}, !- Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- Source Object
+  11,                                     !- Outlet Port
+  {282e1bec-68cb-437f-885e-622f56923888}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {ee9db51b-2647-4267-ac53-531835fe4e7f}, !- Handle
+  {c90697a1-1db4-48e8-a673-d683a01c9b47}, !- Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- HVAC Component
+  {f6c41eeb-45c0-4ef8-891a-be86654df1d6}; !- Port 1
+
+OS:PortList,
+  {dc2a016d-4714-464e-8957-76452de3500e}, !- Handle
+  {08563b13-d3ac-442c-844f-7108a168661c}, !- Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}; !- HVAC Component
+
+OS:PortList,
+  {ffcdb616-0a69-4458-99d5-7f5f97328ba8}, !- Handle
+  {02ee142e-e15f-4821-837f-a1cd41cd6622}, !- Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- HVAC Component
+  {92330d4b-d736-436c-9854-91535e5dc141}; !- Port 1
+
+OS:Sizing:Zone,
+  {c89be4ab-235c-44f2-9eff-978cd656e927}, !- Handle
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {074b2659-874e-4a6d-8f1f-4f2a92df3bda}, !- Handle
+  Zone HVAC Equipment List 3,             !- Name
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {d1fbfcdf-9b3c-4e5a-b79c-6d8f1ff842a9}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- Handle
+  Story 1 South Perimeter Thermal Zone,   !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {361893ba-4b48-469e-b180-c936b4f5c6e7}, !- Zone Air Inlet Port List
+  {41d9992a-9e63-4463-a18b-5ed9bbdfb64a}, !- Zone Air Exhaust Port List
+  {711e7309-1112-4220-94df-82fd897844f7}, !- Zone Air Node Name
+  {6a6600fc-e16f-4da9-929c-6b05c1189a3a}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {ad9f6b5b-4c4d-4f0a-838f-e87d9efce967}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {46f19629-e348-439a-8fa8-85e86d25c698}, !- Handle
+  Node 4,                                 !- Name
+  {711e7309-1112-4220-94df-82fd897844f7}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {711e7309-1112-4220-94df-82fd897844f7}, !- Handle
+  {39a33627-3b05-40f8-a89f-7de19e2311e7}, !- Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- Source Object
+  11,                                     !- Outlet Port
+  {46f19629-e348-439a-8fa8-85e86d25c698}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {361893ba-4b48-469e-b180-c936b4f5c6e7}, !- Handle
+  {d72069cb-5ee9-469d-b7ef-9cc6b96f047e}, !- Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- HVAC Component
+  {278ecb44-56e8-414a-b452-a965193966dd}; !- Port 1
+
+OS:PortList,
+  {41d9992a-9e63-4463-a18b-5ed9bbdfb64a}, !- Handle
+  {4175d8b1-807b-49a1-bd47-a2005250e05e}, !- Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}; !- HVAC Component
+
+OS:PortList,
+  {6a6600fc-e16f-4da9-929c-6b05c1189a3a}, !- Handle
+  {e74446f9-0ea0-4e40-834c-b16c74c20792}, !- Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- HVAC Component
+  {f09ae136-7de8-48f4-8aaf-5d2a9025e530}; !- Port 1
+
+OS:Sizing:Zone,
+  {920328b3-5d12-43dc-a487-efdcbe55a865}, !- Handle
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {08f02e82-9f86-4686-b93a-2b033e66f631}, !- Handle
+  Zone HVAC Equipment List 4,             !- Name
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {836b644e-756d-4c6b-8ace-417dbda0f974}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- Handle
+  Story 1 West Perimeter Thermal Zone,    !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {560c5c30-99f6-4cc3-be13-59c80772e991}, !- Zone Air Inlet Port List
+  {8cd3f3a0-e287-4006-bd01-ac5d02620161}, !- Zone Air Exhaust Port List
+  {a26dad25-fc14-46f1-b4e3-7543eff1d065}, !- Zone Air Node Name
+  {7deb148b-e74b-411c-a111-6046693f968a}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {c93cd97c-604f-46b1-a644-ed5acb910a06}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {aff0f87e-ae88-4258-a4a5-67cf6d641720}, !- Handle
+  Node 5,                                 !- Name
+  {a26dad25-fc14-46f1-b4e3-7543eff1d065}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {a26dad25-fc14-46f1-b4e3-7543eff1d065}, !- Handle
+  {842e36d6-5725-4b12-bae2-c7b45294b2fc}, !- Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- Source Object
+  11,                                     !- Outlet Port
+  {aff0f87e-ae88-4258-a4a5-67cf6d641720}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {560c5c30-99f6-4cc3-be13-59c80772e991}, !- Handle
+  {8142f7c4-fd61-4fee-9bf7-2edfe5e68097}, !- Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- HVAC Component
+  {a4b3edaf-5ebe-4df5-bf59-88ff05cf290a}; !- Port 1
+
+OS:PortList,
+  {8cd3f3a0-e287-4006-bd01-ac5d02620161}, !- Handle
+  {350611c2-b8a7-43ee-b1f9-31c6abf6755f}, !- Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}; !- HVAC Component
+
+OS:PortList,
+  {7deb148b-e74b-411c-a111-6046693f968a}, !- Handle
+  {427ea380-503a-4d4f-9b52-4ba78094c4d9}, !- Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- HVAC Component
+  {6e7b603d-cd5d-405e-a7f4-76cc3eb550ac}; !- Port 1
+
+OS:Sizing:Zone,
+  {4081fdcf-d902-43bb-8e4e-405426a82120}, !- Handle
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {1f94274f-e495-4394-a83d-c146488278bf}, !- Handle
+  Zone HVAC Equipment List 5,             !- Name
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {4de7fb41-c8d1-458e-9e38-0f68fa17c640}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- Handle
+  Story 2 Core Thermal Zone,              !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {f7dd0c47-b5e7-4185-a236-1fd546b72f0a}, !- Zone Air Inlet Port List
+  {63fdfa37-fa7d-4c01-bf34-9b186addda4c}, !- Zone Air Exhaust Port List
+  {c6d5f0a6-97d4-43fa-aa44-69880036cbb6}, !- Zone Air Node Name
+  {143632a7-12f9-4ab9-a95f-b8e2ed43c00a}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {30116d22-051b-4377-89b7-07f281015581}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {884b3aaf-1f2a-4d4c-81ff-c4887d523c66}, !- Handle
+  Node 6,                                 !- Name
+  {c6d5f0a6-97d4-43fa-aa44-69880036cbb6}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c6d5f0a6-97d4-43fa-aa44-69880036cbb6}, !- Handle
+  {65160e33-17f8-47b4-b14b-0b1858a20b73}, !- Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- Source Object
+  11,                                     !- Outlet Port
+  {884b3aaf-1f2a-4d4c-81ff-c4887d523c66}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {f7dd0c47-b5e7-4185-a236-1fd546b72f0a}, !- Handle
+  {078c7363-8790-4793-9f53-88dca4d48484}, !- Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- HVAC Component
+  {d012d69e-50dd-4d84-953c-43e4feb3e529}; !- Port 1
+
+OS:PortList,
+  {63fdfa37-fa7d-4c01-bf34-9b186addda4c}, !- Handle
+  {32bf5e02-f40f-4132-b4b7-d53329ee25e6}, !- Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}; !- HVAC Component
+
+OS:PortList,
+  {143632a7-12f9-4ab9-a95f-b8e2ed43c00a}, !- Handle
+  {5e17d06b-adec-483a-afcb-d46bfb031f26}, !- Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- HVAC Component
+  {3f3ec081-c957-460c-a40e-e8242d80e494}; !- Port 1
+
+OS:Sizing:Zone,
+  {f44699c9-43c2-4884-8f79-55f2dee64a02}, !- Handle
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {b1186304-614e-4052-917d-4f518ffe327c}, !- Handle
+  Zone HVAC Equipment List 6,             !- Name
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {a406fe15-6483-4f33-8c2b-af898a9a2144}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- Handle
+  Story 2 East Perimeter Thermal Zone,    !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {96bff8ff-e52d-43ab-899f-7cdcdafa815a}, !- Zone Air Inlet Port List
+  {4e414adb-8512-43d4-9f99-c9a1ea7d2b43}, !- Zone Air Exhaust Port List
+  {c4f40d78-9847-433e-aced-b42306f6d53e}, !- Zone Air Node Name
+  {43f04564-917d-4242-86b1-a84e44c68ed8}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {6eda21c1-de3d-477c-858a-c872ae4bd83f}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {0f5963c3-fa51-4905-a57d-6a82c44c63af}, !- Handle
+  Node 7,                                 !- Name
+  {c4f40d78-9847-433e-aced-b42306f6d53e}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c4f40d78-9847-433e-aced-b42306f6d53e}, !- Handle
+  {f04fef3f-f6e5-4e06-9fd7-b0af1764fd9f}, !- Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- Source Object
+  11,                                     !- Outlet Port
+  {0f5963c3-fa51-4905-a57d-6a82c44c63af}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {96bff8ff-e52d-43ab-899f-7cdcdafa815a}, !- Handle
+  {ad02fe03-35bc-46a1-a761-2a32aefb47c5}, !- Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- HVAC Component
+  {617951d7-f87a-49ec-9ad3-e789c20ab896}; !- Port 1
+
+OS:PortList,
+  {4e414adb-8512-43d4-9f99-c9a1ea7d2b43}, !- Handle
+  {681aaba2-9280-4d60-8aaf-2d67a1aeaf11}, !- Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}; !- HVAC Component
+
+OS:PortList,
+  {43f04564-917d-4242-86b1-a84e44c68ed8}, !- Handle
+  {446f1e88-d7ce-402c-8cd8-f7a22036bef2}, !- Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- HVAC Component
+  {fed08038-ab86-4f79-a648-41493a09f5bd}; !- Port 1
+
+OS:Sizing:Zone,
+  {4fbc09b9-f2a1-488f-bdfa-708afd3ba8a1}, !- Handle
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {54630f46-6386-41ad-8657-7929e68553a6}, !- Handle
+  Zone HVAC Equipment List 7,             !- Name
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {7c7eb001-b140-4147-9fb9-053f9bf96be9}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- Handle
+  Story 2 North Perimeter Thermal Zone,   !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {87f75aba-f2ed-42f3-b362-f5c995e946bc}, !- Zone Air Inlet Port List
+  {f9ece0ef-5a22-486a-a4df-214c71bf773c}, !- Zone Air Exhaust Port List
+  {bae84c0d-77f5-4428-a33c-5a6f797e1e02}, !- Zone Air Node Name
+  {6ee3f473-d624-4484-ba66-8a197f2dd9ff}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {a851d184-9b3e-41e6-a41a-e08db15c0b16}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {4e28c6d0-f399-4d98-9317-9913606e69ca}, !- Handle
+  Node 8,                                 !- Name
+  {bae84c0d-77f5-4428-a33c-5a6f797e1e02}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {bae84c0d-77f5-4428-a33c-5a6f797e1e02}, !- Handle
+  {b24a8a66-19dd-442b-bdc1-baf2571de6a5}, !- Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- Source Object
+  11,                                     !- Outlet Port
+  {4e28c6d0-f399-4d98-9317-9913606e69ca}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {87f75aba-f2ed-42f3-b362-f5c995e946bc}, !- Handle
+  {3f637421-843c-4482-939d-978377f123e9}, !- Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- HVAC Component
+  {b8270d1d-b79c-4642-ae43-8bb5d896b8df}; !- Port 1
+
+OS:PortList,
+  {f9ece0ef-5a22-486a-a4df-214c71bf773c}, !- Handle
+  {48aa1475-814e-449e-9c93-d0f92086af0a}, !- Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}; !- HVAC Component
+
+OS:PortList,
+  {6ee3f473-d624-4484-ba66-8a197f2dd9ff}, !- Handle
+  {c5e68d30-7ede-4b22-b513-e4137a8b251b}, !- Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- HVAC Component
+  {74243c2f-6a41-4e0f-85f6-fac38ad9b368}; !- Port 1
+
+OS:Sizing:Zone,
+  {74402f0b-22c2-4a96-99f8-e4f5381be6e4}, !- Handle
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {d28b8e48-5233-4bc0-82fe-ae41c4cf7db4}, !- Handle
+  Zone HVAC Equipment List 8,             !- Name
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {41e1dd69-d076-47a0-92eb-9ca7e2b74960}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- Handle
+  Story 2 South Perimeter Thermal Zone,   !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {cf6a1fdc-227d-4566-94e8-0775a3b81b88}, !- Zone Air Inlet Port List
+  {0f18a7df-a0dc-4d7b-897b-1408170fca25}, !- Zone Air Exhaust Port List
+  {36268b3b-caab-4bde-9e2d-7ea312f758d0}, !- Zone Air Node Name
+  {d7254e50-6d58-4d69-af8c-894ac16cd5f0}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {cd5b44a6-a3c0-4b50-b427-99b251cb97cc}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {e09bd855-c596-45a3-b999-453f681c8201}, !- Handle
+  Node 9,                                 !- Name
+  {36268b3b-caab-4bde-9e2d-7ea312f758d0}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {36268b3b-caab-4bde-9e2d-7ea312f758d0}, !- Handle
+  {39075c29-42e2-4f90-8429-e7e9adfd063f}, !- Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- Source Object
+  11,                                     !- Outlet Port
+  {e09bd855-c596-45a3-b999-453f681c8201}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {cf6a1fdc-227d-4566-94e8-0775a3b81b88}, !- Handle
+  {e64f1d39-1623-4738-8b66-d98776e1d47a}, !- Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- HVAC Component
+  {c623d4cb-f69c-4468-9b57-74d721fa34cc}; !- Port 1
+
+OS:PortList,
+  {0f18a7df-a0dc-4d7b-897b-1408170fca25}, !- Handle
+  {483a33d0-a3a7-4773-b17a-5c1f1683116b}, !- Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}; !- HVAC Component
+
+OS:PortList,
+  {d7254e50-6d58-4d69-af8c-894ac16cd5f0}, !- Handle
+  {d5d1f143-5f4d-45c2-8d1e-03fc4184b5b5}, !- Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- HVAC Component
+  {c034a9f5-01a9-441d-8a03-e2bf8763394b}; !- Port 1
+
+OS:Sizing:Zone,
+  {5bb01c92-c1c0-424f-b69f-a39f80900576}, !- Handle
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {d12fe66f-a22f-4a09-bf31-ef82823618fc}, !- Handle
+  Zone HVAC Equipment List 9,             !- Name
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {5a5c4428-b261-4681-8ef1-3586cca0a8de}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:ThermalZone,
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- Handle
+  Story 2 West Perimeter Thermal Zone,    !- Name
+  ,                                       !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {3ae89c27-f399-431e-abe6-950d0acd2603}, !- Zone Air Inlet Port List
+  {9bc8e004-6521-4f67-ba32-95280058829a}, !- Zone Air Exhaust Port List
+  {a1941340-93a6-4bcf-918f-540302135b30}, !- Zone Air Node Name
+  {1dd2ff4e-afe8-471e-9ea8-1a0cd85e704f}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {3092098e-d518-4569-89ff-0de053382346}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {586fbf32-7250-4954-8e79-fb612ef29b6a}, !- Handle
+  Node 10,                                !- Name
+  {a1941340-93a6-4bcf-918f-540302135b30}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {a1941340-93a6-4bcf-918f-540302135b30}, !- Handle
+  {2e452fc2-c326-4de7-b86a-593fe9ab32ab}, !- Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- Source Object
+  11,                                     !- Outlet Port
+  {586fbf32-7250-4954-8e79-fb612ef29b6a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {3ae89c27-f399-431e-abe6-950d0acd2603}, !- Handle
+  {93aaf805-8b74-4f4c-b7c4-b366bcdecb22}, !- Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- HVAC Component
+  {fac1042d-3a54-434b-b937-b437254551a4}; !- Port 1
+
+OS:PortList,
+  {9bc8e004-6521-4f67-ba32-95280058829a}, !- Handle
+  {c918d055-a7a0-41b5-8123-aa436c723dbb}, !- Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}; !- HVAC Component
+
+OS:PortList,
+  {1dd2ff4e-afe8-471e-9ea8-1a0cd85e704f}, !- Handle
+  {72db14c9-95b4-45e4-a59a-3c22a19f9868}, !- Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- HVAC Component
+  {ee29408f-83fd-4525-916a-aaf072686a92}; !- Port 1
+
+OS:Sizing:Zone,
+  {8c264b29-455e-495e-9932-0637771b1640}, !- Handle
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ,                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize;                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+
+OS:ZoneHVAC:EquipmentList,
+  {1434ef10-ae34-496f-b2dc-2729688c4af5}, !- Handle
+  Zone HVAC Equipment List 10,            !- Name
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {b855d341-cd0f-49b9-843a-7f7f2c3c11da}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+
+OS:SubSurface,
+  {c3c0ce9b-95f3-4dde-81a0-388120903198}, !- Handle
+  Sub Surface 1,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {a12b7c6c-9a2d-4a02-a5d5-fa839b1ecccf}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
+  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
+  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
+  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {3d071020-8d3b-4959-b249-628d0f315466}, !- Handle
+  Sub Surface 2,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {3d83a5af-e289-44b7-a36b-07c0f3846185}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
+  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {ed34bef8-2c45-4af8-9ddb-4567f0fe7b68}, !- Handle
+  Sub Surface 3,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {a7659f94-99bf-4ef6-a195-406885a777b9}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  3, -2.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  3, -2.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  3, 46.9746, 1,                          !- X,Y,Z Vertex 3 {m}
+  3, 46.9746, 2.60162725328934;           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {ac129f41-86bd-4b9d-b125-5df9878f3640}, !- Handle
+  Sub Surface 4,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {36641ebf-802a-4d0b-8244-b3f1a4309b9c}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 49.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  0, 49.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  0, 0.0254000000000048, 1,               !- X,Y,Z Vertex 3 {m}
+  0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {205bafb4-f688-4355-afd1-30a8363c270e}, !- Handle
+  Sub Surface 5,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {4c21fe1a-1959-475d-b2e1-40b6d145dac2}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
+  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
+  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
+  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {6b9dc277-cbff-42e3-b6e1-58e0c7d0b773}, !- Handle
+  Sub Surface 6,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {f8dd0deb-ec2f-4079-bfcc-73d4c9eaee27}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 49.9746, 2.60162725328934,           !- X,Y,Z Vertex 1 {m}
+  0, 49.9746, 1,                          !- X,Y,Z Vertex 2 {m}
+  0, 0.0254000000000048, 1,               !- X,Y,Z Vertex 3 {m}
+  0, 0.0254000000000048, 2.60162725328934; !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {555e2ed1-7d71-438f-8a59-17b18d84936c}, !- Handle
+  Sub Surface 7,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {f51653e3-934b-480a-80e5-6b664b2f4f3f}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  0.0254, 0, 2.60081321311226,            !- X,Y,Z Vertex 1 {m}
+  0.0254, 0, 1,                           !- X,Y,Z Vertex 2 {m}
+  99.9746, 0, 1,                          !- X,Y,Z Vertex 3 {m}
+  99.9746, 0, 2.60081321311226;           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {25d9d153-b44e-42ed-bd5f-17b8105cb89c}, !- Handle
+  Sub Surface 8,                          !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {96b20eed-d318-45a3-857f-7b6d87b5b015}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  96.9746, 3, 2.60081321311226,           !- X,Y,Z Vertex 1 {m}
+  96.9746, 3, 1,                          !- X,Y,Z Vertex 2 {m}
+  -2.97460000000001, 3, 1,                !- X,Y,Z Vertex 3 {m}
+  -2.97460000000001, 3, 2.60081321311226; !- X,Y,Z Vertex 4 {m}
+
+OS:Schedule:Constant,
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Handle
+  Always On Discrete,                     !- Name
+  {65de7ee7-fda0-4d74-8319-55a9897ee107}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {65de7ee7-fda0-4d74-8319-55a9897ee107}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:AirLoopHVAC,
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- Handle
+  Packaged Rooftop Air Conditioner,       !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {955cadf1-224b-497f-9f99-6d9da788cd16}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {c3f26cb7-8f57-4475-8814-8f48985f34ff}, !- Supply Side Inlet Node Name
+  {ced0783e-acfb-468c-973d-70660630a02c}, !- Demand Side Outlet Node Name
+  {f5ef169a-a4e3-488d-bc58-3263b215432f}, !- Demand Side Inlet Node A
+  {ac8f6c34-7b4c-48ba-8ec0-3bf6bcba6aa9}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {12fd55dd-96bc-40db-af83-e32a003e2699}, !- Demand Mixer Name
+  {9f10ca2c-b253-4bd3-87e7-23d48fea902d}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {cb4ed692-43ee-4fbf-aa43-0bfb8a0351fc}, !- Handle
+  Node 11,                                !- Name
+  {c3f26cb7-8f57-4475-8814-8f48985f34ff}, !- Inlet Port
+  {68fdea03-b689-4b90-ac51-02a32bd15a93}; !- Outlet Port
+
+OS:Node,
+  {594a66b4-c0fa-47a7-8e61-7c5bbc842eeb}, !- Handle
+  Node 12,                                !- Name
+  {fd33fd94-1a93-477a-8b78-b58c1259b5de}, !- Inlet Port
+  {ac8f6c34-7b4c-48ba-8ec0-3bf6bcba6aa9}; !- Outlet Port
+
+OS:Connection,
+  {c3f26cb7-8f57-4475-8814-8f48985f34ff}, !- Handle
+  {e1c0fa19-79ac-41b6-9988-31e3a0d242b3}, !- Name
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- Source Object
+  8,                                      !- Outlet Port
+  {cb4ed692-43ee-4fbf-aa43-0bfb8a0351fc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {ac8f6c34-7b4c-48ba-8ec0-3bf6bcba6aa9}, !- Handle
+  {1b165137-1b61-4d91-a26b-4c6565199f99}, !- Name
+  {594a66b4-c0fa-47a7-8e61-7c5bbc842eeb}, !- Source Object
+  3,                                      !- Outlet Port
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {fba60e2b-ba3a-471c-8532-69777628c125}, !- Handle
+  Node 13,                                !- Name
+  {f5ef169a-a4e3-488d-bc58-3263b215432f}, !- Inlet Port
+  {762c565e-df06-4d28-b92b-350754f00217}; !- Outlet Port
+
+OS:Node,
+  {f7b0e138-ca65-4f29-9d8c-076b6af297ec}, !- Handle
+  Node 14,                                !- Name
+  {d29e227b-5311-4c94-93be-6d6905873498}, !- Inlet Port
+  {ced0783e-acfb-468c-973d-70660630a02c}; !- Outlet Port
+
+OS:Node,
+  {fad5963a-2a07-4418-89c1-84c34c40397b}, !- Handle
+  Node 15,                                !- Name
+  {b0575b6e-e3bd-401c-a7d0-41f7ebdf36d8}, !- Inlet Port
+  {fa153a84-fa19-48e3-85a0-fa9a38ba36a3}; !- Outlet Port
+
+OS:Connection,
+  {f5ef169a-a4e3-488d-bc58-3263b215432f}, !- Handle
+  {8df4335c-987d-406c-8796-d4023c9ac606}, !- Name
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- Source Object
+  10,                                     !- Outlet Port
+  {fba60e2b-ba3a-471c-8532-69777628c125}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {ced0783e-acfb-468c-973d-70660630a02c}, !- Handle
+  {67fa692b-c859-4fbd-9465-074c0249b800}, !- Name
+  {f7b0e138-ca65-4f29-9d8c-076b6af297ec}, !- Source Object
+  3,                                      !- Outlet Port
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {9f10ca2c-b253-4bd3-87e7-23d48fea902d}, !- Handle
+  Air Loop HVAC Zone Splitter 1,          !- Name
+  {762c565e-df06-4d28-b92b-350754f00217}, !- Inlet Node Name
+  {93b3c35c-5f01-4de6-852b-14f8f4c3b3d9}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {12fd55dd-96bc-40db-af83-e32a003e2699}, !- Handle
+  Air Loop HVAC Zone Mixer 1,             !- Name
+  {d29e227b-5311-4c94-93be-6d6905873498}, !- Outlet Node Name
+  {857bc243-8b63-4149-ac0c-a8fc728de47d}; !- Inlet Node Name 1
+
+OS:Connection,
+  {762c565e-df06-4d28-b92b-350754f00217}, !- Handle
+  {d1e963ec-4662-45d7-abb0-4f06cb14d9cd}, !- Name
+  {fba60e2b-ba3a-471c-8532-69777628c125}, !- Source Object
+  3,                                      !- Outlet Port
+  {9f10ca2c-b253-4bd3-87e7-23d48fea902d}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d29e227b-5311-4c94-93be-6d6905873498}, !- Handle
+  {a75b6e3d-c73b-4f57-b1de-66d9f2087507}, !- Name
+  {12fd55dd-96bc-40db-af83-e32a003e2699}, !- Source Object
+  2,                                      !- Outlet Port
+  {f7b0e138-ca65-4f29-9d8c-076b6af297ec}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {e4ea427d-4e0a-46d5-9185-5de30292ed35}, !- Handle
+  {7222c734-ae8b-4887-b4f3-061a8782764f}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {955cadf1-224b-497f-9f99-6d9da788cd16}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList; !- Name
+
+OS:Fan:ConstantVolume,
+  {b231c2df-0ebb-46de-bfd0-840afb729dbf}, !- Handle
+  Fan Constant Volume 1,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {21a99a67-1522-4a0f-a386-023bf887be19}, !- Air Inlet Node Name
+  {fd33fd94-1a93-477a-8b78-b58c1259b5de}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {2f01d031-012d-467b-9e17-0f7662e2381f}, !- Handle
+  Coil Heating Gas 1,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {a4184250-139e-49ef-a5f9-4373e6606d7a}, !- Air Inlet Node Name
+  {bf6821f6-869c-41b8-9a5d-00de1d85478b}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {12f56495-b766-44bd-8c75-fb319b35702d}, !- Handle
+  Coil Cooling DX Single Speed 1,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {e26aa11f-cf9f-47e6-9551-6da01140a46a}, !- Air Inlet Node Name
+  {ff191e69-153c-4479-bc06-05069a8300f6}, !- Air Outlet Node Name
+  {e6e00a70-8609-474b-9119-5c493d51c91e}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {54ce298d-400a-4ec6-b591-10bed71b3f53}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {2ce37d73-3e2d-4ae6-97d4-ad6d7cd1edc8}, !- Energy Input Ratio Function of Temperature Curve Name
+  {694514a3-987e-41c7-9e9b-655d8a90327d}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {9e580b13-5de8-4dd4-9e63-5a947d860285}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {e6e00a70-8609-474b-9119-5c493d51c91e}, !- Handle
+  Curve Biquadratic 1,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {54ce298d-400a-4ec6-b591-10bed71b3f53}, !- Handle
+  Curve Quadratic 1,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {2ce37d73-3e2d-4ae6-97d4-ad6d7cd1edc8}, !- Handle
+  Curve Biquadratic 2,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {694514a3-987e-41c7-9e9b-655d8a90327d}, !- Handle
+  Curve Quadratic 2,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {9e580b13-5de8-4dd4-9e63-5a947d860285}, !- Handle
+  Curve Quadratic 3,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {6cdb53fd-4de7-48b1-a0c6-8e73a7b05e4c}, !- Handle
+  Setpoint Manager Single Zone Reheat 1,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {3e93cb77-fb9c-4989-9f5b-59a26a8ff50c}, !- Control Zone Name
+  {594a66b4-c0fa-47a7-8e61-7c5bbc842eeb}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {8669b410-9ad3-4bb3-a40e-1996ee674add}, !- Handle
+  Controller Outdoor Air 1,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {3bcab871-e0a7-4eaf-a43a-1d8bbcdd4d0e}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {3bcab871-e0a7-4eaf-a43a-1d8bbcdd4d0e}, !- Handle
+  Controller Mechanical Ventilation 1,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {7917406a-012f-400a-947a-60a46baa4e57}, !- Handle
+  Air Loop HVAC Outdoor Air System 1,     !- Name
+  {8669b410-9ad3-4bb3-a40e-1996ee674add}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {d7f53afb-3b77-44a2-b31f-d24b45d0be69}, !- Mixed Air Node Name
+  {16a2ef45-e5ae-4c11-850c-9f3ba909967d}, !- Outdoor Air Stream Node Name
+  {c1c941bc-0a36-4262-b717-ab2fb15439dc}, !- Relief Air Stream Node Name
+  {68fdea03-b689-4b90-ac51-02a32bd15a93}; !- Return Air Stream Node Name
+
+OS:Node,
+  {5dc1cc25-3275-4296-9508-7b586c23fc8f}, !- Handle
+  Node 16,                                !- Name
+  ,                                       !- Inlet Port
+  {16a2ef45-e5ae-4c11-850c-9f3ba909967d}; !- Outlet Port
+
+OS:Connection,
+  {16a2ef45-e5ae-4c11-850c-9f3ba909967d}, !- Handle
+  {a8e38372-2db5-48d3-832b-468c73f47681}, !- Name
+  {5dc1cc25-3275-4296-9508-7b586c23fc8f}, !- Source Object
+  3,                                      !- Outlet Port
+  {7917406a-012f-400a-947a-60a46baa4e57}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {14832ca7-0bc5-4214-8926-fcfc43b75e57}, !- Handle
+  Node 17,                                !- Name
+  {c1c941bc-0a36-4262-b717-ab2fb15439dc}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c1c941bc-0a36-4262-b717-ab2fb15439dc}, !- Handle
+  {564413c0-8073-482a-8940-6b76aeceaaa9}, !- Name
+  {7917406a-012f-400a-947a-60a46baa4e57}, !- Source Object
+  7,                                      !- Outlet Port
+  {14832ca7-0bc5-4214-8926-fcfc43b75e57}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {68fdea03-b689-4b90-ac51-02a32bd15a93}, !- Handle
+  {a1951c50-aacb-437b-82c0-c604483d64fe}, !- Name
+  {cb4ed692-43ee-4fbf-aa43-0bfb8a0351fc}, !- Source Object
+  3,                                      !- Outlet Port
+  {7917406a-012f-400a-947a-60a46baa4e57}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {1fc990c9-5d8b-4131-b139-e7f3b1d2c7ed}, !- Handle
+  Node 18,                                !- Name
+  {d7f53afb-3b77-44a2-b31f-d24b45d0be69}, !- Inlet Port
+  {e26aa11f-cf9f-47e6-9551-6da01140a46a}; !- Outlet Port
+
+OS:Connection,
+  {d7f53afb-3b77-44a2-b31f-d24b45d0be69}, !- Handle
+  {a1cdbffa-0fcb-4d9e-aad3-4a6cae6297bb}, !- Name
+  {7917406a-012f-400a-947a-60a46baa4e57}, !- Source Object
+  5,                                      !- Outlet Port
+  {1fc990c9-5d8b-4131-b139-e7f3b1d2c7ed}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e26aa11f-cf9f-47e6-9551-6da01140a46a}, !- Handle
+  {19fdac86-80fb-4e77-b833-06d73d12f68f}, !- Name
+  {1fc990c9-5d8b-4131-b139-e7f3b1d2c7ed}, !- Source Object
+  3,                                      !- Outlet Port
+  {12f56495-b766-44bd-8c75-fb319b35702d}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {9bdfffd2-3458-4b23-bdc5-0e13b823d7ef}, !- Handle
+  Node 19,                                !- Name
+  {ff191e69-153c-4479-bc06-05069a8300f6}, !- Inlet Port
+  {a4184250-139e-49ef-a5f9-4373e6606d7a}; !- Outlet Port
+
+OS:Connection,
+  {ff191e69-153c-4479-bc06-05069a8300f6}, !- Handle
+  {743178d9-9fd2-4919-8570-722993b2b5e6}, !- Name
+  {12f56495-b766-44bd-8c75-fb319b35702d}, !- Source Object
+  9,                                      !- Outlet Port
+  {9bdfffd2-3458-4b23-bdc5-0e13b823d7ef}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {a4184250-139e-49ef-a5f9-4373e6606d7a}, !- Handle
+  {073807b0-9bb8-4949-b53a-31471874c7c4}, !- Name
+  {9bdfffd2-3458-4b23-bdc5-0e13b823d7ef}, !- Source Object
+  3,                                      !- Outlet Port
+  {2f01d031-012d-467b-9e17-0f7662e2381f}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {697b13c3-47a6-41aa-a97b-0f98a251861d}, !- Handle
+  Node 20,                                !- Name
+  {bf6821f6-869c-41b8-9a5d-00de1d85478b}, !- Inlet Port
+  {21a99a67-1522-4a0f-a386-023bf887be19}; !- Outlet Port
+
+OS:Connection,
+  {bf6821f6-869c-41b8-9a5d-00de1d85478b}, !- Handle
+  {20e263cb-ece6-4048-9c10-0b60700dcd9c}, !- Name
+  {2f01d031-012d-467b-9e17-0f7662e2381f}, !- Source Object
+  6,                                      !- Outlet Port
+  {697b13c3-47a6-41aa-a97b-0f98a251861d}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {21a99a67-1522-4a0f-a386-023bf887be19}, !- Handle
+  {bc075977-8f36-4ef9-ab57-5bf3c5ed111a}, !- Name
+  {697b13c3-47a6-41aa-a97b-0f98a251861d}, !- Source Object
+  3,                                      !- Outlet Port
+  {b231c2df-0ebb-46de-bfd0-840afb729dbf}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {fd33fd94-1a93-477a-8b78-b58c1259b5de}, !- Handle
+  {cd5c3fc5-34e3-4703-b51b-9c54a7b8a55d}, !- Name
+  {b231c2df-0ebb-46de-bfd0-840afb729dbf}, !- Source Object
+  9,                                      !- Outlet Port
+  {594a66b4-c0fa-47a7-8e61-7c5bbc842eeb}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {e78e6fec-c27d-4739-81d7-37264f8b8620}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 1, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {f73d9d18-fd16-48e6-8465-570962de5666}, !- Air Inlet Node Name
+  {b0575b6e-e3bd-401c-a7d0-41f7ebdf36d8}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {de38d5f5-adb1-42e4-b180-94ce9787222a}, !- Handle
+  Node 21,                                !- Name
+  {93b3c35c-5f01-4de6-852b-14f8f4c3b3d9}, !- Inlet Port
+  {f73d9d18-fd16-48e6-8465-570962de5666}; !- Outlet Port
+
+OS:Connection,
+  {93b3c35c-5f01-4de6-852b-14f8f4c3b3d9}, !- Handle
+  {2001b85c-1eb2-473b-ba97-36eb394d9b0f}, !- Name
+  {9f10ca2c-b253-4bd3-87e7-23d48fea902d}, !- Source Object
+  3,                                      !- Outlet Port
+  {de38d5f5-adb1-42e4-b180-94ce9787222a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {f73d9d18-fd16-48e6-8465-570962de5666}, !- Handle
+  {591a45a4-f164-4232-aaeb-2dfda14c7b33}, !- Name
+  {de38d5f5-adb1-42e4-b180-94ce9787222a}, !- Source Object
+  3,                                      !- Outlet Port
+  {e78e6fec-c27d-4739-81d7-37264f8b8620}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {b0575b6e-e3bd-401c-a7d0-41f7ebdf36d8}, !- Handle
+  {90718a01-c0b4-4c88-9775-24b724a81af3}, !- Name
+  {e78e6fec-c27d-4739-81d7-37264f8b8620}, !- Source Object
+  4,                                      !- Outlet Port
+  {fad5963a-2a07-4418-89c1-84c34c40397b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {436b0f3e-fb51-4b27-ab19-ea4b5687f501}, !- Handle
+  Node 22,                                !- Name
+  {c67a7145-06a6-496a-ad9f-382fc7327182}, !- Inlet Port
+  {857bc243-8b63-4149-ac0c-a8fc728de47d}; !- Outlet Port
+
+OS:Connection,
+  {fa153a84-fa19-48e3-85a0-fa9a38ba36a3}, !- Handle
+  {180e8267-d874-4436-ae4c-b0de1a9f5f48}, !- Name
+  {fad5963a-2a07-4418-89c1-84c34c40397b}, !- Source Object
+  3,                                      !- Outlet Port
+  {2843a47f-9d1b-4cc9-a3fa-affd0a3bef39}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {c67a7145-06a6-496a-ad9f-382fc7327182}, !- Handle
+  {e6645347-6ed5-4ac5-80cf-981b0bb1ba58}, !- Name
+  {a352b1e4-5e4c-4ab1-9599-76b40a86fcc8}, !- Source Object
+  3,                                      !- Outlet Port
+  {436b0f3e-fb51-4b27-ab19-ea4b5687f501}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {857bc243-8b63-4149-ac0c-a8fc728de47d}, !- Handle
+  {f4ba0cd1-1e4f-4e3c-9f54-e24c9edb3b0a}, !- Name
+  {436b0f3e-fb51-4b27-ab19-ea4b5687f501}, !- Source Object
+  3,                                      !- Outlet Port
+  {12fd55dd-96bc-40db-af83-e32a003e2699}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- Handle
+  Packaged Rooftop Air Conditioner 1,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {f98b3b31-3a75-4a0a-98f5-4a3396731d21}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {58fb9645-b98f-4b52-81bc-255551a0db0e}, !- Supply Side Inlet Node Name
+  {4732a5f3-70b2-486c-82ed-270a8acf1725}, !- Demand Side Outlet Node Name
+  {e4041b3e-0ec4-46b1-9e20-570296f8cdd1}, !- Demand Side Inlet Node A
+  {345ea00e-8eb7-44f9-98ff-cc3da1af3b35}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {18e0f907-c1a1-48ff-aec8-43a600199969}, !- Demand Mixer Name
+  {d8b46478-5a9b-4b7b-a9cc-7430a549e576}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {80e6ddd4-d7c4-43ad-808a-0b8d68c31752}, !- Handle
+  Node 23,                                !- Name
+  {58fb9645-b98f-4b52-81bc-255551a0db0e}, !- Inlet Port
+  {883e8d06-6519-406c-9940-c3b109e6fb62}; !- Outlet Port
+
+OS:Node,
+  {8c2e77a3-8c15-4e7b-bd3c-904de3825f8f}, !- Handle
+  Node 24,                                !- Name
+  {8df7dcfb-e2c5-4b9e-9621-e34d6512b4a2}, !- Inlet Port
+  {345ea00e-8eb7-44f9-98ff-cc3da1af3b35}; !- Outlet Port
+
+OS:Connection,
+  {58fb9645-b98f-4b52-81bc-255551a0db0e}, !- Handle
+  {b4d54737-5012-46d9-a9b0-e49511062e2f}, !- Name
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- Source Object
+  8,                                      !- Outlet Port
+  {80e6ddd4-d7c4-43ad-808a-0b8d68c31752}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {345ea00e-8eb7-44f9-98ff-cc3da1af3b35}, !- Handle
+  {978a0694-41e7-4299-aece-c87a8fa21c19}, !- Name
+  {8c2e77a3-8c15-4e7b-bd3c-904de3825f8f}, !- Source Object
+  3,                                      !- Outlet Port
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {38e89860-4390-489b-8245-f39288593e9e}, !- Handle
+  Node 25,                                !- Name
+  {e4041b3e-0ec4-46b1-9e20-570296f8cdd1}, !- Inlet Port
+  {b0a6dc97-0dea-4036-b5e5-04e911c6c907}; !- Outlet Port
+
+OS:Node,
+  {c63565f9-7f75-4ef8-ad4d-fad64fe89264}, !- Handle
+  Node 26,                                !- Name
+  {908794a8-2717-407a-a48f-444073019221}, !- Inlet Port
+  {4732a5f3-70b2-486c-82ed-270a8acf1725}; !- Outlet Port
+
+OS:Node,
+  {c86f31d2-3ef7-45e5-9d32-8b037a1c2136}, !- Handle
+  Node 27,                                !- Name
+  {539a9a58-541e-4005-97d3-2022730a9ed5}, !- Inlet Port
+  {c015e6df-8a94-4719-bda9-e768324c3430}; !- Outlet Port
+
+OS:Connection,
+  {e4041b3e-0ec4-46b1-9e20-570296f8cdd1}, !- Handle
+  {fabcc42b-fa8a-4b16-b5e5-c8c57733a0fe}, !- Name
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- Source Object
+  10,                                     !- Outlet Port
+  {38e89860-4390-489b-8245-f39288593e9e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {4732a5f3-70b2-486c-82ed-270a8acf1725}, !- Handle
+  {66accf71-2575-49f6-a103-cbb6c480ef57}, !- Name
+  {c63565f9-7f75-4ef8-ad4d-fad64fe89264}, !- Source Object
+  3,                                      !- Outlet Port
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {d8b46478-5a9b-4b7b-a9cc-7430a549e576}, !- Handle
+  Air Loop HVAC Zone Splitter 2,          !- Name
+  {b0a6dc97-0dea-4036-b5e5-04e911c6c907}, !- Inlet Node Name
+  {2c012a2e-0138-449c-a6e1-b5530cd8e91b}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {18e0f907-c1a1-48ff-aec8-43a600199969}, !- Handle
+  Air Loop HVAC Zone Mixer 2,             !- Name
+  {908794a8-2717-407a-a48f-444073019221}, !- Outlet Node Name
+  {8ba76f55-a8d8-48db-8a64-8faf58905d56}; !- Inlet Node Name 1
+
+OS:Connection,
+  {b0a6dc97-0dea-4036-b5e5-04e911c6c907}, !- Handle
+  {845c0fd1-577d-4e86-b1bf-66c077efa4b1}, !- Name
+  {38e89860-4390-489b-8245-f39288593e9e}, !- Source Object
+  3,                                      !- Outlet Port
+  {d8b46478-5a9b-4b7b-a9cc-7430a549e576}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {908794a8-2717-407a-a48f-444073019221}, !- Handle
+  {6b9e69d5-f5e3-477c-8f5f-91a93248b456}, !- Name
+  {18e0f907-c1a1-48ff-aec8-43a600199969}, !- Source Object
+  2,                                      !- Outlet Port
+  {c63565f9-7f75-4ef8-ad4d-fad64fe89264}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {dfffafa4-4ce8-44b5-8c83-3807832edef9}, !- Handle
+  {f3ad92f0-d307-4092-a40f-cb47f826405f}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {f98b3b31-3a75-4a0a-98f5-4a3396731d21}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 1; !- Name
+
+OS:Fan:ConstantVolume,
+  {2ad3ea7b-8f39-48d3-bd59-dcd5b6259376}, !- Handle
+  Fan Constant Volume 2,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {65db2543-2d47-4d63-a803-b92f4c83cd27}, !- Air Inlet Node Name
+  {8df7dcfb-e2c5-4b9e-9621-e34d6512b4a2}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {9f63138e-0219-4e17-a53a-a2b23c5d6387}, !- Handle
+  Coil Heating Gas 2,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {fc20b6c5-c7e0-4844-90b9-3a6d322eb3c5}, !- Air Inlet Node Name
+  {54b5405e-3aff-441d-a81f-e2418306cb73}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {00ffc017-63ed-46c5-8770-83154c00a1ee}, !- Handle
+  Coil Cooling DX Single Speed 2,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {773d941d-0a6a-4edd-8c76-84edaa591fc5}, !- Air Inlet Node Name
+  {a74cd291-06ea-48ad-9706-a020e4d82b76}, !- Air Outlet Node Name
+  {1a24d98e-fc7e-429f-90ec-bb607f5b215c}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {51993c4e-e726-44ab-944a-16616a63a7a7}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {08846ed2-26ba-4bb4-ac1c-0e4d279b46cd}, !- Energy Input Ratio Function of Temperature Curve Name
+  {977dae9e-2a14-4b77-b71a-150e06856733}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {e3a2a1a2-6e2c-4c5a-b499-8cda0bea726e}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {1a24d98e-fc7e-429f-90ec-bb607f5b215c}, !- Handle
+  Curve Biquadratic 3,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {51993c4e-e726-44ab-944a-16616a63a7a7}, !- Handle
+  Curve Quadratic 4,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {08846ed2-26ba-4bb4-ac1c-0e4d279b46cd}, !- Handle
+  Curve Biquadratic 4,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {977dae9e-2a14-4b77-b71a-150e06856733}, !- Handle
+  Curve Quadratic 5,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {e3a2a1a2-6e2c-4c5a-b499-8cda0bea726e}, !- Handle
+  Curve Quadratic 6,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {8836bdfe-511d-4ea5-bf61-ac4f266761f2}, !- Handle
+  Setpoint Manager Single Zone Reheat 2,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {41d51f5b-b3ef-4c22-b2c7-9511124d3195}, !- Control Zone Name
+  {8c2e77a3-8c15-4e7b-bd3c-904de3825f8f}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {b8c1136b-c29f-48d4-bed7-3c93d7d42140}, !- Handle
+  Controller Outdoor Air 2,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {ef541d0f-ad6e-4544-90f5-628eaefff42e}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {ef541d0f-ad6e-4544-90f5-628eaefff42e}, !- Handle
+  Controller Mechanical Ventilation 2,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {8b1ad890-1313-4110-bca4-5eda6e5b4397}, !- Handle
+  Air Loop HVAC Outdoor Air System 2,     !- Name
+  {b8c1136b-c29f-48d4-bed7-3c93d7d42140}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {ded874b8-57ea-460f-b488-f80e3874367d}, !- Mixed Air Node Name
+  {05aa14e2-9839-49e8-aa9d-d89eb7998f49}, !- Outdoor Air Stream Node Name
+  {47bd191a-bc9e-410d-a810-63e974248780}, !- Relief Air Stream Node Name
+  {883e8d06-6519-406c-9940-c3b109e6fb62}; !- Return Air Stream Node Name
+
+OS:Node,
+  {c31571ac-bc1c-4aa0-907c-4f7aa878834c}, !- Handle
+  Node 28,                                !- Name
+  ,                                       !- Inlet Port
+  {05aa14e2-9839-49e8-aa9d-d89eb7998f49}; !- Outlet Port
+
+OS:Connection,
+  {05aa14e2-9839-49e8-aa9d-d89eb7998f49}, !- Handle
+  {7ba700ce-c403-4b80-9b90-26918e77d06a}, !- Name
+  {c31571ac-bc1c-4aa0-907c-4f7aa878834c}, !- Source Object
+  3,                                      !- Outlet Port
+  {8b1ad890-1313-4110-bca4-5eda6e5b4397}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {71ab92b9-3e7f-4007-83e5-79f78e49d1d8}, !- Handle
+  Node 29,                                !- Name
+  {47bd191a-bc9e-410d-a810-63e974248780}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {47bd191a-bc9e-410d-a810-63e974248780}, !- Handle
+  {2716f801-7c34-4643-8ea8-6707924d1161}, !- Name
+  {8b1ad890-1313-4110-bca4-5eda6e5b4397}, !- Source Object
+  7,                                      !- Outlet Port
+  {71ab92b9-3e7f-4007-83e5-79f78e49d1d8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {883e8d06-6519-406c-9940-c3b109e6fb62}, !- Handle
+  {c65b796a-d387-449a-855e-ea6b5a21976c}, !- Name
+  {80e6ddd4-d7c4-43ad-808a-0b8d68c31752}, !- Source Object
+  3,                                      !- Outlet Port
+  {8b1ad890-1313-4110-bca4-5eda6e5b4397}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {90e5bc96-5f4f-4e3e-bf8c-3aea18fedae1}, !- Handle
+  Node 30,                                !- Name
+  {ded874b8-57ea-460f-b488-f80e3874367d}, !- Inlet Port
+  {773d941d-0a6a-4edd-8c76-84edaa591fc5}; !- Outlet Port
+
+OS:Connection,
+  {ded874b8-57ea-460f-b488-f80e3874367d}, !- Handle
+  {b4e6a3db-4b95-4152-960a-a8c627155e63}, !- Name
+  {8b1ad890-1313-4110-bca4-5eda6e5b4397}, !- Source Object
+  5,                                      !- Outlet Port
+  {90e5bc96-5f4f-4e3e-bf8c-3aea18fedae1}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {773d941d-0a6a-4edd-8c76-84edaa591fc5}, !- Handle
+  {d6d82fd5-587b-4a10-9975-492448d69e25}, !- Name
+  {90e5bc96-5f4f-4e3e-bf8c-3aea18fedae1}, !- Source Object
+  3,                                      !- Outlet Port
+  {00ffc017-63ed-46c5-8770-83154c00a1ee}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {d15a760d-85ff-4385-8e55-3f3f0267d43f}, !- Handle
+  Node 31,                                !- Name
+  {a74cd291-06ea-48ad-9706-a020e4d82b76}, !- Inlet Port
+  {fc20b6c5-c7e0-4844-90b9-3a6d322eb3c5}; !- Outlet Port
+
+OS:Connection,
+  {a74cd291-06ea-48ad-9706-a020e4d82b76}, !- Handle
+  {a54cd36e-cf18-4de1-b191-64e6652851c5}, !- Name
+  {00ffc017-63ed-46c5-8770-83154c00a1ee}, !- Source Object
+  9,                                      !- Outlet Port
+  {d15a760d-85ff-4385-8e55-3f3f0267d43f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {fc20b6c5-c7e0-4844-90b9-3a6d322eb3c5}, !- Handle
+  {e068874d-2f38-4b74-a357-d08d92ab0523}, !- Name
+  {d15a760d-85ff-4385-8e55-3f3f0267d43f}, !- Source Object
+  3,                                      !- Outlet Port
+  {9f63138e-0219-4e17-a53a-a2b23c5d6387}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {ea70a6b3-5cef-4671-b181-29c89cb3b2a9}, !- Handle
+  Node 32,                                !- Name
+  {54b5405e-3aff-441d-a81f-e2418306cb73}, !- Inlet Port
+  {65db2543-2d47-4d63-a803-b92f4c83cd27}; !- Outlet Port
+
+OS:Connection,
+  {54b5405e-3aff-441d-a81f-e2418306cb73}, !- Handle
+  {1592cd5c-8505-4843-a98e-0300a330cb83}, !- Name
+  {9f63138e-0219-4e17-a53a-a2b23c5d6387}, !- Source Object
+  6,                                      !- Outlet Port
+  {ea70a6b3-5cef-4671-b181-29c89cb3b2a9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {65db2543-2d47-4d63-a803-b92f4c83cd27}, !- Handle
+  {41e6799e-1584-4210-b9cc-e0cfd562ba3d}, !- Name
+  {ea70a6b3-5cef-4671-b181-29c89cb3b2a9}, !- Source Object
+  3,                                      !- Outlet Port
+  {2ad3ea7b-8f39-48d3-bd59-dcd5b6259376}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {8df7dcfb-e2c5-4b9e-9621-e34d6512b4a2}, !- Handle
+  {360f9a5d-8477-4242-b65b-5a479fbe4aa7}, !- Name
+  {2ad3ea7b-8f39-48d3-bd59-dcd5b6259376}, !- Source Object
+  9,                                      !- Outlet Port
+  {8c2e77a3-8c15-4e7b-bd3c-904de3825f8f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {255d2fc1-fd88-49cc-bda0-064637cb454c}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 2, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {6c7f3156-4f91-4edc-9210-3150e6030a76}, !- Air Inlet Node Name
+  {539a9a58-541e-4005-97d3-2022730a9ed5}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {5667fcc1-0aec-4a7a-bf6f-1b254b44f3eb}, !- Handle
+  Node 33,                                !- Name
+  {2c012a2e-0138-449c-a6e1-b5530cd8e91b}, !- Inlet Port
+  {6c7f3156-4f91-4edc-9210-3150e6030a76}; !- Outlet Port
+
+OS:Connection,
+  {2c012a2e-0138-449c-a6e1-b5530cd8e91b}, !- Handle
+  {e9a0facd-4ae0-47af-8645-d6d2e555f951}, !- Name
+  {d8b46478-5a9b-4b7b-a9cc-7430a549e576}, !- Source Object
+  3,                                      !- Outlet Port
+  {5667fcc1-0aec-4a7a-bf6f-1b254b44f3eb}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6c7f3156-4f91-4edc-9210-3150e6030a76}, !- Handle
+  {83eaf060-e96e-4984-93d5-1acbe39f776b}, !- Name
+  {5667fcc1-0aec-4a7a-bf6f-1b254b44f3eb}, !- Source Object
+  3,                                      !- Outlet Port
+  {255d2fc1-fd88-49cc-bda0-064637cb454c}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {539a9a58-541e-4005-97d3-2022730a9ed5}, !- Handle
+  {740d321f-d995-416b-9361-7a50f45c2b56}, !- Name
+  {255d2fc1-fd88-49cc-bda0-064637cb454c}, !- Source Object
+  4,                                      !- Outlet Port
+  {c86f31d2-3ef7-45e5-9d32-8b037a1c2136}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {c7718bb5-be16-432d-b6eb-a4288c4e52ca}, !- Handle
+  Node 34,                                !- Name
+  {147cda33-b1be-4bf3-8f23-9895587d99d9}, !- Inlet Port
+  {8ba76f55-a8d8-48db-8a64-8faf58905d56}; !- Outlet Port
+
+OS:Connection,
+  {c015e6df-8a94-4719-bda9-e768324c3430}, !- Handle
+  {5ca496a2-8e18-427a-a539-db9e6ffa7c38}, !- Name
+  {c86f31d2-3ef7-45e5-9d32-8b037a1c2136}, !- Source Object
+  3,                                      !- Outlet Port
+  {18fe0af3-63f0-48e6-a4db-3e3f2ea37e3c}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {147cda33-b1be-4bf3-8f23-9895587d99d9}, !- Handle
+  {552aa4e0-0683-4540-b0f7-f69800c10413}, !- Name
+  {97d73549-c1a6-487d-9a66-7a7c75bebf3a}, !- Source Object
+  3,                                      !- Outlet Port
+  {c7718bb5-be16-432d-b6eb-a4288c4e52ca}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {8ba76f55-a8d8-48db-8a64-8faf58905d56}, !- Handle
+  {f4e3f6ca-17f7-4848-a70e-e4c645888b37}, !- Name
+  {c7718bb5-be16-432d-b6eb-a4288c4e52ca}, !- Source Object
+  3,                                      !- Outlet Port
+  {18e0f907-c1a1-48ff-aec8-43a600199969}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- Handle
+  Packaged Rooftop Air Conditioner 2,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {8596c694-d8ef-4965-98b0-b9193a458be4}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {8616a795-c8e4-42c2-977b-36f2fd80bc0d}, !- Supply Side Inlet Node Name
+  {d9096c2a-43f0-43dd-a379-6e2a9d5a7186}, !- Demand Side Outlet Node Name
+  {e3c10604-bfd8-426e-8e8f-caa347c737b9}, !- Demand Side Inlet Node A
+  {b8fe5000-865f-4ae8-a84e-c2af01eca083}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {8befd519-434e-4c37-a925-47f96623204d}, !- Demand Mixer Name
+  {602832ad-6318-4010-b4ae-8c5255c021f4}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {d3a8e7cf-992d-43e0-ac2b-163a42e56e33}, !- Handle
+  Node 35,                                !- Name
+  {8616a795-c8e4-42c2-977b-36f2fd80bc0d}, !- Inlet Port
+  {4e79ce92-c9cb-451f-98a2-7b26c4d7ceeb}; !- Outlet Port
+
+OS:Node,
+  {7f33e285-a3ff-4499-929e-bb33ec098c6c}, !- Handle
+  Node 36,                                !- Name
+  {eb1f46ac-fa46-4f72-897e-0cb215a783f7}, !- Inlet Port
+  {b8fe5000-865f-4ae8-a84e-c2af01eca083}; !- Outlet Port
+
+OS:Connection,
+  {8616a795-c8e4-42c2-977b-36f2fd80bc0d}, !- Handle
+  {900eb474-7309-4cc1-9ac6-ef08bf8f372f}, !- Name
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- Source Object
+  8,                                      !- Outlet Port
+  {d3a8e7cf-992d-43e0-ac2b-163a42e56e33}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {b8fe5000-865f-4ae8-a84e-c2af01eca083}, !- Handle
+  {d947f3c6-439c-4799-b47b-b1339c8f1995}, !- Name
+  {7f33e285-a3ff-4499-929e-bb33ec098c6c}, !- Source Object
+  3,                                      !- Outlet Port
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {eaac4ba1-5caf-4516-880b-7c7d829f01c3}, !- Handle
+  Node 37,                                !- Name
+  {e3c10604-bfd8-426e-8e8f-caa347c737b9}, !- Inlet Port
+  {a8fd1f95-5753-428f-952d-246cc7eedd2f}; !- Outlet Port
+
+OS:Node,
+  {b3e0ca99-b7c0-494f-a1d5-4e1152536158}, !- Handle
+  Node 38,                                !- Name
+  {1b95e125-e3a7-4ce1-9043-84b817a60568}, !- Inlet Port
+  {d9096c2a-43f0-43dd-a379-6e2a9d5a7186}; !- Outlet Port
+
+OS:Node,
+  {329e5df9-039f-481f-8434-a926be92b5df}, !- Handle
+  Node 39,                                !- Name
+  {d2700de9-5526-4b98-a6bc-4b6b03eb25e8}, !- Inlet Port
+  {f6c41eeb-45c0-4ef8-891a-be86654df1d6}; !- Outlet Port
+
+OS:Connection,
+  {e3c10604-bfd8-426e-8e8f-caa347c737b9}, !- Handle
+  {6639be24-25e4-498a-95c0-1a0e6b9d19a8}, !- Name
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- Source Object
+  10,                                     !- Outlet Port
+  {eaac4ba1-5caf-4516-880b-7c7d829f01c3}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d9096c2a-43f0-43dd-a379-6e2a9d5a7186}, !- Handle
+  {67a71e27-d6ac-470c-84a0-1d6800b04031}, !- Name
+  {b3e0ca99-b7c0-494f-a1d5-4e1152536158}, !- Source Object
+  3,                                      !- Outlet Port
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {602832ad-6318-4010-b4ae-8c5255c021f4}, !- Handle
+  Air Loop HVAC Zone Splitter 3,          !- Name
+  {a8fd1f95-5753-428f-952d-246cc7eedd2f}, !- Inlet Node Name
+  {d5fc5768-f3bc-4379-ac76-05f62c9884a5}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {8befd519-434e-4c37-a925-47f96623204d}, !- Handle
+  Air Loop HVAC Zone Mixer 3,             !- Name
+  {1b95e125-e3a7-4ce1-9043-84b817a60568}, !- Outlet Node Name
+  {24ff1639-efa6-4698-b82d-127324267b50}; !- Inlet Node Name 1
+
+OS:Connection,
+  {a8fd1f95-5753-428f-952d-246cc7eedd2f}, !- Handle
+  {6a22e638-3f3d-44ca-bb0a-ed53a149f13c}, !- Name
+  {eaac4ba1-5caf-4516-880b-7c7d829f01c3}, !- Source Object
+  3,                                      !- Outlet Port
+  {602832ad-6318-4010-b4ae-8c5255c021f4}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {1b95e125-e3a7-4ce1-9043-84b817a60568}, !- Handle
+  {5f8b89f6-7d84-4041-83da-c78da659d18f}, !- Name
+  {8befd519-434e-4c37-a925-47f96623204d}, !- Source Object
+  2,                                      !- Outlet Port
+  {b3e0ca99-b7c0-494f-a1d5-4e1152536158}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {93933a07-6320-49fa-865a-c7bdd35705e4}, !- Handle
+  {9a1c9262-2b42-4958-9a72-40ad6c0238a7}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {8596c694-d8ef-4965-98b0-b9193a458be4}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 2; !- Name
+
+OS:Fan:ConstantVolume,
+  {c44edc44-5b30-4035-928f-ba2b5a4a9f4e}, !- Handle
+  Fan Constant Volume 3,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {ba97d954-395f-4d4d-ae6c-d11de1b4657d}, !- Air Inlet Node Name
+  {eb1f46ac-fa46-4f72-897e-0cb215a783f7}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {469ad6ae-2675-4b74-9cff-f851423ac798}, !- Handle
+  Coil Heating Gas 3,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {08397a58-818f-446c-971a-b16aa1972651}, !- Air Inlet Node Name
+  {4cb25f45-b2da-4e37-a138-9dc316e6cce8}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {1c606b15-466c-4ad9-9e34-bf2961a6438d}, !- Handle
+  Coil Cooling DX Single Speed 3,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {d88878a3-2d08-42e0-a18f-8ff649ef2239}, !- Air Inlet Node Name
+  {de6ff5f0-cb4b-49eb-baf9-a11e27fe51ad}, !- Air Outlet Node Name
+  {280badcb-14cb-44c0-b4a9-076789e5a459}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {ae78686f-68bd-47d6-a793-5984b9917c74}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {6a14a6de-d0b3-4ba6-a86c-282b6204c851}, !- Energy Input Ratio Function of Temperature Curve Name
+  {b3060a24-1623-4630-989c-eb9f418c48dc}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {007f0a54-2d8b-4c7f-84fd-e72e162588d0}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {280badcb-14cb-44c0-b4a9-076789e5a459}, !- Handle
+  Curve Biquadratic 5,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {ae78686f-68bd-47d6-a793-5984b9917c74}, !- Handle
+  Curve Quadratic 7,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {6a14a6de-d0b3-4ba6-a86c-282b6204c851}, !- Handle
+  Curve Biquadratic 6,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {b3060a24-1623-4630-989c-eb9f418c48dc}, !- Handle
+  Curve Quadratic 8,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {007f0a54-2d8b-4c7f-84fd-e72e162588d0}, !- Handle
+  Curve Quadratic 9,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {a94fde6c-8fc5-400f-9319-6818159ec5f8}, !- Handle
+  Setpoint Manager Single Zone Reheat 3,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {c0d04884-ae47-42d5-8ebd-4bb6fbef8aa2}, !- Control Zone Name
+  {7f33e285-a3ff-4499-929e-bb33ec098c6c}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {0415e98f-610b-4dfe-a343-7b836f42e1f9}, !- Handle
+  Controller Outdoor Air 3,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {abaa4c72-8de1-48e0-998c-99c5c8b45dc8}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {abaa4c72-8de1-48e0-998c-99c5c8b45dc8}, !- Handle
+  Controller Mechanical Ventilation 3,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {fa598958-b07a-4220-ac33-65232ada272c}, !- Handle
+  Air Loop HVAC Outdoor Air System 3,     !- Name
+  {0415e98f-610b-4dfe-a343-7b836f42e1f9}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {d9bfc8ea-293a-4bc5-8339-94fa8cc10bff}, !- Mixed Air Node Name
+  {fe62dc93-33e8-48b0-bcf2-6b29d7395089}, !- Outdoor Air Stream Node Name
+  {4fd6b8b9-0c3e-4236-a5bb-e656ca995cc9}, !- Relief Air Stream Node Name
+  {4e79ce92-c9cb-451f-98a2-7b26c4d7ceeb}; !- Return Air Stream Node Name
+
+OS:Node,
+  {8b0a12e3-432e-460a-be8d-c4a938b00916}, !- Handle
+  Node 40,                                !- Name
+  ,                                       !- Inlet Port
+  {fe62dc93-33e8-48b0-bcf2-6b29d7395089}; !- Outlet Port
+
+OS:Connection,
+  {fe62dc93-33e8-48b0-bcf2-6b29d7395089}, !- Handle
+  {32425051-b5cd-444e-86e8-3c1d40fab0b8}, !- Name
+  {8b0a12e3-432e-460a-be8d-c4a938b00916}, !- Source Object
+  3,                                      !- Outlet Port
+  {fa598958-b07a-4220-ac33-65232ada272c}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {456efc0c-7e35-447d-865a-66ec8774680a}, !- Handle
+  Node 41,                                !- Name
+  {4fd6b8b9-0c3e-4236-a5bb-e656ca995cc9}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {4fd6b8b9-0c3e-4236-a5bb-e656ca995cc9}, !- Handle
+  {a5a4f312-8c01-4489-b37d-fa8aefd34d04}, !- Name
+  {fa598958-b07a-4220-ac33-65232ada272c}, !- Source Object
+  7,                                      !- Outlet Port
+  {456efc0c-7e35-447d-865a-66ec8774680a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {4e79ce92-c9cb-451f-98a2-7b26c4d7ceeb}, !- Handle
+  {d953007a-7e3c-425e-be46-abbf181103d2}, !- Name
+  {d3a8e7cf-992d-43e0-ac2b-163a42e56e33}, !- Source Object
+  3,                                      !- Outlet Port
+  {fa598958-b07a-4220-ac33-65232ada272c}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {7360e760-d391-4fb9-b2c5-0afbfe2a06e7}, !- Handle
+  Node 42,                                !- Name
+  {d9bfc8ea-293a-4bc5-8339-94fa8cc10bff}, !- Inlet Port
+  {d88878a3-2d08-42e0-a18f-8ff649ef2239}; !- Outlet Port
+
+OS:Connection,
+  {d9bfc8ea-293a-4bc5-8339-94fa8cc10bff}, !- Handle
+  {231cbe18-228c-4bcd-b690-945ec999c73c}, !- Name
+  {fa598958-b07a-4220-ac33-65232ada272c}, !- Source Object
+  5,                                      !- Outlet Port
+  {7360e760-d391-4fb9-b2c5-0afbfe2a06e7}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d88878a3-2d08-42e0-a18f-8ff649ef2239}, !- Handle
+  {08f34287-562e-488d-a91e-a7c319a95e3e}, !- Name
+  {7360e760-d391-4fb9-b2c5-0afbfe2a06e7}, !- Source Object
+  3,                                      !- Outlet Port
+  {1c606b15-466c-4ad9-9e34-bf2961a6438d}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {cd274275-c4b7-4e75-bdd6-c4b90c1aaf6b}, !- Handle
+  Node 43,                                !- Name
+  {de6ff5f0-cb4b-49eb-baf9-a11e27fe51ad}, !- Inlet Port
+  {08397a58-818f-446c-971a-b16aa1972651}; !- Outlet Port
+
+OS:Connection,
+  {de6ff5f0-cb4b-49eb-baf9-a11e27fe51ad}, !- Handle
+  {f912bd55-24ac-4ea6-ae0c-19aaf61c2ed5}, !- Name
+  {1c606b15-466c-4ad9-9e34-bf2961a6438d}, !- Source Object
+  9,                                      !- Outlet Port
+  {cd274275-c4b7-4e75-bdd6-c4b90c1aaf6b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {08397a58-818f-446c-971a-b16aa1972651}, !- Handle
+  {c1322796-6910-415a-87af-a64750be915c}, !- Name
+  {cd274275-c4b7-4e75-bdd6-c4b90c1aaf6b}, !- Source Object
+  3,                                      !- Outlet Port
+  {469ad6ae-2675-4b74-9cff-f851423ac798}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {2354a93e-774d-4a6b-8aa3-d4d61be1405c}, !- Handle
+  Node 44,                                !- Name
+  {4cb25f45-b2da-4e37-a138-9dc316e6cce8}, !- Inlet Port
+  {ba97d954-395f-4d4d-ae6c-d11de1b4657d}; !- Outlet Port
+
+OS:Connection,
+  {4cb25f45-b2da-4e37-a138-9dc316e6cce8}, !- Handle
+  {81929bab-b7f8-4bab-a4f8-213418b3c4e6}, !- Name
+  {469ad6ae-2675-4b74-9cff-f851423ac798}, !- Source Object
+  6,                                      !- Outlet Port
+  {2354a93e-774d-4a6b-8aa3-d4d61be1405c}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {ba97d954-395f-4d4d-ae6c-d11de1b4657d}, !- Handle
+  {378317e7-db25-481c-a606-4165df5a6d86}, !- Name
+  {2354a93e-774d-4a6b-8aa3-d4d61be1405c}, !- Source Object
+  3,                                      !- Outlet Port
+  {c44edc44-5b30-4035-928f-ba2b5a4a9f4e}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {eb1f46ac-fa46-4f72-897e-0cb215a783f7}, !- Handle
+  {b62a3418-7a67-4a30-b698-c5957e6be7f9}, !- Name
+  {c44edc44-5b30-4035-928f-ba2b5a4a9f4e}, !- Source Object
+  9,                                      !- Outlet Port
+  {7f33e285-a3ff-4499-929e-bb33ec098c6c}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {d1fbfcdf-9b3c-4e5a-b79c-6d8f1ff842a9}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 3, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {1cd8fb57-c9e8-4328-86ac-61d06f875d51}, !- Air Inlet Node Name
+  {d2700de9-5526-4b98-a6bc-4b6b03eb25e8}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {e76cd867-d417-449c-a511-0d275860366b}, !- Handle
+  Node 45,                                !- Name
+  {d5fc5768-f3bc-4379-ac76-05f62c9884a5}, !- Inlet Port
+  {1cd8fb57-c9e8-4328-86ac-61d06f875d51}; !- Outlet Port
+
+OS:Connection,
+  {d5fc5768-f3bc-4379-ac76-05f62c9884a5}, !- Handle
+  {847d7350-e169-4c3b-b339-e1429bf490d8}, !- Name
+  {602832ad-6318-4010-b4ae-8c5255c021f4}, !- Source Object
+  3,                                      !- Outlet Port
+  {e76cd867-d417-449c-a511-0d275860366b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {1cd8fb57-c9e8-4328-86ac-61d06f875d51}, !- Handle
+  {5687bd52-3877-4e52-9182-615212078235}, !- Name
+  {e76cd867-d417-449c-a511-0d275860366b}, !- Source Object
+  3,                                      !- Outlet Port
+  {d1fbfcdf-9b3c-4e5a-b79c-6d8f1ff842a9}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {d2700de9-5526-4b98-a6bc-4b6b03eb25e8}, !- Handle
+  {b4a261a3-d1dd-4adc-8727-e15a78232838}, !- Name
+  {d1fbfcdf-9b3c-4e5a-b79c-6d8f1ff842a9}, !- Source Object
+  4,                                      !- Outlet Port
+  {329e5df9-039f-481f-8434-a926be92b5df}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {72796bc0-765a-423a-9d42-1f162454ae6e}, !- Handle
+  Node 46,                                !- Name
+  {92330d4b-d736-436c-9854-91535e5dc141}, !- Inlet Port
+  {24ff1639-efa6-4698-b82d-127324267b50}; !- Outlet Port
+
+OS:Connection,
+  {f6c41eeb-45c0-4ef8-891a-be86654df1d6}, !- Handle
+  {4d5d99f0-941a-476b-94df-692a396b12c2}, !- Name
+  {329e5df9-039f-481f-8434-a926be92b5df}, !- Source Object
+  3,                                      !- Outlet Port
+  {ee9db51b-2647-4267-ac53-531835fe4e7f}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {92330d4b-d736-436c-9854-91535e5dc141}, !- Handle
+  {5c9ffe9b-04d8-4e98-a5e1-1a1c17755ce0}, !- Name
+  {ffcdb616-0a69-4458-99d5-7f5f97328ba8}, !- Source Object
+  3,                                      !- Outlet Port
+  {72796bc0-765a-423a-9d42-1f162454ae6e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {24ff1639-efa6-4698-b82d-127324267b50}, !- Handle
+  {e26ed3dd-3bba-496b-8458-bc3c4c541faf}, !- Name
+  {72796bc0-765a-423a-9d42-1f162454ae6e}, !- Source Object
+  3,                                      !- Outlet Port
+  {8befd519-434e-4c37-a925-47f96623204d}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- Handle
+  Packaged Rooftop Air Conditioner 3,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {3f73b127-6734-41a7-bb73-f1d61e21702a}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {945b6a4a-c98c-4a51-95eb-befe8891e2b2}, !- Supply Side Inlet Node Name
+  {35f26953-b521-4204-a827-1038b62a5012}, !- Demand Side Outlet Node Name
+  {ef2df7bc-1bc2-4ab6-8355-1ef8fe09eba7}, !- Demand Side Inlet Node A
+  {1d289c85-4159-4e8b-b93d-a8f3081f0f82}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {d7f4a79b-b57c-44b1-bbf9-ba415d383e4b}, !- Demand Mixer Name
+  {f571c5ef-8398-4012-9125-e90c56875f27}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {f31671f6-7c8b-457c-91d8-ec0e3ae14fcc}, !- Handle
+  Node 47,                                !- Name
+  {945b6a4a-c98c-4a51-95eb-befe8891e2b2}, !- Inlet Port
+  {d2a24f09-94f0-4286-aa13-3d4d1dce1531}; !- Outlet Port
+
+OS:Node,
+  {2382f877-4b85-4880-b824-105a784f288a}, !- Handle
+  Node 48,                                !- Name
+  {dd5a23ad-a043-4b8c-b1cd-c3d8b74ef75e}, !- Inlet Port
+  {1d289c85-4159-4e8b-b93d-a8f3081f0f82}; !- Outlet Port
+
+OS:Connection,
+  {945b6a4a-c98c-4a51-95eb-befe8891e2b2}, !- Handle
+  {b1365806-8540-4d8f-a1b2-e0d111a17c20}, !- Name
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- Source Object
+  8,                                      !- Outlet Port
+  {f31671f6-7c8b-457c-91d8-ec0e3ae14fcc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {1d289c85-4159-4e8b-b93d-a8f3081f0f82}, !- Handle
+  {2ca50d6e-a444-4d57-a3d7-70c9bbc3c80f}, !- Name
+  {2382f877-4b85-4880-b824-105a784f288a}, !- Source Object
+  3,                                      !- Outlet Port
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {a8d2c027-1eff-4874-8564-cde9d31ce0f1}, !- Handle
+  Node 49,                                !- Name
+  {ef2df7bc-1bc2-4ab6-8355-1ef8fe09eba7}, !- Inlet Port
+  {2cb2186b-eac5-462f-9b08-2eff6e2071d3}; !- Outlet Port
+
+OS:Node,
+  {53906d70-2b40-4b29-be77-a5c4e4dd0042}, !- Handle
+  Node 50,                                !- Name
+  {d383ff0d-ba7a-4285-896c-f2cbde6ec612}, !- Inlet Port
+  {35f26953-b521-4204-a827-1038b62a5012}; !- Outlet Port
+
+OS:Node,
+  {72bb0106-0d23-4ddf-88b5-5fe8d4d3af57}, !- Handle
+  Node 51,                                !- Name
+  {923ad82e-b50d-461b-860f-b3ffe5eb3210}, !- Inlet Port
+  {278ecb44-56e8-414a-b452-a965193966dd}; !- Outlet Port
+
+OS:Connection,
+  {ef2df7bc-1bc2-4ab6-8355-1ef8fe09eba7}, !- Handle
+  {a5778f6f-a01b-4ffb-bb29-1d4a0d0863c8}, !- Name
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- Source Object
+  10,                                     !- Outlet Port
+  {a8d2c027-1eff-4874-8564-cde9d31ce0f1}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {35f26953-b521-4204-a827-1038b62a5012}, !- Handle
+  {756790e1-8bac-412b-ae86-0dfca5692ef4}, !- Name
+  {53906d70-2b40-4b29-be77-a5c4e4dd0042}, !- Source Object
+  3,                                      !- Outlet Port
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {f571c5ef-8398-4012-9125-e90c56875f27}, !- Handle
+  Air Loop HVAC Zone Splitter 4,          !- Name
+  {2cb2186b-eac5-462f-9b08-2eff6e2071d3}, !- Inlet Node Name
+  {4c20491d-5cf6-4375-ab5a-02588a810e42}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {d7f4a79b-b57c-44b1-bbf9-ba415d383e4b}, !- Handle
+  Air Loop HVAC Zone Mixer 4,             !- Name
+  {d383ff0d-ba7a-4285-896c-f2cbde6ec612}, !- Outlet Node Name
+  {fd43742d-008b-462c-a519-1a654096e70f}; !- Inlet Node Name 1
+
+OS:Connection,
+  {2cb2186b-eac5-462f-9b08-2eff6e2071d3}, !- Handle
+  {f2149034-086c-434e-88ac-e024b12632b9}, !- Name
+  {a8d2c027-1eff-4874-8564-cde9d31ce0f1}, !- Source Object
+  3,                                      !- Outlet Port
+  {f571c5ef-8398-4012-9125-e90c56875f27}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d383ff0d-ba7a-4285-896c-f2cbde6ec612}, !- Handle
+  {7b165d1e-b853-4e14-a1ed-b1091a795b13}, !- Name
+  {d7f4a79b-b57c-44b1-bbf9-ba415d383e4b}, !- Source Object
+  2,                                      !- Outlet Port
+  {53906d70-2b40-4b29-be77-a5c4e4dd0042}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {31493d00-6ea9-421b-b775-a3d96a9778b1}, !- Handle
+  {b8a3ba74-8c2e-4645-af5c-074a3225a277}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {3f73b127-6734-41a7-bb73-f1d61e21702a}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 3; !- Name
+
+OS:Fan:ConstantVolume,
+  {63fe58e0-a847-4cd6-9281-b6643ec2de64}, !- Handle
+  Fan Constant Volume 4,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {b1d8977c-91da-49c0-a6e3-30949f77fb68}, !- Air Inlet Node Name
+  {dd5a23ad-a043-4b8c-b1cd-c3d8b74ef75e}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {baef559e-cbde-4bee-9520-a6373ece44a5}, !- Handle
+  Coil Heating Gas 4,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {ed759f88-d9ff-4f2a-a7f0-52b419fa4f24}, !- Air Inlet Node Name
+  {106a8390-bf44-49c7-b784-2919ae8c2ce3}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {f2ab38ce-00d4-4e36-8990-dc6399f7ac02}, !- Handle
+  Coil Cooling DX Single Speed 4,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {7acd0ca7-268d-4490-af6a-99c06d326cc1}, !- Air Inlet Node Name
+  {8490977c-b92b-45a6-82de-da64d8399c79}, !- Air Outlet Node Name
+  {7aeb8e83-4a09-4368-9689-17e09738d54e}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {cbea7de2-387d-4504-9fcc-45d4ce3a66b1}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {19a21adf-ed5e-477c-9e1c-cd036af96ad5}, !- Energy Input Ratio Function of Temperature Curve Name
+  {e7cd54e7-c3e7-4247-80ac-6564e526e05b}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {cfa712aa-125e-4ea8-a5fd-3df8abd398d0}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {7aeb8e83-4a09-4368-9689-17e09738d54e}, !- Handle
+  Curve Biquadratic 7,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {cbea7de2-387d-4504-9fcc-45d4ce3a66b1}, !- Handle
+  Curve Quadratic 10,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {19a21adf-ed5e-477c-9e1c-cd036af96ad5}, !- Handle
+  Curve Biquadratic 8,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {e7cd54e7-c3e7-4247-80ac-6564e526e05b}, !- Handle
+  Curve Quadratic 11,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {cfa712aa-125e-4ea8-a5fd-3df8abd398d0}, !- Handle
+  Curve Quadratic 12,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {abadf239-385c-4e3d-bb48-31d7e24fbf75}, !- Handle
+  Setpoint Manager Single Zone Reheat 4,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {2e81a602-19ee-4942-8bb4-6bd0f5e62a46}, !- Control Zone Name
+  {2382f877-4b85-4880-b824-105a784f288a}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {1a8af5d6-ed33-419a-9b1e-169d2fea7000}, !- Handle
+  Controller Outdoor Air 4,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {23585412-2c5c-4599-a706-df1cf8970329}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {23585412-2c5c-4599-a706-df1cf8970329}, !- Handle
+  Controller Mechanical Ventilation 4,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {f7f89a0a-1580-4817-aa16-0da81c472f08}, !- Handle
+  Air Loop HVAC Outdoor Air System 4,     !- Name
+  {1a8af5d6-ed33-419a-9b1e-169d2fea7000}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {73d979fb-deb6-4c78-97af-f4e4b963e665}, !- Mixed Air Node Name
+  {0e078980-f8b8-4702-adf6-162c5b11febe}, !- Outdoor Air Stream Node Name
+  {29f0d33b-1e88-438f-bf5b-8fbaa59e5c06}, !- Relief Air Stream Node Name
+  {d2a24f09-94f0-4286-aa13-3d4d1dce1531}; !- Return Air Stream Node Name
+
+OS:Node,
+  {29212963-555c-40ef-a5e6-423889b32cbf}, !- Handle
+  Node 52,                                !- Name
+  ,                                       !- Inlet Port
+  {0e078980-f8b8-4702-adf6-162c5b11febe}; !- Outlet Port
+
+OS:Connection,
+  {0e078980-f8b8-4702-adf6-162c5b11febe}, !- Handle
+  {14ef055a-a4a7-4077-97de-73ca802d2c5f}, !- Name
+  {29212963-555c-40ef-a5e6-423889b32cbf}, !- Source Object
+  3,                                      !- Outlet Port
+  {f7f89a0a-1580-4817-aa16-0da81c472f08}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {68c17533-3e1b-4b43-a69b-1a84b14031a8}, !- Handle
+  Node 53,                                !- Name
+  {29f0d33b-1e88-438f-bf5b-8fbaa59e5c06}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {29f0d33b-1e88-438f-bf5b-8fbaa59e5c06}, !- Handle
+  {477a9218-8ffb-4c27-9a31-59181bcf9578}, !- Name
+  {f7f89a0a-1580-4817-aa16-0da81c472f08}, !- Source Object
+  7,                                      !- Outlet Port
+  {68c17533-3e1b-4b43-a69b-1a84b14031a8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d2a24f09-94f0-4286-aa13-3d4d1dce1531}, !- Handle
+  {14bf28fe-cdae-4e94-8029-e97804d7fe1f}, !- Name
+  {f31671f6-7c8b-457c-91d8-ec0e3ae14fcc}, !- Source Object
+  3,                                      !- Outlet Port
+  {f7f89a0a-1580-4817-aa16-0da81c472f08}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {33b61a47-220e-44ce-99b3-e5f90de55d22}, !- Handle
+  Node 54,                                !- Name
+  {73d979fb-deb6-4c78-97af-f4e4b963e665}, !- Inlet Port
+  {7acd0ca7-268d-4490-af6a-99c06d326cc1}; !- Outlet Port
+
+OS:Connection,
+  {73d979fb-deb6-4c78-97af-f4e4b963e665}, !- Handle
+  {2e57c0f6-8099-4d25-8a02-d81a9d20509b}, !- Name
+  {f7f89a0a-1580-4817-aa16-0da81c472f08}, !- Source Object
+  5,                                      !- Outlet Port
+  {33b61a47-220e-44ce-99b3-e5f90de55d22}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {7acd0ca7-268d-4490-af6a-99c06d326cc1}, !- Handle
+  {e2531182-af44-4b2a-a123-dbd8f70e089e}, !- Name
+  {33b61a47-220e-44ce-99b3-e5f90de55d22}, !- Source Object
+  3,                                      !- Outlet Port
+  {f2ab38ce-00d4-4e36-8990-dc6399f7ac02}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {310e2f5e-552e-4b3a-9505-e4ba712ecf4e}, !- Handle
+  Node 55,                                !- Name
+  {8490977c-b92b-45a6-82de-da64d8399c79}, !- Inlet Port
+  {ed759f88-d9ff-4f2a-a7f0-52b419fa4f24}; !- Outlet Port
+
+OS:Connection,
+  {8490977c-b92b-45a6-82de-da64d8399c79}, !- Handle
+  {8c57a411-04d6-47a9-bc99-99645891bdbf}, !- Name
+  {f2ab38ce-00d4-4e36-8990-dc6399f7ac02}, !- Source Object
+  9,                                      !- Outlet Port
+  {310e2f5e-552e-4b3a-9505-e4ba712ecf4e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {ed759f88-d9ff-4f2a-a7f0-52b419fa4f24}, !- Handle
+  {3dda1474-5649-4b49-b00c-ee3e0fd0e3f0}, !- Name
+  {310e2f5e-552e-4b3a-9505-e4ba712ecf4e}, !- Source Object
+  3,                                      !- Outlet Port
+  {baef559e-cbde-4bee-9520-a6373ece44a5}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {effbec84-a9af-4d7b-84dd-617a35e0ba62}, !- Handle
+  Node 56,                                !- Name
+  {106a8390-bf44-49c7-b784-2919ae8c2ce3}, !- Inlet Port
+  {b1d8977c-91da-49c0-a6e3-30949f77fb68}; !- Outlet Port
+
+OS:Connection,
+  {106a8390-bf44-49c7-b784-2919ae8c2ce3}, !- Handle
+  {905efcb7-7be2-414a-93ef-099c57a5f6ab}, !- Name
+  {baef559e-cbde-4bee-9520-a6373ece44a5}, !- Source Object
+  6,                                      !- Outlet Port
+  {effbec84-a9af-4d7b-84dd-617a35e0ba62}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {b1d8977c-91da-49c0-a6e3-30949f77fb68}, !- Handle
+  {45c6ebe6-ec76-464d-b21f-fefdae879253}, !- Name
+  {effbec84-a9af-4d7b-84dd-617a35e0ba62}, !- Source Object
+  3,                                      !- Outlet Port
+  {63fe58e0-a847-4cd6-9281-b6643ec2de64}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {dd5a23ad-a043-4b8c-b1cd-c3d8b74ef75e}, !- Handle
+  {e6f1cdac-6e87-4ec2-8980-6b1d396e2d9c}, !- Name
+  {63fe58e0-a847-4cd6-9281-b6643ec2de64}, !- Source Object
+  9,                                      !- Outlet Port
+  {2382f877-4b85-4880-b824-105a784f288a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {836b644e-756d-4c6b-8ace-417dbda0f974}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 4, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {cbdcb988-d732-4b1b-8eb0-fda5d0ab13e2}, !- Air Inlet Node Name
+  {923ad82e-b50d-461b-860f-b3ffe5eb3210}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {5e0c2e2b-35b6-43aa-804b-a2cc17daa253}, !- Handle
+  Node 57,                                !- Name
+  {4c20491d-5cf6-4375-ab5a-02588a810e42}, !- Inlet Port
+  {cbdcb988-d732-4b1b-8eb0-fda5d0ab13e2}; !- Outlet Port
+
+OS:Connection,
+  {4c20491d-5cf6-4375-ab5a-02588a810e42}, !- Handle
+  {a5847fae-65c7-4851-9163-2e4a29af8041}, !- Name
+  {f571c5ef-8398-4012-9125-e90c56875f27}, !- Source Object
+  3,                                      !- Outlet Port
+  {5e0c2e2b-35b6-43aa-804b-a2cc17daa253}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {cbdcb988-d732-4b1b-8eb0-fda5d0ab13e2}, !- Handle
+  {0d421bf0-f143-4ab7-92d0-a9c5e112fe37}, !- Name
+  {5e0c2e2b-35b6-43aa-804b-a2cc17daa253}, !- Source Object
+  3,                                      !- Outlet Port
+  {836b644e-756d-4c6b-8ace-417dbda0f974}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {923ad82e-b50d-461b-860f-b3ffe5eb3210}, !- Handle
+  {244486e8-44b9-41d8-b762-6c00cd230fdc}, !- Name
+  {836b644e-756d-4c6b-8ace-417dbda0f974}, !- Source Object
+  4,                                      !- Outlet Port
+  {72bb0106-0d23-4ddf-88b5-5fe8d4d3af57}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {559765ad-4f14-4739-b72e-95e8f736caf4}, !- Handle
+  Node 58,                                !- Name
+  {f09ae136-7de8-48f4-8aaf-5d2a9025e530}, !- Inlet Port
+  {fd43742d-008b-462c-a519-1a654096e70f}; !- Outlet Port
+
+OS:Connection,
+  {278ecb44-56e8-414a-b452-a965193966dd}, !- Handle
+  {aaecea68-6c20-4fba-ad21-f132bc331cb8}, !- Name
+  {72bb0106-0d23-4ddf-88b5-5fe8d4d3af57}, !- Source Object
+  3,                                      !- Outlet Port
+  {361893ba-4b48-469e-b180-c936b4f5c6e7}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {f09ae136-7de8-48f4-8aaf-5d2a9025e530}, !- Handle
+  {a280a4ec-9a12-4926-96bf-e3fd76a8a057}, !- Name
+  {6a6600fc-e16f-4da9-929c-6b05c1189a3a}, !- Source Object
+  3,                                      !- Outlet Port
+  {559765ad-4f14-4739-b72e-95e8f736caf4}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {fd43742d-008b-462c-a519-1a654096e70f}, !- Handle
+  {2254470b-3123-4d7b-834a-4d8dbe85bc23}, !- Name
+  {559765ad-4f14-4739-b72e-95e8f736caf4}, !- Source Object
+  3,                                      !- Outlet Port
+  {d7f4a79b-b57c-44b1-bbf9-ba415d383e4b}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- Handle
+  Packaged Rooftop Air Conditioner 4,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {0f6876ea-e6b5-465e-a3b6-88952b99e51e}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {53b0c973-5a3d-40a5-b50d-6c185c88a692}, !- Supply Side Inlet Node Name
+  {6c2a7fef-47a0-4789-b369-95de8fd1f7d7}, !- Demand Side Outlet Node Name
+  {15d5d1a7-b93e-4b33-82c6-3267a1c29407}, !- Demand Side Inlet Node A
+  {ce2d0cad-c985-46c0-b490-38e6edf4efa5}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {540f7a01-e4a4-4ca3-8865-529d7c6ec08f}, !- Demand Mixer Name
+  {ca366378-89d9-4246-987f-6c8c36d19fd9}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {b8d5407a-5dbd-4562-bce9-3c57c27d14fc}, !- Handle
+  Node 59,                                !- Name
+  {53b0c973-5a3d-40a5-b50d-6c185c88a692}, !- Inlet Port
+  {4b35b305-067c-4b2b-915f-ae6e6e915674}; !- Outlet Port
+
+OS:Node,
+  {12fdbbbd-a742-4c97-9f5b-5e1d927fb33f}, !- Handle
+  Node 60,                                !- Name
+  {e385e19b-d1bd-4d63-8062-1931d3b22794}, !- Inlet Port
+  {ce2d0cad-c985-46c0-b490-38e6edf4efa5}; !- Outlet Port
+
+OS:Connection,
+  {53b0c973-5a3d-40a5-b50d-6c185c88a692}, !- Handle
+  {f8928b01-448d-41e7-a137-4577c8fade39}, !- Name
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- Source Object
+  8,                                      !- Outlet Port
+  {b8d5407a-5dbd-4562-bce9-3c57c27d14fc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {ce2d0cad-c985-46c0-b490-38e6edf4efa5}, !- Handle
+  {240a84ac-d6c3-4e84-afd1-13dd723cbe37}, !- Name
+  {12fdbbbd-a742-4c97-9f5b-5e1d927fb33f}, !- Source Object
+  3,                                      !- Outlet Port
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {87588b0f-09df-4695-a2fc-0dd42bfc60eb}, !- Handle
+  Node 61,                                !- Name
+  {15d5d1a7-b93e-4b33-82c6-3267a1c29407}, !- Inlet Port
+  {9452cbf4-0529-436e-b041-453f8e99070f}; !- Outlet Port
+
+OS:Node,
+  {9c7d0260-ec0d-4fcf-89db-4fe5a5a542ca}, !- Handle
+  Node 62,                                !- Name
+  {e865ebd1-d461-40b6-90d0-a622107f068b}, !- Inlet Port
+  {6c2a7fef-47a0-4789-b369-95de8fd1f7d7}; !- Outlet Port
+
+OS:Node,
+  {9b9808b9-35f7-414d-8db6-623072a4a961}, !- Handle
+  Node 63,                                !- Name
+  {5c9f1152-66c8-45f3-a09f-c8f3be34f356}, !- Inlet Port
+  {a4b3edaf-5ebe-4df5-bf59-88ff05cf290a}; !- Outlet Port
+
+OS:Connection,
+  {15d5d1a7-b93e-4b33-82c6-3267a1c29407}, !- Handle
+  {54664307-5dcf-4c18-a164-76acf84826e1}, !- Name
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- Source Object
+  10,                                     !- Outlet Port
+  {87588b0f-09df-4695-a2fc-0dd42bfc60eb}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6c2a7fef-47a0-4789-b369-95de8fd1f7d7}, !- Handle
+  {fccbda0f-87a1-49f3-8556-1aba1cd13d5d}, !- Name
+  {9c7d0260-ec0d-4fcf-89db-4fe5a5a542ca}, !- Source Object
+  3,                                      !- Outlet Port
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {ca366378-89d9-4246-987f-6c8c36d19fd9}, !- Handle
+  Air Loop HVAC Zone Splitter 5,          !- Name
+  {9452cbf4-0529-436e-b041-453f8e99070f}, !- Inlet Node Name
+  {402757c9-1918-40f6-8764-0a63db5c51db}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {540f7a01-e4a4-4ca3-8865-529d7c6ec08f}, !- Handle
+  Air Loop HVAC Zone Mixer 5,             !- Name
+  {e865ebd1-d461-40b6-90d0-a622107f068b}, !- Outlet Node Name
+  {e2e9b5fc-5f24-4ac9-9999-b20c5b65dd5b}; !- Inlet Node Name 1
+
+OS:Connection,
+  {9452cbf4-0529-436e-b041-453f8e99070f}, !- Handle
+  {52b8e7a6-3ae7-4fcf-b0fd-c0b7740e46e8}, !- Name
+  {87588b0f-09df-4695-a2fc-0dd42bfc60eb}, !- Source Object
+  3,                                      !- Outlet Port
+  {ca366378-89d9-4246-987f-6c8c36d19fd9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e865ebd1-d461-40b6-90d0-a622107f068b}, !- Handle
+  {bb8c81c0-f2cc-4e62-ae0c-91de8214b14f}, !- Name
+  {540f7a01-e4a4-4ca3-8865-529d7c6ec08f}, !- Source Object
+  2,                                      !- Outlet Port
+  {9c7d0260-ec0d-4fcf-89db-4fe5a5a542ca}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {2d976987-9964-4f84-8acc-7afe9e8812a6}, !- Handle
+  {5dd5d59c-1097-4b49-a0b6-16608a184122}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {0f6876ea-e6b5-465e-a3b6-88952b99e51e}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 4; !- Name
+
+OS:Fan:ConstantVolume,
+  {8e21fab5-e014-44de-8910-3c24565c87bf}, !- Handle
+  Fan Constant Volume 5,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {40336403-f5c0-4f54-8a37-67d46e135dd0}, !- Air Inlet Node Name
+  {e385e19b-d1bd-4d63-8062-1931d3b22794}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {021589f6-02f4-4cf2-a65d-63fb4173fe57}, !- Handle
+  Coil Heating Gas 5,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {85027f36-099e-4aa3-a403-43659f6fad6e}, !- Air Inlet Node Name
+  {d5750ec1-fe1f-4d65-aac7-838e443c3e06}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {86539c8d-620f-4739-84a5-7e1a9332985d}, !- Handle
+  Coil Cooling DX Single Speed 5,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {8dd376c3-47a4-4050-8a89-f331b7cdf418}, !- Air Inlet Node Name
+  {ee2764ae-5864-4efc-8567-39396a842fdb}, !- Air Outlet Node Name
+  {2e7aae70-a123-4188-beaf-74aac3a793a1}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {4ee4861a-b29f-4818-8e62-15e40f6a398a}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {579aa82f-d6cb-4211-91db-1b4fd5b7249a}, !- Energy Input Ratio Function of Temperature Curve Name
+  {3ef44f19-7957-47d7-856b-d78c114791b0}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {7d820651-c0c4-4891-8346-910736cb83ae}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {2e7aae70-a123-4188-beaf-74aac3a793a1}, !- Handle
+  Curve Biquadratic 9,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {4ee4861a-b29f-4818-8e62-15e40f6a398a}, !- Handle
+  Curve Quadratic 13,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {579aa82f-d6cb-4211-91db-1b4fd5b7249a}, !- Handle
+  Curve Biquadratic 10,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {3ef44f19-7957-47d7-856b-d78c114791b0}, !- Handle
+  Curve Quadratic 14,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {7d820651-c0c4-4891-8346-910736cb83ae}, !- Handle
+  Curve Quadratic 15,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {114b49be-7b8a-4ab2-9300-f6a4ef3ee191}, !- Handle
+  Setpoint Manager Single Zone Reheat 5,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {82cea8ba-f295-4264-8ae6-a5a461c72f88}, !- Control Zone Name
+  {12fdbbbd-a742-4c97-9f5b-5e1d927fb33f}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {654efe8a-9319-48fa-9510-a9206248b8ef}, !- Handle
+  Controller Outdoor Air 5,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {123c9e2d-623a-4c4f-a33d-015c14d7d740}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {123c9e2d-623a-4c4f-a33d-015c14d7d740}, !- Handle
+  Controller Mechanical Ventilation 5,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {8eb78b2a-4083-4ab9-851d-5b47c06d35a4}, !- Handle
+  Air Loop HVAC Outdoor Air System 5,     !- Name
+  {654efe8a-9319-48fa-9510-a9206248b8ef}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {455585f3-2746-4d8b-a1f5-5f3e968a72b9}, !- Mixed Air Node Name
+  {72de83d0-76a0-4d3c-a523-e3583f95612e}, !- Outdoor Air Stream Node Name
+  {8fe6496a-b154-4eb4-b0d3-d9081a73498a}, !- Relief Air Stream Node Name
+  {4b35b305-067c-4b2b-915f-ae6e6e915674}; !- Return Air Stream Node Name
+
+OS:Node,
+  {e636158a-e438-4fde-bb91-8cf73b02f5e1}, !- Handle
+  Node 64,                                !- Name
+  ,                                       !- Inlet Port
+  {72de83d0-76a0-4d3c-a523-e3583f95612e}; !- Outlet Port
+
+OS:Connection,
+  {72de83d0-76a0-4d3c-a523-e3583f95612e}, !- Handle
+  {60a4fb48-c96d-4e77-9752-f99758c2f35f}, !- Name
+  {e636158a-e438-4fde-bb91-8cf73b02f5e1}, !- Source Object
+  3,                                      !- Outlet Port
+  {8eb78b2a-4083-4ab9-851d-5b47c06d35a4}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {32773451-e3de-45be-a6de-ae65d5ed78e8}, !- Handle
+  Node 65,                                !- Name
+  {8fe6496a-b154-4eb4-b0d3-d9081a73498a}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {8fe6496a-b154-4eb4-b0d3-d9081a73498a}, !- Handle
+  {22077a4e-7724-496e-b1e3-ff78c59932b1}, !- Name
+  {8eb78b2a-4083-4ab9-851d-5b47c06d35a4}, !- Source Object
+  7,                                      !- Outlet Port
+  {32773451-e3de-45be-a6de-ae65d5ed78e8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {4b35b305-067c-4b2b-915f-ae6e6e915674}, !- Handle
+  {4f1ad783-702f-44bb-ac60-5eb4dcd6c996}, !- Name
+  {b8d5407a-5dbd-4562-bce9-3c57c27d14fc}, !- Source Object
+  3,                                      !- Outlet Port
+  {8eb78b2a-4083-4ab9-851d-5b47c06d35a4}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {fb6a68a7-1a29-42d2-9fa3-d973c1b96cbb}, !- Handle
+  Node 66,                                !- Name
+  {455585f3-2746-4d8b-a1f5-5f3e968a72b9}, !- Inlet Port
+  {8dd376c3-47a4-4050-8a89-f331b7cdf418}; !- Outlet Port
+
+OS:Connection,
+  {455585f3-2746-4d8b-a1f5-5f3e968a72b9}, !- Handle
+  {bfacf5d9-08a7-4f58-8796-473c5398142e}, !- Name
+  {8eb78b2a-4083-4ab9-851d-5b47c06d35a4}, !- Source Object
+  5,                                      !- Outlet Port
+  {fb6a68a7-1a29-42d2-9fa3-d973c1b96cbb}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {8dd376c3-47a4-4050-8a89-f331b7cdf418}, !- Handle
+  {2302a51c-fd12-4dac-8d00-baa2320fd27c}, !- Name
+  {fb6a68a7-1a29-42d2-9fa3-d973c1b96cbb}, !- Source Object
+  3,                                      !- Outlet Port
+  {86539c8d-620f-4739-84a5-7e1a9332985d}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {dded9b0d-48d9-47e8-8cc4-2478dab93ec7}, !- Handle
+  Node 67,                                !- Name
+  {ee2764ae-5864-4efc-8567-39396a842fdb}, !- Inlet Port
+  {85027f36-099e-4aa3-a403-43659f6fad6e}; !- Outlet Port
+
+OS:Connection,
+  {ee2764ae-5864-4efc-8567-39396a842fdb}, !- Handle
+  {763ef3ff-b590-4040-8646-d4fc5148dd09}, !- Name
+  {86539c8d-620f-4739-84a5-7e1a9332985d}, !- Source Object
+  9,                                      !- Outlet Port
+  {dded9b0d-48d9-47e8-8cc4-2478dab93ec7}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {85027f36-099e-4aa3-a403-43659f6fad6e}, !- Handle
+  {f26db75b-cd4f-4ef6-934a-1faa3cefef76}, !- Name
+  {dded9b0d-48d9-47e8-8cc4-2478dab93ec7}, !- Source Object
+  3,                                      !- Outlet Port
+  {021589f6-02f4-4cf2-a65d-63fb4173fe57}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {d99b252c-5fe3-4577-824b-618fe62245d1}, !- Handle
+  Node 68,                                !- Name
+  {d5750ec1-fe1f-4d65-aac7-838e443c3e06}, !- Inlet Port
+  {40336403-f5c0-4f54-8a37-67d46e135dd0}; !- Outlet Port
+
+OS:Connection,
+  {d5750ec1-fe1f-4d65-aac7-838e443c3e06}, !- Handle
+  {7caa2c10-2697-4aaa-a77e-eea41b02e5b6}, !- Name
+  {021589f6-02f4-4cf2-a65d-63fb4173fe57}, !- Source Object
+  6,                                      !- Outlet Port
+  {d99b252c-5fe3-4577-824b-618fe62245d1}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {40336403-f5c0-4f54-8a37-67d46e135dd0}, !- Handle
+  {455c59f7-37f2-4462-89db-649adbf0890b}, !- Name
+  {d99b252c-5fe3-4577-824b-618fe62245d1}, !- Source Object
+  3,                                      !- Outlet Port
+  {8e21fab5-e014-44de-8910-3c24565c87bf}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {e385e19b-d1bd-4d63-8062-1931d3b22794}, !- Handle
+  {a14f87a3-6ea5-4edd-8934-ecfb5f3f46a5}, !- Name
+  {8e21fab5-e014-44de-8910-3c24565c87bf}, !- Source Object
+  9,                                      !- Outlet Port
+  {12fdbbbd-a742-4c97-9f5b-5e1d927fb33f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {4de7fb41-c8d1-458e-9e38-0f68fa17c640}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 5, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {6048842e-a5d7-40ce-94fd-5cadd6376b3c}, !- Air Inlet Node Name
+  {5c9f1152-66c8-45f3-a09f-c8f3be34f356}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {4ccba4ba-2d27-4759-95ed-88a38c748edc}, !- Handle
+  Node 69,                                !- Name
+  {402757c9-1918-40f6-8764-0a63db5c51db}, !- Inlet Port
+  {6048842e-a5d7-40ce-94fd-5cadd6376b3c}; !- Outlet Port
+
+OS:Connection,
+  {402757c9-1918-40f6-8764-0a63db5c51db}, !- Handle
+  {95b9e4ef-9ccb-4096-b9cf-f646cab1c0a7}, !- Name
+  {ca366378-89d9-4246-987f-6c8c36d19fd9}, !- Source Object
+  3,                                      !- Outlet Port
+  {4ccba4ba-2d27-4759-95ed-88a38c748edc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6048842e-a5d7-40ce-94fd-5cadd6376b3c}, !- Handle
+  {7b2cfba8-902c-4768-ad9c-8deae5d531f0}, !- Name
+  {4ccba4ba-2d27-4759-95ed-88a38c748edc}, !- Source Object
+  3,                                      !- Outlet Port
+  {4de7fb41-c8d1-458e-9e38-0f68fa17c640}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {5c9f1152-66c8-45f3-a09f-c8f3be34f356}, !- Handle
+  {ab15d9ff-c112-4272-9669-cd88c858724d}, !- Name
+  {4de7fb41-c8d1-458e-9e38-0f68fa17c640}, !- Source Object
+  4,                                      !- Outlet Port
+  {9b9808b9-35f7-414d-8db6-623072a4a961}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {64caf87f-6137-4c2d-8e7d-8b15c43774d8}, !- Handle
+  Node 70,                                !- Name
+  {6e7b603d-cd5d-405e-a7f4-76cc3eb550ac}, !- Inlet Port
+  {e2e9b5fc-5f24-4ac9-9999-b20c5b65dd5b}; !- Outlet Port
+
+OS:Connection,
+  {a4b3edaf-5ebe-4df5-bf59-88ff05cf290a}, !- Handle
+  {f58c1b3e-d42f-4be4-804b-120e8a25c0e6}, !- Name
+  {9b9808b9-35f7-414d-8db6-623072a4a961}, !- Source Object
+  3,                                      !- Outlet Port
+  {560c5c30-99f6-4cc3-be13-59c80772e991}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {6e7b603d-cd5d-405e-a7f4-76cc3eb550ac}, !- Handle
+  {d2427a81-2a23-416c-9d6c-650f1a033e45}, !- Name
+  {7deb148b-e74b-411c-a111-6046693f968a}, !- Source Object
+  3,                                      !- Outlet Port
+  {64caf87f-6137-4c2d-8e7d-8b15c43774d8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e2e9b5fc-5f24-4ac9-9999-b20c5b65dd5b}, !- Handle
+  {f9c43f2a-6859-4aa2-ae73-77a29e1754b0}, !- Name
+  {64caf87f-6137-4c2d-8e7d-8b15c43774d8}, !- Source Object
+  3,                                      !- Outlet Port
+  {540f7a01-e4a4-4ca3-8865-529d7c6ec08f}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- Handle
+  Packaged Rooftop Air Conditioner 5,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {bbd6b55e-9c36-4a06-8433-65ec31b6ad34}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {060a36e9-c349-4356-8b9b-23b5ba2c6bc7}, !- Supply Side Inlet Node Name
+  {f3425240-f052-40cc-b56e-f2d8d51e2c49}, !- Demand Side Outlet Node Name
+  {053092c7-469f-4f8d-8967-9757f867a181}, !- Demand Side Inlet Node A
+  {7b67e1a1-4f04-4b22-816b-41f61689df18}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {c17e6442-a5f2-4086-8fad-42d46f216308}, !- Demand Mixer Name
+  {81cabfd0-2bfe-4ae1-97c6-679673a983c8}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {b68bf42b-6319-46d2-9fd2-f3aa7f6b6282}, !- Handle
+  Node 71,                                !- Name
+  {060a36e9-c349-4356-8b9b-23b5ba2c6bc7}, !- Inlet Port
+  {847413ec-8804-4a9b-98ac-c1bfc01cfa77}; !- Outlet Port
+
+OS:Node,
+  {6b83d71f-ee01-47d8-a1b6-40b2f8f505df}, !- Handle
+  Node 72,                                !- Name
+  {d7b4e4fd-027e-49f3-a6d3-f49246921068}, !- Inlet Port
+  {7b67e1a1-4f04-4b22-816b-41f61689df18}; !- Outlet Port
+
+OS:Connection,
+  {060a36e9-c349-4356-8b9b-23b5ba2c6bc7}, !- Handle
+  {3b2a4b1a-b9ce-4f82-8701-1fb8bc0f7f88}, !- Name
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- Source Object
+  8,                                      !- Outlet Port
+  {b68bf42b-6319-46d2-9fd2-f3aa7f6b6282}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {7b67e1a1-4f04-4b22-816b-41f61689df18}, !- Handle
+  {b2e25d68-422b-4102-9789-542cd41449c1}, !- Name
+  {6b83d71f-ee01-47d8-a1b6-40b2f8f505df}, !- Source Object
+  3,                                      !- Outlet Port
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {9ce551c8-4e44-4dcf-b7aa-db5651ace865}, !- Handle
+  Node 73,                                !- Name
+  {053092c7-469f-4f8d-8967-9757f867a181}, !- Inlet Port
+  {1f5494bd-61fb-40e3-ba27-4d1780decccc}; !- Outlet Port
+
+OS:Node,
+  {45d1fcc7-72fc-48b5-be4f-7094f9e208af}, !- Handle
+  Node 74,                                !- Name
+  {d40c5bb3-ac12-4545-9652-c0e8008a082b}, !- Inlet Port
+  {f3425240-f052-40cc-b56e-f2d8d51e2c49}; !- Outlet Port
+
+OS:Node,
+  {4a9c04fb-4961-4603-a85a-6ae8afc21bbc}, !- Handle
+  Node 75,                                !- Name
+  {d02359e6-617e-4768-b984-45f74ff0c3e2}, !- Inlet Port
+  {d012d69e-50dd-4d84-953c-43e4feb3e529}; !- Outlet Port
+
+OS:Connection,
+  {053092c7-469f-4f8d-8967-9757f867a181}, !- Handle
+  {ec8d0f78-c4d4-4d12-aac5-43b3841ee051}, !- Name
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- Source Object
+  10,                                     !- Outlet Port
+  {9ce551c8-4e44-4dcf-b7aa-db5651ace865}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {f3425240-f052-40cc-b56e-f2d8d51e2c49}, !- Handle
+  {a9eec66c-da60-4403-b868-9bf5a4b7170b}, !- Name
+  {45d1fcc7-72fc-48b5-be4f-7094f9e208af}, !- Source Object
+  3,                                      !- Outlet Port
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {81cabfd0-2bfe-4ae1-97c6-679673a983c8}, !- Handle
+  Air Loop HVAC Zone Splitter 6,          !- Name
+  {1f5494bd-61fb-40e3-ba27-4d1780decccc}, !- Inlet Node Name
+  {ffdf2a51-d98c-43f3-b7e8-61fcdd1bb98e}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {c17e6442-a5f2-4086-8fad-42d46f216308}, !- Handle
+  Air Loop HVAC Zone Mixer 6,             !- Name
+  {d40c5bb3-ac12-4545-9652-c0e8008a082b}, !- Outlet Node Name
+  {334bae4e-7164-4688-8a04-572aa97c9227}; !- Inlet Node Name 1
+
+OS:Connection,
+  {1f5494bd-61fb-40e3-ba27-4d1780decccc}, !- Handle
+  {78fd11ec-6ba2-443d-ab0d-e1fb4526988e}, !- Name
+  {9ce551c8-4e44-4dcf-b7aa-db5651ace865}, !- Source Object
+  3,                                      !- Outlet Port
+  {81cabfd0-2bfe-4ae1-97c6-679673a983c8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d40c5bb3-ac12-4545-9652-c0e8008a082b}, !- Handle
+  {171df812-d39e-42da-b0dc-49f89e60fd3e}, !- Name
+  {c17e6442-a5f2-4086-8fad-42d46f216308}, !- Source Object
+  2,                                      !- Outlet Port
+  {45d1fcc7-72fc-48b5-be4f-7094f9e208af}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {329031e5-fcd7-4ef9-abee-e634f4cf2305}, !- Handle
+  {5f943bd3-06bd-4b44-bf82-251835d87436}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {bbd6b55e-9c36-4a06-8433-65ec31b6ad34}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 5; !- Name
+
+OS:Fan:ConstantVolume,
+  {957cb7fe-71f7-4715-ab34-2fc1205e1f4c}, !- Handle
+  Fan Constant Volume 6,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {c199ff1e-a875-47d6-ace3-a94ef40b5b85}, !- Air Inlet Node Name
+  {d7b4e4fd-027e-49f3-a6d3-f49246921068}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {5d6a7b40-f0f2-4e71-b71c-6ca70e64f17f}, !- Handle
+  Coil Heating Gas 6,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {2116c73f-0904-49ba-ab0c-1220df5e1327}, !- Air Inlet Node Name
+  {8469dc24-add5-49bc-aa93-2ec3f4a3bc7c}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {fa3d24d7-fa15-45f1-b633-a7c1b55f0d9a}, !- Handle
+  Coil Cooling DX Single Speed 6,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {6154fd1d-bb37-4848-84fa-62d40397fbc1}, !- Air Inlet Node Name
+  {2797b1d0-a0d1-48a3-a0ed-8cbc3a3fa7f0}, !- Air Outlet Node Name
+  {a9c3cc7b-bf78-456f-af7f-386384cb47df}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {982b47ad-cb2d-4230-8433-99ff984c571d}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {9c249ff4-27d7-48fa-a301-42829e51fd20}, !- Energy Input Ratio Function of Temperature Curve Name
+  {e55b5e78-55f3-40c8-a478-70b78a1497be}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {853cebd9-9e43-4c25-babc-e4c78fcbba53}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {a9c3cc7b-bf78-456f-af7f-386384cb47df}, !- Handle
+  Curve Biquadratic 11,                   !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {982b47ad-cb2d-4230-8433-99ff984c571d}, !- Handle
+  Curve Quadratic 16,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {9c249ff4-27d7-48fa-a301-42829e51fd20}, !- Handle
+  Curve Biquadratic 12,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {e55b5e78-55f3-40c8-a478-70b78a1497be}, !- Handle
+  Curve Quadratic 17,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {853cebd9-9e43-4c25-babc-e4c78fcbba53}, !- Handle
+  Curve Quadratic 18,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {21222636-8433-45da-8343-ead5a84446c7}, !- Handle
+  Setpoint Manager Single Zone Reheat 6,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {658447b4-127f-4a1a-85ec-c2bfa2984b24}, !- Control Zone Name
+  {6b83d71f-ee01-47d8-a1b6-40b2f8f505df}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {6f9d9232-7c8d-425d-aec6-2eee580ad257}, !- Handle
+  Controller Outdoor Air 6,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {2bd335d9-f582-4ddb-b4bd-d3718b83e63b}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {2bd335d9-f582-4ddb-b4bd-d3718b83e63b}, !- Handle
+  Controller Mechanical Ventilation 6,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {96969bb4-12de-4604-9de4-066025bfb96e}, !- Handle
+  Air Loop HVAC Outdoor Air System 6,     !- Name
+  {6f9d9232-7c8d-425d-aec6-2eee580ad257}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {720b06c2-de23-49f2-a177-06e23d8327c8}, !- Mixed Air Node Name
+  {101d0e6e-8e34-430d-96b2-0b76b1ad7277}, !- Outdoor Air Stream Node Name
+  {b2571687-f0ce-44b9-94d2-8a9b3ee91ed6}, !- Relief Air Stream Node Name
+  {847413ec-8804-4a9b-98ac-c1bfc01cfa77}; !- Return Air Stream Node Name
+
+OS:Node,
+  {ab06d374-7d66-4df9-a8a8-c8d073401f1b}, !- Handle
+  Node 76,                                !- Name
+  ,                                       !- Inlet Port
+  {101d0e6e-8e34-430d-96b2-0b76b1ad7277}; !- Outlet Port
+
+OS:Connection,
+  {101d0e6e-8e34-430d-96b2-0b76b1ad7277}, !- Handle
+  {2f5eb204-538c-4a9c-ace2-5fea7e1c69c8}, !- Name
+  {ab06d374-7d66-4df9-a8a8-c8d073401f1b}, !- Source Object
+  3,                                      !- Outlet Port
+  {96969bb4-12de-4604-9de4-066025bfb96e}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {122fecfa-9bcc-4be6-bc01-c98a310aac9b}, !- Handle
+  Node 77,                                !- Name
+  {b2571687-f0ce-44b9-94d2-8a9b3ee91ed6}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {b2571687-f0ce-44b9-94d2-8a9b3ee91ed6}, !- Handle
+  {9416be1f-be56-421a-9a27-14b38443eb02}, !- Name
+  {96969bb4-12de-4604-9de4-066025bfb96e}, !- Source Object
+  7,                                      !- Outlet Port
+  {122fecfa-9bcc-4be6-bc01-c98a310aac9b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {847413ec-8804-4a9b-98ac-c1bfc01cfa77}, !- Handle
+  {f14cca2b-8212-43d7-a902-aeed09604818}, !- Name
+  {b68bf42b-6319-46d2-9fd2-f3aa7f6b6282}, !- Source Object
+  3,                                      !- Outlet Port
+  {96969bb4-12de-4604-9de4-066025bfb96e}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {256c5ca9-6a81-4df1-a061-743f84d299ce}, !- Handle
+  Node 78,                                !- Name
+  {720b06c2-de23-49f2-a177-06e23d8327c8}, !- Inlet Port
+  {6154fd1d-bb37-4848-84fa-62d40397fbc1}; !- Outlet Port
+
+OS:Connection,
+  {720b06c2-de23-49f2-a177-06e23d8327c8}, !- Handle
+  {c286e954-324f-4705-852b-c838ba09d2a8}, !- Name
+  {96969bb4-12de-4604-9de4-066025bfb96e}, !- Source Object
+  5,                                      !- Outlet Port
+  {256c5ca9-6a81-4df1-a061-743f84d299ce}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6154fd1d-bb37-4848-84fa-62d40397fbc1}, !- Handle
+  {13e0dbea-6344-44b0-83d4-fbc992f1afd4}, !- Name
+  {256c5ca9-6a81-4df1-a061-743f84d299ce}, !- Source Object
+  3,                                      !- Outlet Port
+  {fa3d24d7-fa15-45f1-b633-a7c1b55f0d9a}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {13c2602b-100f-4b9a-9ae9-557b0486116d}, !- Handle
+  Node 79,                                !- Name
+  {2797b1d0-a0d1-48a3-a0ed-8cbc3a3fa7f0}, !- Inlet Port
+  {2116c73f-0904-49ba-ab0c-1220df5e1327}; !- Outlet Port
+
+OS:Connection,
+  {2797b1d0-a0d1-48a3-a0ed-8cbc3a3fa7f0}, !- Handle
+  {246cd52b-24e4-4109-8bab-4a1c6cfa6196}, !- Name
+  {fa3d24d7-fa15-45f1-b633-a7c1b55f0d9a}, !- Source Object
+  9,                                      !- Outlet Port
+  {13c2602b-100f-4b9a-9ae9-557b0486116d}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {2116c73f-0904-49ba-ab0c-1220df5e1327}, !- Handle
+  {a89c4c66-544f-4a6f-8543-68352671ce9d}, !- Name
+  {13c2602b-100f-4b9a-9ae9-557b0486116d}, !- Source Object
+  3,                                      !- Outlet Port
+  {5d6a7b40-f0f2-4e71-b71c-6ca70e64f17f}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {4fd77804-3b65-4978-9a67-cc1b6e34c525}, !- Handle
+  Node 80,                                !- Name
+  {8469dc24-add5-49bc-aa93-2ec3f4a3bc7c}, !- Inlet Port
+  {c199ff1e-a875-47d6-ace3-a94ef40b5b85}; !- Outlet Port
+
+OS:Connection,
+  {8469dc24-add5-49bc-aa93-2ec3f4a3bc7c}, !- Handle
+  {29b8cbdc-ec28-482d-93a5-bf664baef324}, !- Name
+  {5d6a7b40-f0f2-4e71-b71c-6ca70e64f17f}, !- Source Object
+  6,                                      !- Outlet Port
+  {4fd77804-3b65-4978-9a67-cc1b6e34c525}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {c199ff1e-a875-47d6-ace3-a94ef40b5b85}, !- Handle
+  {bc67af57-509a-44af-94cd-be8e0cf80695}, !- Name
+  {4fd77804-3b65-4978-9a67-cc1b6e34c525}, !- Source Object
+  3,                                      !- Outlet Port
+  {957cb7fe-71f7-4715-ab34-2fc1205e1f4c}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {d7b4e4fd-027e-49f3-a6d3-f49246921068}, !- Handle
+  {7b737c3f-1a51-4557-9144-86155b7d0061}, !- Name
+  {957cb7fe-71f7-4715-ab34-2fc1205e1f4c}, !- Source Object
+  9,                                      !- Outlet Port
+  {6b83d71f-ee01-47d8-a1b6-40b2f8f505df}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {a406fe15-6483-4f33-8c2b-af898a9a2144}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 6, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {e125f5ce-30f5-4029-8309-4f97b67a73b7}, !- Air Inlet Node Name
+  {d02359e6-617e-4768-b984-45f74ff0c3e2}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {25d06351-05cf-4096-ac92-b05b793fa8db}, !- Handle
+  Node 81,                                !- Name
+  {ffdf2a51-d98c-43f3-b7e8-61fcdd1bb98e}, !- Inlet Port
+  {e125f5ce-30f5-4029-8309-4f97b67a73b7}; !- Outlet Port
+
+OS:Connection,
+  {ffdf2a51-d98c-43f3-b7e8-61fcdd1bb98e}, !- Handle
+  {d227cb49-3d8f-4750-819a-995d99d29e78}, !- Name
+  {81cabfd0-2bfe-4ae1-97c6-679673a983c8}, !- Source Object
+  3,                                      !- Outlet Port
+  {25d06351-05cf-4096-ac92-b05b793fa8db}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e125f5ce-30f5-4029-8309-4f97b67a73b7}, !- Handle
+  {cb3674fc-5b05-48a1-bc86-3b18479f57c6}, !- Name
+  {25d06351-05cf-4096-ac92-b05b793fa8db}, !- Source Object
+  3,                                      !- Outlet Port
+  {a406fe15-6483-4f33-8c2b-af898a9a2144}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {d02359e6-617e-4768-b984-45f74ff0c3e2}, !- Handle
+  {fc51cddb-886d-4586-97a7-7d3eedfe7820}, !- Name
+  {a406fe15-6483-4f33-8c2b-af898a9a2144}, !- Source Object
+  4,                                      !- Outlet Port
+  {4a9c04fb-4961-4603-a85a-6ae8afc21bbc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {914f671f-ea50-493a-8b17-d2841fe9d541}, !- Handle
+  Node 82,                                !- Name
+  {3f3ec081-c957-460c-a40e-e8242d80e494}, !- Inlet Port
+  {334bae4e-7164-4688-8a04-572aa97c9227}; !- Outlet Port
+
+OS:Connection,
+  {d012d69e-50dd-4d84-953c-43e4feb3e529}, !- Handle
+  {16daac33-3921-4297-9734-9fd962face16}, !- Name
+  {4a9c04fb-4961-4603-a85a-6ae8afc21bbc}, !- Source Object
+  3,                                      !- Outlet Port
+  {f7dd0c47-b5e7-4185-a236-1fd546b72f0a}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {3f3ec081-c957-460c-a40e-e8242d80e494}, !- Handle
+  {9b5f07ba-bb6e-4032-a020-51f871505e23}, !- Name
+  {143632a7-12f9-4ab9-a95f-b8e2ed43c00a}, !- Source Object
+  3,                                      !- Outlet Port
+  {914f671f-ea50-493a-8b17-d2841fe9d541}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {334bae4e-7164-4688-8a04-572aa97c9227}, !- Handle
+  {68f55cb8-d987-4729-ab78-3bc18ea478e7}, !- Name
+  {914f671f-ea50-493a-8b17-d2841fe9d541}, !- Source Object
+  3,                                      !- Outlet Port
+  {c17e6442-a5f2-4086-8fad-42d46f216308}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- Handle
+  Packaged Rooftop Air Conditioner 6,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {c47f512c-aca0-48b9-a11d-d2dea9364abd}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {a500ade2-bb55-4c69-a88a-e4447d5db778}, !- Supply Side Inlet Node Name
+  {16897949-0f71-4140-baf9-8a58b4b09a74}, !- Demand Side Outlet Node Name
+  {7e12d137-ae0e-4a9b-bd16-260a4578f92b}, !- Demand Side Inlet Node A
+  {5953aa93-bc3d-4562-9a96-d7752868722b}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {60ff2ce4-4bf4-457c-99db-18e0bc255bbb}, !- Demand Mixer Name
+  {7f1f1673-8837-4fa8-a3c1-a12792dd6d5f}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {bc9e5d8a-c2c3-4cd8-9146-1bd85f39a104}, !- Handle
+  Node 83,                                !- Name
+  {a500ade2-bb55-4c69-a88a-e4447d5db778}, !- Inlet Port
+  {18ca8d1c-99c3-4b44-b568-bed48c7c790d}; !- Outlet Port
+
+OS:Node,
+  {c48f6370-00e6-402b-8b41-a675164258d5}, !- Handle
+  Node 84,                                !- Name
+  {040e7bc5-800a-4477-9f60-fe07bf99fca7}, !- Inlet Port
+  {5953aa93-bc3d-4562-9a96-d7752868722b}; !- Outlet Port
+
+OS:Connection,
+  {a500ade2-bb55-4c69-a88a-e4447d5db778}, !- Handle
+  {b8f1b9ed-4e5c-45ee-8add-4994d35f4a25}, !- Name
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- Source Object
+  8,                                      !- Outlet Port
+  {bc9e5d8a-c2c3-4cd8-9146-1bd85f39a104}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {5953aa93-bc3d-4562-9a96-d7752868722b}, !- Handle
+  {6fa9c8fd-b9d5-485a-bb7d-6d0a89ab4c91}, !- Name
+  {c48f6370-00e6-402b-8b41-a675164258d5}, !- Source Object
+  3,                                      !- Outlet Port
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {d3eb8cb6-a560-4b33-97bd-7574890ec753}, !- Handle
+  Node 85,                                !- Name
+  {7e12d137-ae0e-4a9b-bd16-260a4578f92b}, !- Inlet Port
+  {1f4f90bb-c9ca-4eb2-8905-045162535fae}; !- Outlet Port
+
+OS:Node,
+  {69efe53e-3962-484d-a6c5-5966d5c93f8a}, !- Handle
+  Node 86,                                !- Name
+  {09b482cd-37a6-4e59-95ab-5c1f64b25a71}, !- Inlet Port
+  {16897949-0f71-4140-baf9-8a58b4b09a74}; !- Outlet Port
+
+OS:Node,
+  {afb4bdf9-5c94-4ab2-9131-700b99761aac}, !- Handle
+  Node 87,                                !- Name
+  {8d0a4c54-26a0-453c-9aa3-c2fb9d58209d}, !- Inlet Port
+  {617951d7-f87a-49ec-9ad3-e789c20ab896}; !- Outlet Port
+
+OS:Connection,
+  {7e12d137-ae0e-4a9b-bd16-260a4578f92b}, !- Handle
+  {c9b04988-f529-4a6f-a32c-2f00b677fe36}, !- Name
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- Source Object
+  10,                                     !- Outlet Port
+  {d3eb8cb6-a560-4b33-97bd-7574890ec753}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {16897949-0f71-4140-baf9-8a58b4b09a74}, !- Handle
+  {d2f74be7-9548-4860-b22c-21f3b0d88f84}, !- Name
+  {69efe53e-3962-484d-a6c5-5966d5c93f8a}, !- Source Object
+  3,                                      !- Outlet Port
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {7f1f1673-8837-4fa8-a3c1-a12792dd6d5f}, !- Handle
+  Air Loop HVAC Zone Splitter 7,          !- Name
+  {1f4f90bb-c9ca-4eb2-8905-045162535fae}, !- Inlet Node Name
+  {ec8a0962-a1de-42ac-8e82-cb8b307c4aa1}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {60ff2ce4-4bf4-457c-99db-18e0bc255bbb}, !- Handle
+  Air Loop HVAC Zone Mixer 7,             !- Name
+  {09b482cd-37a6-4e59-95ab-5c1f64b25a71}, !- Outlet Node Name
+  {1f717636-0df3-46e3-abdd-b37dc0fd99e1}; !- Inlet Node Name 1
+
+OS:Connection,
+  {1f4f90bb-c9ca-4eb2-8905-045162535fae}, !- Handle
+  {dd678df2-c443-4f5e-ab60-791a3027dfbc}, !- Name
+  {d3eb8cb6-a560-4b33-97bd-7574890ec753}, !- Source Object
+  3,                                      !- Outlet Port
+  {7f1f1673-8837-4fa8-a3c1-a12792dd6d5f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {09b482cd-37a6-4e59-95ab-5c1f64b25a71}, !- Handle
+  {dc89832b-b023-4643-93c8-e16f0db5f0b0}, !- Name
+  {60ff2ce4-4bf4-457c-99db-18e0bc255bbb}, !- Source Object
+  2,                                      !- Outlet Port
+  {69efe53e-3962-484d-a6c5-5966d5c93f8a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {7d3d7253-a684-41a6-9ca6-de13fb18aa1c}, !- Handle
+  {93dc48c8-f721-49ca-807d-02b1a4bcab0a}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {c47f512c-aca0-48b9-a11d-d2dea9364abd}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 6; !- Name
+
+OS:Fan:ConstantVolume,
+  {d196eaeb-f01b-43cc-83eb-d77759febaec}, !- Handle
+  Fan Constant Volume 7,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {206bcc85-1aaf-4f16-a92d-f5f01e5cd34d}, !- Air Inlet Node Name
+  {040e7bc5-800a-4477-9f60-fe07bf99fca7}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {3f1869c9-dae2-4c64-86a4-8aef7e40966a}, !- Handle
+  Coil Heating Gas 7,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {737107fd-c9ef-40c2-a009-dbfdd6c02fc5}, !- Air Inlet Node Name
+  {072f82cd-e3ed-48c2-90be-13c09ff215ca}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {68596aa0-979f-4263-a3b5-cc547226c02a}, !- Handle
+  Coil Cooling DX Single Speed 7,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {01cf1213-ce0f-410b-aa45-dc847f98ffc3}, !- Air Inlet Node Name
+  {d15aa6a4-0480-4579-8974-a6ea69b3af8e}, !- Air Outlet Node Name
+  {3b798b0d-4e3a-40c7-b086-8ce54a213380}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {7321c4c5-23f4-4dd8-9e74-caeda6a4d19c}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {0d02e5f4-5532-4232-8646-6fdc3a77e20d}, !- Energy Input Ratio Function of Temperature Curve Name
+  {ccac91ba-44c4-43cb-af30-a0727cb56692}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {8ae4f210-c94d-47c1-b544-9e5e6a5092e6}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {3b798b0d-4e3a-40c7-b086-8ce54a213380}, !- Handle
+  Curve Biquadratic 13,                   !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {7321c4c5-23f4-4dd8-9e74-caeda6a4d19c}, !- Handle
+  Curve Quadratic 19,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {0d02e5f4-5532-4232-8646-6fdc3a77e20d}, !- Handle
+  Curve Biquadratic 14,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {ccac91ba-44c4-43cb-af30-a0727cb56692}, !- Handle
+  Curve Quadratic 20,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {8ae4f210-c94d-47c1-b544-9e5e6a5092e6}, !- Handle
+  Curve Quadratic 21,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {44b8c2ee-73a1-4d89-9464-d9b00d076e35}, !- Handle
+  Setpoint Manager Single Zone Reheat 7,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {5c78c01f-7d60-4aa8-97f2-191d1da3144f}, !- Control Zone Name
+  {c48f6370-00e6-402b-8b41-a675164258d5}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {f3377fcc-549c-4820-ab7d-f12fc3f28945}, !- Handle
+  Controller Outdoor Air 7,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {1f67c0d8-86ec-484e-93da-d566af641fea}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {1f67c0d8-86ec-484e-93da-d566af641fea}, !- Handle
+  Controller Mechanical Ventilation 7,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {341c327e-e0fe-46c8-b862-d467b1a635ae}, !- Handle
+  Air Loop HVAC Outdoor Air System 7,     !- Name
+  {f3377fcc-549c-4820-ab7d-f12fc3f28945}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {829979da-38a7-4146-a051-a1a9b92ada97}, !- Mixed Air Node Name
+  {c17bef66-395d-4457-a49c-360415b24aaf}, !- Outdoor Air Stream Node Name
+  {5e098fa9-90bf-4d55-87b0-e54399ad96ed}, !- Relief Air Stream Node Name
+  {18ca8d1c-99c3-4b44-b568-bed48c7c790d}; !- Return Air Stream Node Name
+
+OS:Node,
+  {3ac9788f-907f-47df-b795-e7f0e1aba742}, !- Handle
+  Node 88,                                !- Name
+  ,                                       !- Inlet Port
+  {c17bef66-395d-4457-a49c-360415b24aaf}; !- Outlet Port
+
+OS:Connection,
+  {c17bef66-395d-4457-a49c-360415b24aaf}, !- Handle
+  {8bcf8562-0618-4435-a652-874a14dae1d8}, !- Name
+  {3ac9788f-907f-47df-b795-e7f0e1aba742}, !- Source Object
+  3,                                      !- Outlet Port
+  {341c327e-e0fe-46c8-b862-d467b1a635ae}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {f838b3ad-6e94-4194-8604-61d6328a9507}, !- Handle
+  Node 89,                                !- Name
+  {5e098fa9-90bf-4d55-87b0-e54399ad96ed}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {5e098fa9-90bf-4d55-87b0-e54399ad96ed}, !- Handle
+  {59ecdb5f-1f13-493a-adfa-3522529a02d0}, !- Name
+  {341c327e-e0fe-46c8-b862-d467b1a635ae}, !- Source Object
+  7,                                      !- Outlet Port
+  {f838b3ad-6e94-4194-8604-61d6328a9507}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {18ca8d1c-99c3-4b44-b568-bed48c7c790d}, !- Handle
+  {3dfa0c18-df96-44e7-8cbe-327087daab2a}, !- Name
+  {bc9e5d8a-c2c3-4cd8-9146-1bd85f39a104}, !- Source Object
+  3,                                      !- Outlet Port
+  {341c327e-e0fe-46c8-b862-d467b1a635ae}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {979a7da1-645d-4ef6-9a97-adff8ce0196b}, !- Handle
+  Node 90,                                !- Name
+  {829979da-38a7-4146-a051-a1a9b92ada97}, !- Inlet Port
+  {01cf1213-ce0f-410b-aa45-dc847f98ffc3}; !- Outlet Port
+
+OS:Connection,
+  {829979da-38a7-4146-a051-a1a9b92ada97}, !- Handle
+  {5b60aa89-7ea9-43ea-b4f0-51fe4435b7f6}, !- Name
+  {341c327e-e0fe-46c8-b862-d467b1a635ae}, !- Source Object
+  5,                                      !- Outlet Port
+  {979a7da1-645d-4ef6-9a97-adff8ce0196b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {01cf1213-ce0f-410b-aa45-dc847f98ffc3}, !- Handle
+  {21b15623-c47a-47f1-933c-560d39ae093a}, !- Name
+  {979a7da1-645d-4ef6-9a97-adff8ce0196b}, !- Source Object
+  3,                                      !- Outlet Port
+  {68596aa0-979f-4263-a3b5-cc547226c02a}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {fa91c41e-014a-4342-b70c-c8c033e6867c}, !- Handle
+  Node 91,                                !- Name
+  {d15aa6a4-0480-4579-8974-a6ea69b3af8e}, !- Inlet Port
+  {737107fd-c9ef-40c2-a009-dbfdd6c02fc5}; !- Outlet Port
+
+OS:Connection,
+  {d15aa6a4-0480-4579-8974-a6ea69b3af8e}, !- Handle
+  {495b6fa7-44ce-4fcc-8c8e-1c13794b8f59}, !- Name
+  {68596aa0-979f-4263-a3b5-cc547226c02a}, !- Source Object
+  9,                                      !- Outlet Port
+  {fa91c41e-014a-4342-b70c-c8c033e6867c}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {737107fd-c9ef-40c2-a009-dbfdd6c02fc5}, !- Handle
+  {6a9048e8-4d20-40d9-8e7f-fe3fb4231b3d}, !- Name
+  {fa91c41e-014a-4342-b70c-c8c033e6867c}, !- Source Object
+  3,                                      !- Outlet Port
+  {3f1869c9-dae2-4c64-86a4-8aef7e40966a}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {948eb4dd-db90-4ac6-983e-83a44824c2b1}, !- Handle
+  Node 92,                                !- Name
+  {072f82cd-e3ed-48c2-90be-13c09ff215ca}, !- Inlet Port
+  {206bcc85-1aaf-4f16-a92d-f5f01e5cd34d}; !- Outlet Port
+
+OS:Connection,
+  {072f82cd-e3ed-48c2-90be-13c09ff215ca}, !- Handle
+  {75d8c320-d6b4-418a-8543-25ab09b651a2}, !- Name
+  {3f1869c9-dae2-4c64-86a4-8aef7e40966a}, !- Source Object
+  6,                                      !- Outlet Port
+  {948eb4dd-db90-4ac6-983e-83a44824c2b1}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {206bcc85-1aaf-4f16-a92d-f5f01e5cd34d}, !- Handle
+  {ca86e8a6-89b3-48f1-886a-38113b2b80e6}, !- Name
+  {948eb4dd-db90-4ac6-983e-83a44824c2b1}, !- Source Object
+  3,                                      !- Outlet Port
+  {d196eaeb-f01b-43cc-83eb-d77759febaec}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {040e7bc5-800a-4477-9f60-fe07bf99fca7}, !- Handle
+  {586d0fc3-24b9-4925-b38e-16fdccb666d6}, !- Name
+  {d196eaeb-f01b-43cc-83eb-d77759febaec}, !- Source Object
+  9,                                      !- Outlet Port
+  {c48f6370-00e6-402b-8b41-a675164258d5}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {7c7eb001-b140-4147-9fb9-053f9bf96be9}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 7, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {77113550-1d5d-4e7b-b61a-5a811dd82b11}, !- Air Inlet Node Name
+  {8d0a4c54-26a0-453c-9aa3-c2fb9d58209d}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {d55513e4-bc63-4e33-8679-0e16006962cc}, !- Handle
+  Node 93,                                !- Name
+  {ec8a0962-a1de-42ac-8e82-cb8b307c4aa1}, !- Inlet Port
+  {77113550-1d5d-4e7b-b61a-5a811dd82b11}; !- Outlet Port
+
+OS:Connection,
+  {ec8a0962-a1de-42ac-8e82-cb8b307c4aa1}, !- Handle
+  {82209d49-4068-4b14-8346-371f45d075f6}, !- Name
+  {7f1f1673-8837-4fa8-a3c1-a12792dd6d5f}, !- Source Object
+  3,                                      !- Outlet Port
+  {d55513e4-bc63-4e33-8679-0e16006962cc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {77113550-1d5d-4e7b-b61a-5a811dd82b11}, !- Handle
+  {74b91034-cfcb-4038-b0a5-d9a1eb3846ac}, !- Name
+  {d55513e4-bc63-4e33-8679-0e16006962cc}, !- Source Object
+  3,                                      !- Outlet Port
+  {7c7eb001-b140-4147-9fb9-053f9bf96be9}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {8d0a4c54-26a0-453c-9aa3-c2fb9d58209d}, !- Handle
+  {2a5ea664-96b4-4b26-877a-abcf9153c151}, !- Name
+  {7c7eb001-b140-4147-9fb9-053f9bf96be9}, !- Source Object
+  4,                                      !- Outlet Port
+  {afb4bdf9-5c94-4ab2-9131-700b99761aac}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {cecdaa0d-d5b4-4859-bf3e-ca2db80783f8}, !- Handle
+  Node 94,                                !- Name
+  {fed08038-ab86-4f79-a648-41493a09f5bd}, !- Inlet Port
+  {1f717636-0df3-46e3-abdd-b37dc0fd99e1}; !- Outlet Port
+
+OS:Connection,
+  {617951d7-f87a-49ec-9ad3-e789c20ab896}, !- Handle
+  {f019a3b5-ae6e-4479-ab0a-00129752c691}, !- Name
+  {afb4bdf9-5c94-4ab2-9131-700b99761aac}, !- Source Object
+  3,                                      !- Outlet Port
+  {96bff8ff-e52d-43ab-899f-7cdcdafa815a}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {fed08038-ab86-4f79-a648-41493a09f5bd}, !- Handle
+  {e47eedbc-eed6-4c4d-86ff-5d261d1e7e13}, !- Name
+  {43f04564-917d-4242-86b1-a84e44c68ed8}, !- Source Object
+  3,                                      !- Outlet Port
+  {cecdaa0d-d5b4-4859-bf3e-ca2db80783f8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {1f717636-0df3-46e3-abdd-b37dc0fd99e1}, !- Handle
+  {36c7a589-d0ff-4a95-9958-c4d005534b4f}, !- Name
+  {cecdaa0d-d5b4-4859-bf3e-ca2db80783f8}, !- Source Object
+  3,                                      !- Outlet Port
+  {60ff2ce4-4bf4-457c-99db-18e0bc255bbb}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- Handle
+  Packaged Rooftop Air Conditioner 7,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {7ca481b5-35eb-439c-9c8e-a2fdfabbfba9}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {4559daa0-d1d2-4b37-98c8-0872bfcea4c2}, !- Supply Side Inlet Node Name
+  {86ec94d3-d54a-4dc5-9cb6-edd484d2274c}, !- Demand Side Outlet Node Name
+  {7d7d8eec-1cbf-4184-b646-3ef95660a32c}, !- Demand Side Inlet Node A
+  {c819a950-aabe-4952-8931-f1cded38ecb9}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {7483b496-9304-4735-a225-91adc035c678}, !- Demand Mixer Name
+  {74c3fa34-ac9b-4261-9223-645724ef3a2b}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {cffc83eb-ff4d-4b21-89df-af6e84727a83}, !- Handle
+  Node 95,                                !- Name
+  {4559daa0-d1d2-4b37-98c8-0872bfcea4c2}, !- Inlet Port
+  {0871b8f3-1224-4264-95b5-b3d4f72daf45}; !- Outlet Port
+
+OS:Node,
+  {bd4738ec-cddd-4f48-b25b-b8f7117a5523}, !- Handle
+  Node 96,                                !- Name
+  {e87939d9-6053-4625-b576-5b47d7d1bfc9}, !- Inlet Port
+  {c819a950-aabe-4952-8931-f1cded38ecb9}; !- Outlet Port
+
+OS:Connection,
+  {4559daa0-d1d2-4b37-98c8-0872bfcea4c2}, !- Handle
+  {c676ce8b-74a1-4292-b237-7dac8109e7e1}, !- Name
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- Source Object
+  8,                                      !- Outlet Port
+  {cffc83eb-ff4d-4b21-89df-af6e84727a83}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {c819a950-aabe-4952-8931-f1cded38ecb9}, !- Handle
+  {218103f7-7c1d-492e-9123-a04bcc13d63a}, !- Name
+  {bd4738ec-cddd-4f48-b25b-b8f7117a5523}, !- Source Object
+  3,                                      !- Outlet Port
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {ac41198c-df75-4ea8-9933-119c1ea98b01}, !- Handle
+  Node 97,                                !- Name
+  {7d7d8eec-1cbf-4184-b646-3ef95660a32c}, !- Inlet Port
+  {ecdd3aec-4123-42c7-918e-e50d9957440f}; !- Outlet Port
+
+OS:Node,
+  {3119f127-3c87-4b94-84d2-1c88aec6a02d}, !- Handle
+  Node 98,                                !- Name
+  {451360c2-b31b-45e6-931e-e2a79d48f8ec}, !- Inlet Port
+  {86ec94d3-d54a-4dc5-9cb6-edd484d2274c}; !- Outlet Port
+
+OS:Node,
+  {3b635445-d179-4a8f-8b49-39e05bd60755}, !- Handle
+  Node 99,                                !- Name
+  {01119260-dda8-483b-bb86-a081625ed3a6}, !- Inlet Port
+  {b8270d1d-b79c-4642-ae43-8bb5d896b8df}; !- Outlet Port
+
+OS:Connection,
+  {7d7d8eec-1cbf-4184-b646-3ef95660a32c}, !- Handle
+  {ccef66e7-d37a-4705-9599-a3b74dac1a49}, !- Name
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- Source Object
+  10,                                     !- Outlet Port
+  {ac41198c-df75-4ea8-9933-119c1ea98b01}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {86ec94d3-d54a-4dc5-9cb6-edd484d2274c}, !- Handle
+  {6c10dd00-57bb-4044-8698-9774eef89aa2}, !- Name
+  {3119f127-3c87-4b94-84d2-1c88aec6a02d}, !- Source Object
+  3,                                      !- Outlet Port
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {74c3fa34-ac9b-4261-9223-645724ef3a2b}, !- Handle
+  Air Loop HVAC Zone Splitter 8,          !- Name
+  {ecdd3aec-4123-42c7-918e-e50d9957440f}, !- Inlet Node Name
+  {bd5eef99-3453-4c30-b680-586921a43dbc}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {7483b496-9304-4735-a225-91adc035c678}, !- Handle
+  Air Loop HVAC Zone Mixer 8,             !- Name
+  {451360c2-b31b-45e6-931e-e2a79d48f8ec}, !- Outlet Node Name
+  {3ae16c1b-fa76-4199-bc70-26a279f821df}; !- Inlet Node Name 1
+
+OS:Connection,
+  {ecdd3aec-4123-42c7-918e-e50d9957440f}, !- Handle
+  {ff42e5ad-4002-486a-8e0a-0905f7d423bb}, !- Name
+  {ac41198c-df75-4ea8-9933-119c1ea98b01}, !- Source Object
+  3,                                      !- Outlet Port
+  {74c3fa34-ac9b-4261-9223-645724ef3a2b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {451360c2-b31b-45e6-931e-e2a79d48f8ec}, !- Handle
+  {13a96a67-8137-4ad0-b796-1b90ff44289a}, !- Name
+  {7483b496-9304-4735-a225-91adc035c678}, !- Source Object
+  2,                                      !- Outlet Port
+  {3119f127-3c87-4b94-84d2-1c88aec6a02d}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {9c5845b0-df70-4a91-827f-e41d05b1bd34}, !- Handle
+  {0d6fb2fc-f8fc-4e96-ab96-060c63b0810d}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {7ca481b5-35eb-439c-9c8e-a2fdfabbfba9}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 7; !- Name
+
+OS:Fan:ConstantVolume,
+  {22a389d5-b620-4b4a-94b2-2efa2a8a9126}, !- Handle
+  Fan Constant Volume 8,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {9c59158a-1038-4bee-b2fd-a7a46ed0a82c}, !- Air Inlet Node Name
+  {e87939d9-6053-4625-b576-5b47d7d1bfc9}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {a9ebbab0-515d-404b-882f-426e7970e488}, !- Handle
+  Coil Heating Gas 8,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {d75a8398-cffd-473d-bc17-ca9ab6a54030}, !- Air Inlet Node Name
+  {70756771-d8ce-42ec-9d6f-e96f3280f70c}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {e1bd44e1-7103-4918-aefe-8d6ba9222235}, !- Handle
+  Coil Cooling DX Single Speed 8,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {e2fc51cf-d85b-4845-8b1c-0b41f1fcfe07}, !- Air Inlet Node Name
+  {cabcde1e-17b5-410d-8f11-aa02a75222bc}, !- Air Outlet Node Name
+  {8752f109-db7f-43c6-ba50-f56e0eeba44c}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {32edc4b0-5596-45fd-8d6f-1be2f8372991}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {029242c9-b995-47ce-9a77-ae3b69901f09}, !- Energy Input Ratio Function of Temperature Curve Name
+  {bbba550b-4c24-468c-a8bf-58055df5383e}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {170e5cab-6427-42d4-9ab3-d8c90154d71e}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {8752f109-db7f-43c6-ba50-f56e0eeba44c}, !- Handle
+  Curve Biquadratic 15,                   !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {32edc4b0-5596-45fd-8d6f-1be2f8372991}, !- Handle
+  Curve Quadratic 22,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {029242c9-b995-47ce-9a77-ae3b69901f09}, !- Handle
+  Curve Biquadratic 16,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {bbba550b-4c24-468c-a8bf-58055df5383e}, !- Handle
+  Curve Quadratic 23,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {170e5cab-6427-42d4-9ab3-d8c90154d71e}, !- Handle
+  Curve Quadratic 24,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {6222626a-d72b-4d30-96d3-37cd727f093f}, !- Handle
+  Setpoint Manager Single Zone Reheat 8,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {cac1695a-a96a-450c-97c2-a72b786d8d48}, !- Control Zone Name
+  {bd4738ec-cddd-4f48-b25b-b8f7117a5523}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {6d8c2bb1-d010-4a90-aac6-6a6cd8a47218}, !- Handle
+  Controller Outdoor Air 8,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {cb3046d1-977a-4b05-80e5-79499cf05f34}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {cb3046d1-977a-4b05-80e5-79499cf05f34}, !- Handle
+  Controller Mechanical Ventilation 8,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {50077f7e-303a-4bb3-bed1-f3204e02b0b4}, !- Handle
+  Air Loop HVAC Outdoor Air System 8,     !- Name
+  {6d8c2bb1-d010-4a90-aac6-6a6cd8a47218}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {a25db252-8f3f-47fb-8416-ff0f08fdc191}, !- Mixed Air Node Name
+  {4dacf325-af0c-4819-ad91-5adaf5a1e2f0}, !- Outdoor Air Stream Node Name
+  {0bebb538-4428-4fb1-ab2d-0960b57638e2}, !- Relief Air Stream Node Name
+  {0871b8f3-1224-4264-95b5-b3d4f72daf45}; !- Return Air Stream Node Name
+
+OS:Node,
+  {1d8bff8b-7afa-4315-a81b-49a00961ddf0}, !- Handle
+  Node 100,                               !- Name
+  ,                                       !- Inlet Port
+  {4dacf325-af0c-4819-ad91-5adaf5a1e2f0}; !- Outlet Port
+
+OS:Connection,
+  {4dacf325-af0c-4819-ad91-5adaf5a1e2f0}, !- Handle
+  {b76d8a83-ef98-4588-81de-892531415c3c}, !- Name
+  {1d8bff8b-7afa-4315-a81b-49a00961ddf0}, !- Source Object
+  3,                                      !- Outlet Port
+  {50077f7e-303a-4bb3-bed1-f3204e02b0b4}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {33421e23-e80e-4ff7-b8e5-ae0e6d6f85d9}, !- Handle
+  Node 101,                               !- Name
+  {0bebb538-4428-4fb1-ab2d-0960b57638e2}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {0bebb538-4428-4fb1-ab2d-0960b57638e2}, !- Handle
+  {812e2d39-f98d-4594-bd9a-3733e6f8b418}, !- Name
+  {50077f7e-303a-4bb3-bed1-f3204e02b0b4}, !- Source Object
+  7,                                      !- Outlet Port
+  {33421e23-e80e-4ff7-b8e5-ae0e6d6f85d9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {0871b8f3-1224-4264-95b5-b3d4f72daf45}, !- Handle
+  {13dcb6dd-87d3-48db-9a8e-fc1a4b8c7c0b}, !- Name
+  {cffc83eb-ff4d-4b21-89df-af6e84727a83}, !- Source Object
+  3,                                      !- Outlet Port
+  {50077f7e-303a-4bb3-bed1-f3204e02b0b4}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {96262f40-e04a-4cda-9f1c-55a9a7c3db78}, !- Handle
+  Node 102,                               !- Name
+  {a25db252-8f3f-47fb-8416-ff0f08fdc191}, !- Inlet Port
+  {e2fc51cf-d85b-4845-8b1c-0b41f1fcfe07}; !- Outlet Port
+
+OS:Connection,
+  {a25db252-8f3f-47fb-8416-ff0f08fdc191}, !- Handle
+  {b4175547-85b6-4dce-9cf1-8d199bc36cb0}, !- Name
+  {50077f7e-303a-4bb3-bed1-f3204e02b0b4}, !- Source Object
+  5,                                      !- Outlet Port
+  {96262f40-e04a-4cda-9f1c-55a9a7c3db78}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e2fc51cf-d85b-4845-8b1c-0b41f1fcfe07}, !- Handle
+  {6647d217-cbba-4fbc-9c5c-4a6510a01496}, !- Name
+  {96262f40-e04a-4cda-9f1c-55a9a7c3db78}, !- Source Object
+  3,                                      !- Outlet Port
+  {e1bd44e1-7103-4918-aefe-8d6ba9222235}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {fdaee8a7-637b-4283-9eaf-64d7b1d12f71}, !- Handle
+  Node 103,                               !- Name
+  {cabcde1e-17b5-410d-8f11-aa02a75222bc}, !- Inlet Port
+  {d75a8398-cffd-473d-bc17-ca9ab6a54030}; !- Outlet Port
+
+OS:Connection,
+  {cabcde1e-17b5-410d-8f11-aa02a75222bc}, !- Handle
+  {c591d2f8-3861-4985-8320-1cff54454a8e}, !- Name
+  {e1bd44e1-7103-4918-aefe-8d6ba9222235}, !- Source Object
+  9,                                      !- Outlet Port
+  {fdaee8a7-637b-4283-9eaf-64d7b1d12f71}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d75a8398-cffd-473d-bc17-ca9ab6a54030}, !- Handle
+  {40ced81b-854c-4719-9393-fbff13f78f4d}, !- Name
+  {fdaee8a7-637b-4283-9eaf-64d7b1d12f71}, !- Source Object
+  3,                                      !- Outlet Port
+  {a9ebbab0-515d-404b-882f-426e7970e488}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {f39a9af7-2b9b-491d-8ec6-f4e458cdaa01}, !- Handle
+  Node 104,                               !- Name
+  {70756771-d8ce-42ec-9d6f-e96f3280f70c}, !- Inlet Port
+  {9c59158a-1038-4bee-b2fd-a7a46ed0a82c}; !- Outlet Port
+
+OS:Connection,
+  {70756771-d8ce-42ec-9d6f-e96f3280f70c}, !- Handle
+  {84a021bf-068a-43b1-b7d0-6c4fd94293b4}, !- Name
+  {a9ebbab0-515d-404b-882f-426e7970e488}, !- Source Object
+  6,                                      !- Outlet Port
+  {f39a9af7-2b9b-491d-8ec6-f4e458cdaa01}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {9c59158a-1038-4bee-b2fd-a7a46ed0a82c}, !- Handle
+  {1794ed97-b53a-4921-a73e-1d456b7a1250}, !- Name
+  {f39a9af7-2b9b-491d-8ec6-f4e458cdaa01}, !- Source Object
+  3,                                      !- Outlet Port
+  {22a389d5-b620-4b4a-94b2-2efa2a8a9126}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {e87939d9-6053-4625-b576-5b47d7d1bfc9}, !- Handle
+  {62e53b97-99e4-42d2-91b0-e7a85c232a93}, !- Name
+  {22a389d5-b620-4b4a-94b2-2efa2a8a9126}, !- Source Object
+  9,                                      !- Outlet Port
+  {bd4738ec-cddd-4f48-b25b-b8f7117a5523}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {41e1dd69-d076-47a0-92eb-9ca7e2b74960}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 8, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {d257ef3d-0f93-4134-b0e3-9c8c3c889d7d}, !- Air Inlet Node Name
+  {01119260-dda8-483b-bb86-a081625ed3a6}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {69290509-05c5-4b7d-886c-04ab94fd2d0e}, !- Handle
+  Node 105,                               !- Name
+  {bd5eef99-3453-4c30-b680-586921a43dbc}, !- Inlet Port
+  {d257ef3d-0f93-4134-b0e3-9c8c3c889d7d}; !- Outlet Port
+
+OS:Connection,
+  {bd5eef99-3453-4c30-b680-586921a43dbc}, !- Handle
+  {ada6d27c-fe3f-49ec-9ac4-73d27822dda2}, !- Name
+  {74c3fa34-ac9b-4261-9223-645724ef3a2b}, !- Source Object
+  3,                                      !- Outlet Port
+  {69290509-05c5-4b7d-886c-04ab94fd2d0e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d257ef3d-0f93-4134-b0e3-9c8c3c889d7d}, !- Handle
+  {9c79b687-9662-41a3-b023-e04b2e5584df}, !- Name
+  {69290509-05c5-4b7d-886c-04ab94fd2d0e}, !- Source Object
+  3,                                      !- Outlet Port
+  {41e1dd69-d076-47a0-92eb-9ca7e2b74960}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {01119260-dda8-483b-bb86-a081625ed3a6}, !- Handle
+  {77726541-15fb-411c-b628-e60805389312}, !- Name
+  {41e1dd69-d076-47a0-92eb-9ca7e2b74960}, !- Source Object
+  4,                                      !- Outlet Port
+  {3b635445-d179-4a8f-8b49-39e05bd60755}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {f2122682-8a5c-44c7-a8f8-8891f9866f07}, !- Handle
+  Node 106,                               !- Name
+  {74243c2f-6a41-4e0f-85f6-fac38ad9b368}, !- Inlet Port
+  {3ae16c1b-fa76-4199-bc70-26a279f821df}; !- Outlet Port
+
+OS:Connection,
+  {b8270d1d-b79c-4642-ae43-8bb5d896b8df}, !- Handle
+  {0da994ed-5f46-47f5-a637-56b882591882}, !- Name
+  {3b635445-d179-4a8f-8b49-39e05bd60755}, !- Source Object
+  3,                                      !- Outlet Port
+  {87f75aba-f2ed-42f3-b362-f5c995e946bc}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {74243c2f-6a41-4e0f-85f6-fac38ad9b368}, !- Handle
+  {3193e79c-6163-442f-bc63-0ed8b3016666}, !- Name
+  {6ee3f473-d624-4484-ba66-8a197f2dd9ff}, !- Source Object
+  3,                                      !- Outlet Port
+  {f2122682-8a5c-44c7-a8f8-8891f9866f07}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {3ae16c1b-fa76-4199-bc70-26a279f821df}, !- Handle
+  {ce5c5faf-c9f8-4718-85f6-707d32d2bac2}, !- Name
+  {f2122682-8a5c-44c7-a8f8-8891f9866f07}, !- Source Object
+  3,                                      !- Outlet Port
+  {7483b496-9304-4735-a225-91adc035c678}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- Handle
+  Packaged Rooftop Air Conditioner 8,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {a018bfa8-47b8-4685-8210-a0936c8faaf5}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {344e9339-2aef-471c-86c4-d8dc5215884d}, !- Supply Side Inlet Node Name
+  {3157f1dc-00b5-4816-a111-e78c106175bd}, !- Demand Side Outlet Node Name
+  {24263fee-f66d-4f3f-b6e2-f9a848ae41e4}, !- Demand Side Inlet Node A
+  {f7c5f48f-d80e-40ee-848c-1443ed282d1e}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {f96e3cf0-9e67-4931-8553-c055e6b69aeb}, !- Demand Mixer Name
+  {8653a34c-d049-4f87-b986-bc5ac619fa4e}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {a2f79b53-6e6a-4279-9dcc-5d5d8a09dd47}, !- Handle
+  Node 107,                               !- Name
+  {344e9339-2aef-471c-86c4-d8dc5215884d}, !- Inlet Port
+  {21ebef25-44f2-40d9-ad9b-025e1c7fb54b}; !- Outlet Port
+
+OS:Node,
+  {229efc63-3a6f-4aa0-8bc8-3ebf47ea9f0e}, !- Handle
+  Node 108,                               !- Name
+  {52165ffb-e324-4bfb-aecd-6e5b66cac85d}, !- Inlet Port
+  {f7c5f48f-d80e-40ee-848c-1443ed282d1e}; !- Outlet Port
+
+OS:Connection,
+  {344e9339-2aef-471c-86c4-d8dc5215884d}, !- Handle
+  {67926102-ce9c-43cf-96e1-98046de855c9}, !- Name
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- Source Object
+  8,                                      !- Outlet Port
+  {a2f79b53-6e6a-4279-9dcc-5d5d8a09dd47}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {f7c5f48f-d80e-40ee-848c-1443ed282d1e}, !- Handle
+  {a8844210-570d-4a0e-bc87-dc48fd0eae30}, !- Name
+  {229efc63-3a6f-4aa0-8bc8-3ebf47ea9f0e}, !- Source Object
+  3,                                      !- Outlet Port
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {4d15bc45-c292-42d0-9188-fcc45d5a9782}, !- Handle
+  Node 109,                               !- Name
+  {24263fee-f66d-4f3f-b6e2-f9a848ae41e4}, !- Inlet Port
+  {f6e19c62-314f-49ef-a89a-28c20f152890}; !- Outlet Port
+
+OS:Node,
+  {ea34419a-d442-4c2e-81ca-572e014e7670}, !- Handle
+  Node 110,                               !- Name
+  {29e5e7b7-3de2-41f0-85d8-edd1abbdd8a8}, !- Inlet Port
+  {3157f1dc-00b5-4816-a111-e78c106175bd}; !- Outlet Port
+
+OS:Node,
+  {86825d84-b372-47c6-bd0d-85046416969f}, !- Handle
+  Node 111,                               !- Name
+  {08a6d9a6-b35e-45f5-a186-bc6b549912c1}, !- Inlet Port
+  {c623d4cb-f69c-4468-9b57-74d721fa34cc}; !- Outlet Port
+
+OS:Connection,
+  {24263fee-f66d-4f3f-b6e2-f9a848ae41e4}, !- Handle
+  {ae12dd8e-dd6f-49b5-abc9-60c0dab7bdaf}, !- Name
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- Source Object
+  10,                                     !- Outlet Port
+  {4d15bc45-c292-42d0-9188-fcc45d5a9782}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {3157f1dc-00b5-4816-a111-e78c106175bd}, !- Handle
+  {dbf4dc33-08e7-423b-919c-53a5f7e51e62}, !- Name
+  {ea34419a-d442-4c2e-81ca-572e014e7670}, !- Source Object
+  3,                                      !- Outlet Port
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {8653a34c-d049-4f87-b986-bc5ac619fa4e}, !- Handle
+  Air Loop HVAC Zone Splitter 9,          !- Name
+  {f6e19c62-314f-49ef-a89a-28c20f152890}, !- Inlet Node Name
+  {28e17642-cdfd-4475-baa9-7b152cdb562b}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {f96e3cf0-9e67-4931-8553-c055e6b69aeb}, !- Handle
+  Air Loop HVAC Zone Mixer 9,             !- Name
+  {29e5e7b7-3de2-41f0-85d8-edd1abbdd8a8}, !- Outlet Node Name
+  {0fb9592a-d09a-4e81-be54-de46d2a75962}; !- Inlet Node Name 1
+
+OS:Connection,
+  {f6e19c62-314f-49ef-a89a-28c20f152890}, !- Handle
+  {c08df209-992c-48e7-bad3-3e0c1f8ca97b}, !- Name
+  {4d15bc45-c292-42d0-9188-fcc45d5a9782}, !- Source Object
+  3,                                      !- Outlet Port
+  {8653a34c-d049-4f87-b986-bc5ac619fa4e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {29e5e7b7-3de2-41f0-85d8-edd1abbdd8a8}, !- Handle
+  {24a38fbe-2c55-4d41-b82e-592f7c676315}, !- Name
+  {f96e3cf0-9e67-4931-8553-c055e6b69aeb}, !- Source Object
+  2,                                      !- Outlet Port
+  {ea34419a-d442-4c2e-81ca-572e014e7670}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {58a26baa-87e5-4803-9df8-a50698c9d2b6}, !- Handle
+  {cebf5beb-2958-4ebc-964d-a4e5c8dd0f69}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {a018bfa8-47b8-4685-8210-a0936c8faaf5}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 8; !- Name
+
+OS:Fan:ConstantVolume,
+  {9f16257e-aa17-4b96-9dde-36a945e83b08}, !- Handle
+  Fan Constant Volume 9,                  !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {14b47223-8e71-4846-bb38-30391bbe5fa3}, !- Air Inlet Node Name
+  {52165ffb-e324-4bfb-aecd-6e5b66cac85d}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {22310109-79d8-4b01-a69d-79b7338a96e3}, !- Handle
+  Coil Heating Gas 9,                     !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {7905f960-484d-4d47-aa23-9535d8c98e3f}, !- Air Inlet Node Name
+  {28b56fdb-503b-40f1-a161-ced9f9eaf072}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {7151de3a-58f7-4831-9d53-782973545890}, !- Handle
+  Coil Cooling DX Single Speed 9,         !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {55e9a5b0-9e11-4f82-8647-efed393f659e}, !- Air Inlet Node Name
+  {2c59ac88-ce0a-4f88-9bdc-f060281abab5}, !- Air Outlet Node Name
+  {f843e8d5-c254-4af3-8de1-82b490eaa80b}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {15fa3bea-3afb-4d35-8ad8-8b76745f5384}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {fe35f43a-61ed-437f-a59f-81b531d88b96}, !- Energy Input Ratio Function of Temperature Curve Name
+  {e7e25380-54ce-48ef-9cc8-20f2d2aad69e}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {14a82655-ba14-4100-9554-339d7fc01476}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {f843e8d5-c254-4af3-8de1-82b490eaa80b}, !- Handle
+  Curve Biquadratic 17,                   !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {15fa3bea-3afb-4d35-8ad8-8b76745f5384}, !- Handle
+  Curve Quadratic 25,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {fe35f43a-61ed-437f-a59f-81b531d88b96}, !- Handle
+  Curve Biquadratic 18,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {e7e25380-54ce-48ef-9cc8-20f2d2aad69e}, !- Handle
+  Curve Quadratic 26,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {14a82655-ba14-4100-9554-339d7fc01476}, !- Handle
+  Curve Quadratic 27,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {52318436-d5c9-4ea1-b083-6c33792d5c5b}, !- Handle
+  Setpoint Manager Single Zone Reheat 9,  !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {f13ffeed-b25e-411b-b530-3424248282c3}, !- Control Zone Name
+  {229efc63-3a6f-4aa0-8bc8-3ebf47ea9f0e}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {cfe21da8-62b3-4221-9880-801479f80e7a}, !- Handle
+  Controller Outdoor Air 9,               !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {2c30be59-59ee-48d2-a791-f99981645988}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {2c30be59-59ee-48d2-a791-f99981645988}, !- Handle
+  Controller Mechanical Ventilation 9,    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {94651572-f30c-48f8-a8ba-7b12f96b151a}, !- Handle
+  Air Loop HVAC Outdoor Air System 9,     !- Name
+  {cfe21da8-62b3-4221-9880-801479f80e7a}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {76c30737-7e5e-42b1-b708-677a4fabcc51}, !- Mixed Air Node Name
+  {79bc2454-1bfc-4a14-81f7-23c4e7ee2a66}, !- Outdoor Air Stream Node Name
+  {7f188943-37ad-4df1-9124-c4a7373c7976}, !- Relief Air Stream Node Name
+  {21ebef25-44f2-40d9-ad9b-025e1c7fb54b}; !- Return Air Stream Node Name
+
+OS:Node,
+  {106641d5-fabb-4e6c-a085-f829f316dfe2}, !- Handle
+  Node 112,                               !- Name
+  ,                                       !- Inlet Port
+  {79bc2454-1bfc-4a14-81f7-23c4e7ee2a66}; !- Outlet Port
+
+OS:Connection,
+  {79bc2454-1bfc-4a14-81f7-23c4e7ee2a66}, !- Handle
+  {48887894-f904-436d-9114-1c08055cfe13}, !- Name
+  {106641d5-fabb-4e6c-a085-f829f316dfe2}, !- Source Object
+  3,                                      !- Outlet Port
+  {94651572-f30c-48f8-a8ba-7b12f96b151a}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {97d63b12-9828-4489-a25a-e8c3f6c1c42f}, !- Handle
+  Node 113,                               !- Name
+  {7f188943-37ad-4df1-9124-c4a7373c7976}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {7f188943-37ad-4df1-9124-c4a7373c7976}, !- Handle
+  {1ffd5c00-0f10-4886-9e8a-22933687eb1c}, !- Name
+  {94651572-f30c-48f8-a8ba-7b12f96b151a}, !- Source Object
+  7,                                      !- Outlet Port
+  {97d63b12-9828-4489-a25a-e8c3f6c1c42f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {21ebef25-44f2-40d9-ad9b-025e1c7fb54b}, !- Handle
+  {26aa9ab6-b865-43d4-a601-277fd2e47cd2}, !- Name
+  {a2f79b53-6e6a-4279-9dcc-5d5d8a09dd47}, !- Source Object
+  3,                                      !- Outlet Port
+  {94651572-f30c-48f8-a8ba-7b12f96b151a}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {ac330158-f982-4ecb-b8ac-4c0972d48bb9}, !- Handle
+  Node 114,                               !- Name
+  {76c30737-7e5e-42b1-b708-677a4fabcc51}, !- Inlet Port
+  {55e9a5b0-9e11-4f82-8647-efed393f659e}; !- Outlet Port
+
+OS:Connection,
+  {76c30737-7e5e-42b1-b708-677a4fabcc51}, !- Handle
+  {64d26325-776b-444d-8606-7af3b7e05a8f}, !- Name
+  {94651572-f30c-48f8-a8ba-7b12f96b151a}, !- Source Object
+  5,                                      !- Outlet Port
+  {ac330158-f982-4ecb-b8ac-4c0972d48bb9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {55e9a5b0-9e11-4f82-8647-efed393f659e}, !- Handle
+  {7e3adb41-b770-4a5f-938a-584f20fae5ee}, !- Name
+  {ac330158-f982-4ecb-b8ac-4c0972d48bb9}, !- Source Object
+  3,                                      !- Outlet Port
+  {7151de3a-58f7-4831-9d53-782973545890}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {826823c5-5f72-4bf6-89e2-9feacb190336}, !- Handle
+  Node 115,                               !- Name
+  {2c59ac88-ce0a-4f88-9bdc-f060281abab5}, !- Inlet Port
+  {7905f960-484d-4d47-aa23-9535d8c98e3f}; !- Outlet Port
+
+OS:Connection,
+  {2c59ac88-ce0a-4f88-9bdc-f060281abab5}, !- Handle
+  {f020c356-4823-46f1-9170-049036be1dd0}, !- Name
+  {7151de3a-58f7-4831-9d53-782973545890}, !- Source Object
+  9,                                      !- Outlet Port
+  {826823c5-5f72-4bf6-89e2-9feacb190336}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {7905f960-484d-4d47-aa23-9535d8c98e3f}, !- Handle
+  {108f54f3-d6c2-4eb6-8bfc-f7589d9ea1ef}, !- Name
+  {826823c5-5f72-4bf6-89e2-9feacb190336}, !- Source Object
+  3,                                      !- Outlet Port
+  {22310109-79d8-4b01-a69d-79b7338a96e3}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {be938b1b-8c51-4dfe-84e4-aff8395e0f8c}, !- Handle
+  Node 116,                               !- Name
+  {28b56fdb-503b-40f1-a161-ced9f9eaf072}, !- Inlet Port
+  {14b47223-8e71-4846-bb38-30391bbe5fa3}; !- Outlet Port
+
+OS:Connection,
+  {28b56fdb-503b-40f1-a161-ced9f9eaf072}, !- Handle
+  {84471022-7e15-48c2-9385-6e89d685341f}, !- Name
+  {22310109-79d8-4b01-a69d-79b7338a96e3}, !- Source Object
+  6,                                      !- Outlet Port
+  {be938b1b-8c51-4dfe-84e4-aff8395e0f8c}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {14b47223-8e71-4846-bb38-30391bbe5fa3}, !- Handle
+  {58eb3755-87ce-4515-9032-679fc314e6fe}, !- Name
+  {be938b1b-8c51-4dfe-84e4-aff8395e0f8c}, !- Source Object
+  3,                                      !- Outlet Port
+  {9f16257e-aa17-4b96-9dde-36a945e83b08}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {52165ffb-e324-4bfb-aecd-6e5b66cac85d}, !- Handle
+  {3aa2815f-b6ef-4eeb-b11b-5db22b091a3f}, !- Name
+  {9f16257e-aa17-4b96-9dde-36a945e83b08}, !- Source Object
+  9,                                      !- Outlet Port
+  {229efc63-3a6f-4aa0-8bc8-3ebf47ea9f0e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {5a5c4428-b261-4681-8ef1-3586cca0a8de}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 9, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {0765fc47-8a6e-45aa-9552-13d223d60337}, !- Air Inlet Node Name
+  {08a6d9a6-b35e-45f5-a186-bc6b549912c1}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {034a608a-46e2-4207-9e54-8c4899b985f3}, !- Handle
+  Node 117,                               !- Name
+  {28e17642-cdfd-4475-baa9-7b152cdb562b}, !- Inlet Port
+  {0765fc47-8a6e-45aa-9552-13d223d60337}; !- Outlet Port
+
+OS:Connection,
+  {28e17642-cdfd-4475-baa9-7b152cdb562b}, !- Handle
+  {da7bc092-da49-4d07-8655-9b76bf892b87}, !- Name
+  {8653a34c-d049-4f87-b986-bc5ac619fa4e}, !- Source Object
+  3,                                      !- Outlet Port
+  {034a608a-46e2-4207-9e54-8c4899b985f3}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {0765fc47-8a6e-45aa-9552-13d223d60337}, !- Handle
+  {fb9394de-d20c-42d6-869f-30283caabedc}, !- Name
+  {034a608a-46e2-4207-9e54-8c4899b985f3}, !- Source Object
+  3,                                      !- Outlet Port
+  {5a5c4428-b261-4681-8ef1-3586cca0a8de}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {08a6d9a6-b35e-45f5-a186-bc6b549912c1}, !- Handle
+  {fda0f221-bda1-40fa-9f28-533a0968511f}, !- Name
+  {5a5c4428-b261-4681-8ef1-3586cca0a8de}, !- Source Object
+  4,                                      !- Outlet Port
+  {86825d84-b372-47c6-bd0d-85046416969f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {a23c9cbd-9082-4483-b95b-9b2f29c785fc}, !- Handle
+  Node 118,                               !- Name
+  {c034a9f5-01a9-441d-8a03-e2bf8763394b}, !- Inlet Port
+  {0fb9592a-d09a-4e81-be54-de46d2a75962}; !- Outlet Port
+
+OS:Connection,
+  {c623d4cb-f69c-4468-9b57-74d721fa34cc}, !- Handle
+  {ebab9205-6d1b-4b56-92df-01196a8ff637}, !- Name
+  {86825d84-b372-47c6-bd0d-85046416969f}, !- Source Object
+  3,                                      !- Outlet Port
+  {cf6a1fdc-227d-4566-94e8-0775a3b81b88}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {c034a9f5-01a9-441d-8a03-e2bf8763394b}, !- Handle
+  {a1a4214f-6b99-4b1e-bf85-59fcbf06571b}, !- Name
+  {d7254e50-6d58-4d69-af8c-894ac16cd5f0}, !- Source Object
+  3,                                      !- Outlet Port
+  {a23c9cbd-9082-4483-b95b-9b2f29c785fc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {0fb9592a-d09a-4e81-be54-de46d2a75962}, !- Handle
+  {afc3e5ce-709e-4be4-b7fa-1908706d690c}, !- Name
+  {a23c9cbd-9082-4483-b95b-9b2f29c785fc}, !- Source Object
+  3,                                      !- Outlet Port
+  {f96e3cf0-9e67-4931-8553-c055e6b69aeb}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:AirLoopHVAC,
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- Handle
+  Packaged Rooftop Air Conditioner 9,     !- Name
+  ,                                       !- Controller List Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  {b0cc4856-1942-4372-ad7b-0cea9a4d7e61}, !- Availability Manager List Name
+  AutoSize,                               !- Design Supply Air Flow Rate {m3/s}
+  ,                                       !- Branch List Name
+  ,                                       !- Connector List Name
+  {cf511a58-62b3-4b67-bd0a-27496b668a74}, !- Supply Side Inlet Node Name
+  {91b3f87e-2003-4a4e-8684-03b88846ecfd}, !- Demand Side Outlet Node Name
+  {d0f3fd65-3389-4851-bb5a-09e4a13f7a6a}, !- Demand Side Inlet Node A
+  {6c210852-9a5a-4784-84aa-44d1ae1c30b0}, !- Supply Side Outlet Node A
+  ,                                       !- Demand Side Inlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  {4fed756d-3fb7-44a8-bc9e-a36d70e645cc}, !- Demand Mixer Name
+  {9d864b2c-b3b9-454e-9896-25424d35b2c2}, !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:Node,
+  {24e69e40-5bfe-4998-9760-64fdb190b4d3}, !- Handle
+  Node 119,                               !- Name
+  {cf511a58-62b3-4b67-bd0a-27496b668a74}, !- Inlet Port
+  {775aa9d3-c183-4026-a5a4-df3d81715634}; !- Outlet Port
+
+OS:Node,
+  {65719403-cbbb-44e9-9ea2-4e437cad9919}, !- Handle
+  Node 120,                               !- Name
+  {af24ccc2-88aa-4592-972f-adf3710a4a76}, !- Inlet Port
+  {6c210852-9a5a-4784-84aa-44d1ae1c30b0}; !- Outlet Port
+
+OS:Connection,
+  {cf511a58-62b3-4b67-bd0a-27496b668a74}, !- Handle
+  {36c03ce2-aa45-47d5-a081-033373eca004}, !- Name
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- Source Object
+  8,                                      !- Outlet Port
+  {24e69e40-5bfe-4998-9760-64fdb190b4d3}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6c210852-9a5a-4784-84aa-44d1ae1c30b0}, !- Handle
+  {22eb7484-69ae-4b89-844e-d47571daa5a7}, !- Name
+  {65719403-cbbb-44e9-9ea2-4e437cad9919}, !- Source Object
+  3,                                      !- Outlet Port
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- Target Object
+  11;                                     !- Inlet Port
+
+OS:Node,
+  {68f78965-755c-4cfb-8069-32385896aa69}, !- Handle
+  Node 121,                               !- Name
+  {d0f3fd65-3389-4851-bb5a-09e4a13f7a6a}, !- Inlet Port
+  {fc2e3678-a001-4c19-bab7-28f04d5a9376}; !- Outlet Port
+
+OS:Node,
+  {0370a311-f3fe-4fb1-9faa-bdca6a0862cc}, !- Handle
+  Node 122,                               !- Name
+  {e5d0d4f6-8783-4ed7-87a4-807e388eb925}, !- Inlet Port
+  {91b3f87e-2003-4a4e-8684-03b88846ecfd}; !- Outlet Port
+
+OS:Node,
+  {f0001bc2-a823-4050-98ed-3d798aaeeb72}, !- Handle
+  Node 123,                               !- Name
+  {bf279139-84da-458f-8035-42d6ba4cd1e2}, !- Inlet Port
+  {fac1042d-3a54-434b-b937-b437254551a4}; !- Outlet Port
+
+OS:Connection,
+  {d0f3fd65-3389-4851-bb5a-09e4a13f7a6a}, !- Handle
+  {0c91d825-523f-435b-b6d1-00d6b709adab}, !- Name
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- Source Object
+  10,                                     !- Outlet Port
+  {68f78965-755c-4cfb-8069-32385896aa69}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {91b3f87e-2003-4a4e-8684-03b88846ecfd}, !- Handle
+  {9e98c083-a271-4b99-8901-e9232ed8a9b2}, !- Name
+  {0370a311-f3fe-4fb1-9faa-bdca6a0862cc}, !- Source Object
+  3,                                      !- Outlet Port
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- Target Object
+  9;                                      !- Inlet Port
+
+OS:AirLoopHVAC:ZoneSplitter,
+  {9d864b2c-b3b9-454e-9896-25424d35b2c2}, !- Handle
+  Air Loop HVAC Zone Splitter 10,         !- Name
+  {fc2e3678-a001-4c19-bab7-28f04d5a9376}, !- Inlet Node Name
+  {c32a84d0-a2b0-48e6-a127-20ffc83deded}; !- Outlet Node Name 1
+
+OS:AirLoopHVAC:ZoneMixer,
+  {4fed756d-3fb7-44a8-bc9e-a36d70e645cc}, !- Handle
+  Air Loop HVAC Zone Mixer 10,            !- Name
+  {e5d0d4f6-8783-4ed7-87a4-807e388eb925}, !- Outlet Node Name
+  {9bcc2d5b-c0bb-4dbc-9223-553c0f1b716f}; !- Inlet Node Name 1
+
+OS:Connection,
+  {fc2e3678-a001-4c19-bab7-28f04d5a9376}, !- Handle
+  {ec38dd37-4ec7-439d-ae66-494952412cf7}, !- Name
+  {68f78965-755c-4cfb-8069-32385896aa69}, !- Source Object
+  3,                                      !- Outlet Port
+  {9d864b2c-b3b9-454e-9896-25424d35b2c2}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {e5d0d4f6-8783-4ed7-87a4-807e388eb925}, !- Handle
+  {076eecee-b935-416b-b77d-36cad4480b7f}, !- Name
+  {4fed756d-3fb7-44a8-bc9e-a36d70e645cc}, !- Source Object
+  2,                                      !- Outlet Port
+  {0370a311-f3fe-4fb1-9faa-bdca6a0862cc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Sizing:System,
+  {7088ab92-b22c-4c76-a975-3ed7d153e093}, !- Handle
+  {fbea3614-d969-4b81-82fc-e38ab63ff6bd}, !- AirLoop Name
+  Sensible,                               !- Type of Load to Size On
+  Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
+  1,                                      !- Central Heating Maximum System Air Flow Ratio
+  7,                                      !- Preheat Design Temperature {C}
+  0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Precool Design Temperature {C}
+  0.008,                                  !- Precool Design Humidity Ratio {kg-H2O/kg-Air}
+  12.8,                                   !- Central Cooling Design Supply Air Temperature {C}
+  40,                                     !- Central Heating Design Supply Air Temperature {C}
+  NonCoincident,                          !- Sizing Option
+  Yes,                                    !- 100% Outdoor Air in Cooling
+  Yes,                                    !- 100% Outdoor Air in Heating
+  0.0085,                                 !- Central Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  0.008,                                  !- Central Heating Design Supply Air Humidity Ratio {kg-H2O/kg-Air}
+  DesignDay,                              !- Cooling Design Air Flow Method
+  0,                                      !- Cooling Design Air Flow Rate {m3/s}
+  DesignDay,                              !- Heating Design Air Flow Method
+  0,                                      !- Heating Design Air Flow Rate {m3/s}
+  ZoneSum,                                !- System Outdoor Air Method
+  1,                                      !- Zone Maximum Outdoor Air Fraction {dimensionless}
+  0.0099676501,                           !- Cooling Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Cooling Fraction of Autosized Cooling Supply Air Flow Rate
+  3.9475456e-05,                          !- Cooling Supply Air Flow Rate Per Unit Cooling Capacity {m3/s-W}
+  0.0099676501,                           !- Heating Supply Air Flow Rate Per Floor Area {m3/s-m2}
+  1,                                      !- Heating Fraction of Autosized Heating Supply Air Flow Rate
+  1,                                      !- Heating Fraction of Autosized Cooling Supply Air Flow Rate
+  3.1588213e-05,                          !- Heating Supply Air Flow Rate Per Unit Heating Capacity {m3/s-W}
+  CoolingDesignCapacity,                  !- Cooling Design Capacity Method
+  autosize,                               !- Cooling Design Capacity {W}
+  234.7,                                  !- Cooling Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Cooling Design Capacity
+  HeatingDesignCapacity,                  !- Heating Design Capacity Method
+  autosize,                               !- Heating Design Capacity {W}
+  157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
+  1,                                      !- Fraction of Autosized Heating Design Capacity
+  OnOff;                                  !- Central Cooling Capacity Control Method
+
+OS:AvailabilityManagerAssignmentList,
+  {b0cc4856-1942-4372-ad7b-0cea9a4d7e61}, !- Handle
+  Air Loop HVAC 1 AvailabilityManagerAssignmentList 9; !- Name
+
+OS:Fan:ConstantVolume,
+  {6024fea9-dc0e-4f37-b7ea-63c5c3921749}, !- Handle
+  Fan Constant Volume 10,                 !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  ,                                       !- Fan Total Efficiency
+  500,                                    !- Pressure Rise {Pa}
+  AutoSize,                               !- Maximum Flow Rate {m3/s}
+  ,                                       !- Motor Efficiency
+  ,                                       !- Motor In Airstream Fraction
+  {1d5a392b-c0bd-4238-891a-329b5675cc60}, !- Air Inlet Node Name
+  {af24ccc2-88aa-4592-972f-adf3710a4a76}, !- Air Outlet Node Name
+  ;                                       !- End-Use Subcategory
+
+OS:Coil:Heating:Gas,
+  {15ad5afd-31c1-4733-a645-1e64cc1bb202}, !- Handle
+  Coil Heating Gas 10,                    !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  0.8,                                    !- Gas Burner Efficiency
+  AutoSize,                               !- Nominal Capacity {W}
+  {d5a220ab-9268-4489-970a-ff5c2a007092}, !- Air Inlet Node Name
+  {b7f3e972-d45d-405e-90dc-7b0dc013b02c}, !- Air Outlet Node Name
+  ,                                       !- Temperature Setpoint Node Name
+  0,                                      !- Parasitic Electric Load {W}
+  ,                                       !- Part Load Fraction Correlation Curve Name
+  0;                                      !- Parasitic Gas Load {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {899632e0-544e-4363-bf22-02f1397bcbc1}, !- Handle
+  Coil Cooling DX Single Speed 10,        !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate {W/(m3/s)}
+  {c2729efa-f051-424e-9e40-52ddae49e477}, !- Air Inlet Node Name
+  {88997baf-9f3a-4db2-9865-505b2d672fac}, !- Air Outlet Node Name
+  {b7476c8e-7302-44cd-9e32-168c9bd4af6d}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {1380d53a-1c8b-4e9b-8f12-b0d8ecea96d7}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {acc92740-8391-44c7-aedf-012bb63622e2}, !- Energy Input Ratio Function of Temperature Curve Name
+  {31d89863-016e-4bc1-b32e-35cde8077db3}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {56786176-2ec6-4862-859e-b4d3c9cafc19}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Nominal Time for Condensate Removal to Begin {s}
+  ,                                       !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  ,                                       !- Maximum Cycling Rate {cycles/hr}
+  ,                                       !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0,                                      !- Evaporative Condenser Effectiveness {dimensionless}
+  Autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  Autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  0,                                      !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  10,                                     !- Basin Heater Setpoint Temperature {C}
+  ;                                       !- Basin Heater Operating Schedule Name
+
+OS:Curve:Biquadratic,
+  {b7476c8e-7302-44cd-9e32-168c9bd4af6d}, !- Handle
+  Curve Biquadratic 19,                   !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {1380d53a-1c8b-4e9b-8f12-b0d8ecea96d7}, !- Handle
+  Curve Quadratic 28,                     !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {acc92740-8391-44c7-aedf-012bb63622e2}, !- Handle
+  Curve Biquadratic 20,                   !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {31d89863-016e-4bc1-b32e-35cde8077db3}, !- Handle
+  Curve Quadratic 29,                     !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {56786176-2ec6-4862-859e-b4d3c9cafc19}, !- Handle
+  Curve Quadratic 30,                     !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:SetpointManager:SingleZone:Reheat,
+  {018a9f4e-2eef-41f7-885a-9d29e0937169}, !- Handle
+  Setpoint Manager Single Zone Reheat 10, !- Name
+  14,                                     !- Minimum Supply Air Temperature {C}
+  40,                                     !- Maximum Supply Air Temperature {C}
+  {b8a9152f-3da5-4b46-b1a4-c3ab6c3f6354}, !- Control Zone Name
+  {65719403-cbbb-44e9-9ea2-4e437cad9919}; !- Setpoint Node or NodeList Name
+
+OS:Controller:OutdoorAir,
+  {82c1baa3-f303-4414-a00f-02c997ef96b9}, !- Handle
+  Controller Outdoor Air 10,              !- Name
+  ,                                       !- Relief Air Outlet Node Name
+  ,                                       !- Return Air Node Name
+  ,                                       !- Mixed Air Node Name
+  ,                                       !- Actuator Node Name
+  0,                                      !- Minimum Outdoor Air Flow Rate {m3/s}
+  Autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
+  NoEconomizer,                           !- Economizer Control Type
+  ModulateFlow,                           !- Economizer Control Action Type
+  28,                                     !- Economizer Maximum Limit Dry-Bulb Temperature {C}
+  64000,                                  !- Economizer Maximum Limit Enthalpy {J/kg}
+  ,                                       !- Economizer Maximum Limit Dewpoint Temperature {C}
+  ,                                       !- Electronic Enthalpy Limit Curve Name
+  -100,                                   !- Economizer Minimum Limit Dry-Bulb Temperature {C}
+  NoLockout,                              !- Lockout Type
+  FixedMinimum,                           !- Minimum Limit Type
+  ,                                       !- Minimum Outdoor Air Schedule Name
+  ,                                       !- Minimum Fraction of Outdoor Air Schedule Name
+  ,                                       !- Maximum Fraction of Outdoor Air Schedule Name
+  {cae537b2-7145-481b-ac44-68845c7b490e}, !- Controller Mechanical Ventilation
+  ,                                       !- Time of Day Economizer Control Schedule Name
+  No,                                     !- High Humidity Control
+  ,                                       !- Humidistat Control Zone Name
+  ,                                       !- High Humidity Outdoor Air Flow Ratio
+  ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+
+OS:Controller:MechanicalVentilation,
+  {cae537b2-7145-481b-ac44-68845c7b490e}, !- Handle
+  Controller Mechanical Ventilation 10,   !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule
+  ,                                       !- Demand Controlled Ventilation
+  ZoneSum;                                !- System Outdoor Air Method
+
+OS:AirLoopHVAC:OutdoorAirSystem,
+  {539e2e04-4708-4190-8a02-a26caaa07775}, !- Handle
+  Air Loop HVAC Outdoor Air System 10,    !- Name
+  {82c1baa3-f303-4414-a00f-02c997ef96b9}, !- Controller Name
+  ,                                       !- Outdoor Air Equipment List Name
+  ,                                       !- Availability Manager List Name
+  {0e62085b-b5d2-410f-84c0-eee6fd776ed0}, !- Mixed Air Node Name
+  {80c00525-5212-4ffb-953c-dae09b5da176}, !- Outdoor Air Stream Node Name
+  {c1be09be-168c-43f4-b600-f86cebe29bd5}, !- Relief Air Stream Node Name
+  {775aa9d3-c183-4026-a5a4-df3d81715634}; !- Return Air Stream Node Name
+
+OS:Node,
+  {61937650-7b01-4e81-948b-0248b3beee7d}, !- Handle
+  Node 124,                               !- Name
+  ,                                       !- Inlet Port
+  {80c00525-5212-4ffb-953c-dae09b5da176}; !- Outlet Port
+
+OS:Connection,
+  {80c00525-5212-4ffb-953c-dae09b5da176}, !- Handle
+  {c58654a4-58c9-4a4e-98a2-67f7f101797e}, !- Name
+  {61937650-7b01-4e81-948b-0248b3beee7d}, !- Source Object
+  3,                                      !- Outlet Port
+  {539e2e04-4708-4190-8a02-a26caaa07775}, !- Target Object
+  6;                                      !- Inlet Port
+
+OS:Node,
+  {6f5fd9ba-dc88-43e5-b199-76f1743d40b2}, !- Handle
+  Node 125,                               !- Name
+  {c1be09be-168c-43f4-b600-f86cebe29bd5}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c1be09be-168c-43f4-b600-f86cebe29bd5}, !- Handle
+  {1ff5d3c0-e419-4f56-bc0c-bae4590bf9e4}, !- Name
+  {539e2e04-4708-4190-8a02-a26caaa07775}, !- Source Object
+  7,                                      !- Outlet Port
+  {6f5fd9ba-dc88-43e5-b199-76f1743d40b2}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {775aa9d3-c183-4026-a5a4-df3d81715634}, !- Handle
+  {d1deba55-8219-4a0b-b556-4d9120639458}, !- Name
+  {24e69e40-5bfe-4998-9760-64fdb190b4d3}, !- Source Object
+  3,                                      !- Outlet Port
+  {539e2e04-4708-4190-8a02-a26caaa07775}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {d57cb652-4ec2-4583-b3c3-9df52f3dc1da}, !- Handle
+  Node 126,                               !- Name
+  {0e62085b-b5d2-410f-84c0-eee6fd776ed0}, !- Inlet Port
+  {c2729efa-f051-424e-9e40-52ddae49e477}; !- Outlet Port
+
+OS:Connection,
+  {0e62085b-b5d2-410f-84c0-eee6fd776ed0}, !- Handle
+  {9f7355e6-50e1-4091-b25c-185afe8a73ec}, !- Name
+  {539e2e04-4708-4190-8a02-a26caaa07775}, !- Source Object
+  5,                                      !- Outlet Port
+  {d57cb652-4ec2-4583-b3c3-9df52f3dc1da}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {c2729efa-f051-424e-9e40-52ddae49e477}, !- Handle
+  {b86407ab-434a-48ed-ae81-bb8727c36465}, !- Name
+  {d57cb652-4ec2-4583-b3c3-9df52f3dc1da}, !- Source Object
+  3,                                      !- Outlet Port
+  {899632e0-544e-4363-bf22-02f1397bcbc1}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Node,
+  {aaa1f481-2896-4d76-9910-ba9a06b3c81e}, !- Handle
+  Node 127,                               !- Name
+  {88997baf-9f3a-4db2-9865-505b2d672fac}, !- Inlet Port
+  {d5a220ab-9268-4489-970a-ff5c2a007092}; !- Outlet Port
+
+OS:Connection,
+  {88997baf-9f3a-4db2-9865-505b2d672fac}, !- Handle
+  {b82971b4-0ec9-4cae-bf45-2182f7f196c4}, !- Name
+  {899632e0-544e-4363-bf22-02f1397bcbc1}, !- Source Object
+  9,                                      !- Outlet Port
+  {aaa1f481-2896-4d76-9910-ba9a06b3c81e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {d5a220ab-9268-4489-970a-ff5c2a007092}, !- Handle
+  {999c000d-5d8f-448d-afc4-2e1948ecd5e3}, !- Name
+  {aaa1f481-2896-4d76-9910-ba9a06b3c81e}, !- Source Object
+  3,                                      !- Outlet Port
+  {15ad5afd-31c1-4733-a645-1e64cc1bb202}, !- Target Object
+  5;                                      !- Inlet Port
+
+OS:Node,
+  {ff8b565e-05a7-4ca1-917c-be19815112a9}, !- Handle
+  Node 128,                               !- Name
+  {b7f3e972-d45d-405e-90dc-7b0dc013b02c}, !- Inlet Port
+  {1d5a392b-c0bd-4238-891a-329b5675cc60}; !- Outlet Port
+
+OS:Connection,
+  {b7f3e972-d45d-405e-90dc-7b0dc013b02c}, !- Handle
+  {bbade8e5-e2b7-4e86-986e-3ff3b353a988}, !- Name
+  {15ad5afd-31c1-4733-a645-1e64cc1bb202}, !- Source Object
+  6,                                      !- Outlet Port
+  {ff8b565e-05a7-4ca1-917c-be19815112a9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {1d5a392b-c0bd-4238-891a-329b5675cc60}, !- Handle
+  {15edb6de-cf6c-483c-8db0-9e919fe8711e}, !- Name
+  {ff8b565e-05a7-4ca1-917c-be19815112a9}, !- Source Object
+  3,                                      !- Outlet Port
+  {6024fea9-dc0e-4f37-b7ea-63c5c3921749}, !- Target Object
+  8;                                      !- Inlet Port
+
+OS:Connection,
+  {af24ccc2-88aa-4592-972f-adf3710a4a76}, !- Handle
+  {284e9349-4eed-42ab-8c3f-91e85f17b33e}, !- Name
+  {6024fea9-dc0e-4f37-b7ea-63c5c3921749}, !- Source Object
+  9,                                      !- Outlet Port
+  {65719403-cbbb-44e9-9ea2-4e437cad9919}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:AirTerminal:SingleDuct:ConstantVolume:NoReheat,
+  {b855d341-cd0f-49b9-843a-7f7f2c3c11da}, !- Handle
+  Air Terminal Single Duct Constant Volume No Reheat 10, !- Name
+  {4e55a0df-251d-42c4-a82b-fe689cf41b55}, !- Availability Schedule Name
+  {6ea3a9bc-0440-4d73-8d96-3d701496f07c}, !- Air Inlet Node Name
+  {bf279139-84da-458f-8035-42d6ba4cd1e2}, !- Air Outlet Node Name
+  AutoSize;                               !- Maximum Air Flow Rate {m3/s}
+
+OS:Node,
+  {35b122a0-8989-4638-a18b-c702a74c6262}, !- Handle
+  Node 129,                               !- Name
+  {c32a84d0-a2b0-48e6-a127-20ffc83deded}, !- Inlet Port
+  {6ea3a9bc-0440-4d73-8d96-3d701496f07c}; !- Outlet Port
+
+OS:Connection,
+  {c32a84d0-a2b0-48e6-a127-20ffc83deded}, !- Handle
+  {a2d82039-824e-44d3-8c31-fc00cb8be35a}, !- Name
+  {9d864b2c-b3b9-454e-9896-25424d35b2c2}, !- Source Object
+  3,                                      !- Outlet Port
+  {35b122a0-8989-4638-a18b-c702a74c6262}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {6ea3a9bc-0440-4d73-8d96-3d701496f07c}, !- Handle
+  {8c2eb7e2-43ab-41f2-9b5d-fcf4a03a7aa3}, !- Name
+  {35b122a0-8989-4638-a18b-c702a74c6262}, !- Source Object
+  3,                                      !- Outlet Port
+  {b855d341-cd0f-49b9-843a-7f7f2c3c11da}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {bf279139-84da-458f-8035-42d6ba4cd1e2}, !- Handle
+  {bc874da5-a9a5-429d-8d32-44fb259319f1}, !- Name
+  {b855d341-cd0f-49b9-843a-7f7f2c3c11da}, !- Source Object
+  4,                                      !- Outlet Port
+  {f0001bc2-a823-4050-98ed-3d798aaeeb72}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Node,
+  {8c219d24-1921-43c7-8956-fa72b1051dd2}, !- Handle
+  Node 130,                               !- Name
+  {ee29408f-83fd-4525-916a-aaf072686a92}, !- Inlet Port
+  {9bcc2d5b-c0bb-4dbc-9223-553c0f1b716f}; !- Outlet Port
+
+OS:Connection,
+  {fac1042d-3a54-434b-b937-b437254551a4}, !- Handle
+  {ac8e231b-2b3a-4bd5-86df-5131b7b92b83}, !- Name
+  {f0001bc2-a823-4050-98ed-3d798aaeeb72}, !- Source Object
+  3,                                      !- Outlet Port
+  {3ae89c27-f399-431e-abe6-950d0acd2603}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Connection,
+  {ee29408f-83fd-4525-916a-aaf072686a92}, !- Handle
+  {7b58e676-32da-403e-a921-50d0eefe9704}, !- Name
+  {1dd2ff4e-afe8-471e-9ea8-1a0cd85e704f}, !- Source Object
+  3,                                      !- Outlet Port
+  {8c219d24-1921-43c7-8956-fa72b1051dd2}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {9bcc2d5b-c0bb-4dbc-9223-553c0f1b716f}, !- Handle
+  {12549d86-be89-4c90-8a4b-e75ce783a209}, !- Name
+  {8c219d24-1921-43c7-8956-fa72b1051dd2}, !- Source Object
+  3,                                      !- Outlet Port
+  {4fed756d-3fb7-44a8-bc9e-a36d70e645cc}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Schedule:Ruleset,
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}, !- Handle
+  Cooling Sch,                            !- Name
+  {9fc91eae-ae84-4cb2-aa71-a7b1dc363a28}, !- Schedule Type Limits Name
+  {389cc63a-478d-44ca-8e69-cd83a8939881}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {389cc63a-478d-44ca-8e69-cd83a8939881}, !- Handle
+  Cooling Sch Default,                    !- Name
+  {9fc91eae-ae84-4cb2-aa71-a7b1dc363a28}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  28;                                     !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Handle
+  Heating Sch,                            !- Name
+  {9fc91eae-ae84-4cb2-aa71-a7b1dc363a28}, !- Schedule Type Limits Name
+  {0d90c7a0-6744-4811-ad6d-9addcabd131b}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {0d90c7a0-6744-4811-ad6d-9addcabd131b}, !- Handle
+  Heating Sch Default,                    !- Name
+  {9fc91eae-ae84-4cb2-aa71-a7b1dc363a28}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24;                                     !- Value Until Time 1
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {4eb27ebf-9f00-4959-923e-69dc2ecad705}, !- Handle
+  Thermostat Setpoint Dual Setpoint 1,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ScheduleTypeLimits,
+  {9fc91eae-ae84-4cb2-aa71-a7b1dc363a28}, !- Handle
+  Temperature,                            !- Name
+  ,                                       !- Lower Limit Value
+  ,                                       !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  Temperature;                            !- Unit Type
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {04e5a183-e49a-4d06-9d48-e4590475bd5b}, !- Handle
+  Thermostat Setpoint Dual Setpoint 2,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {79d75e60-251d-4902-bc0b-d00388361c85}, !- Handle
+  Thermostat Setpoint Dual Setpoint 3,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {ad9f6b5b-4c4d-4f0a-838f-e87d9efce967}, !- Handle
+  Thermostat Setpoint Dual Setpoint 4,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {c93cd97c-604f-46b1-a644-ed5acb910a06}, !- Handle
+  Thermostat Setpoint Dual Setpoint 5,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {30116d22-051b-4377-89b7-07f281015581}, !- Handle
+  Thermostat Setpoint Dual Setpoint 6,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {6eda21c1-de3d-477c-858a-c872ae4bd83f}, !- Handle
+  Thermostat Setpoint Dual Setpoint 7,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {a851d184-9b3e-41e6-a41a-e08db15c0b16}, !- Handle
+  Thermostat Setpoint Dual Setpoint 8,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {cd5b44a6-a3c0-4b50-b427-99b251cb97cc}, !- Handle
+  Thermostat Setpoint Dual Setpoint 9,    !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {3092098e-d518-4569-89ff-0de053382346}, !- Handle
+  Thermostat Setpoint Dual Setpoint 10,   !- Name
+  {c5f966d0-fc97-4fc2-a083-ff6a448ba1a5}, !- Heating Setpoint Temperature Schedule Name
+  {c2dd0dcc-c862-412f-93a8-7664e819f282}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:DefaultConstructionSet,
+  {34e7058c-9698-49ca-9d64-b68d4ddfc445}, ! Handle
+  ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_ConstSet, ! Name
+  {22d3761f-e414-4763-81ff-e3968faa91e6}, ! Default Exterior Surface Constructions Name
+  {2f2823df-db30-4326-8915-40a82f8b38b2}, ! Default Interior Surface Constructions Name
+  {23c9a5a9-f4c5-4fa8-878f-df549e3fe313}, ! Default Ground Contact Surface Constructions Name
+  {ba5f921f-63ac-4771-954e-2e4b09d1652f}, ! Default Exterior SubSurface Constructions Name
+  {1c2e75cc-fc6f-4846-b57b-e1d716e7d4d7}, ! Default Interior SubSurface Constructions Name
+  {4d4b3c3a-c21e-4a62-bcc8-86af4068888e}, ! Interior Partition Construction Name
+  ,                                       ! Space Shading Construction Name
+  ,                                       ! Building Shading Construction Name
+  ;                                       ! Site Shading Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {22d3761f-e414-4763-81ff-e3968faa91e6}, ! Handle
+  ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSurfCons, ! Name
+  {2a8d337f-168b-4d1b-bcdc-33e84a420364}, ! Floor Construction Name
+  {e3f7c26d-825c-4cc8-8bb1-05dd4f2f18e8}, ! Wall Construction Name
+  {146f72c7-8610-4ca3-a041-e26f2aa29b57}; ! Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {2f2823df-db30-4326-8915-40a82f8b38b2}, ! Handle
+  000_Interior_DefSurfCons,               ! Name
+  {7ef0c827-2f6a-4e37-ac2c-c351fd4a72c7}, ! Floor Construction Name
+  {45de28ab-aa27-4545-bb1a-7aeeecbcd047}, ! Wall Construction Name
+  {2696fa89-da0f-4e33-bd60-c61c68c96464}; ! Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {23c9a5a9-f4c5-4fa8-878f-df549e3fe313}, ! Handle
+  000_Ground_DefSurfCons,                 ! Name
+  {2a8d337f-168b-4d1b-bcdc-33e84a420364}, ! Floor Construction Name
+  {2a8d337f-168b-4d1b-bcdc-33e84a420364}, ! Wall Construction Name
+  {2a8d337f-168b-4d1b-bcdc-33e84a420364}; ! Roof Ceiling Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {ba5f921f-63ac-4771-954e-2e4b09d1652f}, ! Handle
+  ASHRAE_189.1-2009_ClimateZone 4-5 (mdoff)_Exterior_DefSubCons, ! Name
+  {a9637460-b3f1-471b-9eff-baeb73c5cb26}, ! Fixed Window Construction Name
+  {a9637460-b3f1-471b-9eff-baeb73c5cb26}, ! Operable Window Construction Name
+  {8394123d-299b-427c-b665-1574bc384355}, ! Door Construction Name
+  {976517a8-a5ee-4a33-bc20-62109632e994}, ! Glass Door Construction Name
+  ,                                       ! Overhead Door Construction Name
+  {976517a8-a5ee-4a33-bc20-62109632e994}, ! Skylight Construction Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}, ! Tubular Daylight Dome Construction Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}; ! Tubular Daylight Diffuser Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {1c2e75cc-fc6f-4846-b57b-e1d716e7d4d7}, ! Handle
+  000_Interior_DefSubCons,                ! Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}, ! Fixed Window Construction Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}, ! Operable Window Construction Name
+  {bb3a47db-1a94-49cf-9369-3181d4d9d153}, ! Door Construction Name
+  {976517a8-a5ee-4a33-bc20-62109632e994}, ! Glass Door Construction Name
+  ,                                       ! Overhead Door Construction Name
+  {976517a8-a5ee-4a33-bc20-62109632e994}, ! Skylight Construction Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}, ! Tubular Daylight Dome Construction Name
+  {bf97c466-eb15-4607-a45d-e917a94f0274}; ! Tubular Daylight Diffuser Construction Name
+
+OS:Construction,
+  {4d4b3c3a-c21e-4a62-bcc8-86af4068888e}, ! Handle
+  000_Interior Partition,                 ! Name
+  ,                                       ! Surface Rendering Name
+  {ba0629fc-7661-4262-a4be-1ce2345e9f29}; ! Layer 1
+
+OS:Construction,
+  {2a8d337f-168b-4d1b-bcdc-33e84a420364}, ! Handle
+  000_ExtSlabCarpet_4in_ClimateZone 1-8,  ! Name
+  ,                                       ! Surface Rendering Name
+  {200209be-0a34-4d67-aed0-3e5dad6fff10}, ! Layer 1
+  {ef74cde7-0f19-4d5f-a695-74d7c5d37cb5}; ! Layer 2
+
+OS:Construction,
+  {e3f7c26d-825c-4cc8-8bb1-05dd4f2f18e8}, ! Handle
+  ASHRAE_189.1-2009_ExtWall_SteelFrame_ClimateZone 4-8, ! Name
+  ,                                       ! Surface Rendering Name
+  {c42a2dce-6215-4f83-9a1c-fb148853668f}, ! Layer 1
+  {50ae8755-fa43-40a7-89b0-f68b74c6afb9}, ! Layer 2
+  {56c01bc9-ec31-4195-87b0-fd58c1ab4d0e}; ! Layer 3
+
+OS:Construction,
+  {146f72c7-8610-4ca3-a041-e26f2aa29b57}, ! Handle
+  ASHRAE_189.1-2009_ExtRoof_IEAD_ClimateZone 2-5, ! Name
+  ,                                       ! Surface Rendering Name
+  {a0943ec3-3e75-4957-83ac-eb8047c63cb3}, ! Layer 1
+  {7bad3c41-a4f2-43df-aa19-c5019e282338}, ! Layer 2
+  {65d6e89d-58dd-4649-a68c-7380684180f7}; ! Layer 3
+
+OS:Construction,
+  {7ef0c827-2f6a-4e37-ac2c-c351fd4a72c7}, ! Handle
+  000_Interior Floor,                     ! Name
+  ,                                       ! Surface Rendering Name
+  {ee177731-3e9f-4b36-ad8b-3b327f8f0458}, ! Layer 1
+  {6d930b1f-bdb1-4397-9a24-8ca3c1952851}, ! Layer 2
+  {5c06a811-65eb-4c0d-ba89-8643e65f3f81}; ! Layer 3
+
+OS:Construction,
+  {45de28ab-aa27-4545-bb1a-7aeeecbcd047}, ! Handle
+  000_Interior Wall,                      ! Name
+  ,                                       ! Surface Rendering Name
+  {de0e32d6-29fd-4005-8698-0ab4a9595a01}, ! Layer 1
+  {5591116a-7f3e-42ae-b000-14f6c1e4ed17}, ! Layer 2
+  {de0e32d6-29fd-4005-8698-0ab4a9595a01}; ! Layer 3
+
+OS:Construction,
+  {2696fa89-da0f-4e33-bd60-c61c68c96464}, ! Handle
+  000_Interior Ceiling,                   ! Name
+  ,                                       ! Surface Rendering Name
+  {5c06a811-65eb-4c0d-ba89-8643e65f3f81}, ! Layer 1
+  {6d930b1f-bdb1-4397-9a24-8ca3c1952851}, ! Layer 2
+  {ee177731-3e9f-4b36-ad8b-3b327f8f0458}; ! Layer 3
+
+OS:Construction,
+  {a9637460-b3f1-471b-9eff-baeb73c5cb26}, ! Handle
+  ASHRAE_189.1-2009_ExtWindow_ClimateZone 4-5, ! Name
+  ,                                       ! Surface Rendering Name
+  {9ba2834b-7d76-4b1f-84b4-6c08646fde12}; ! Layer 1
+
+OS:Construction,
+  {8394123d-299b-427c-b665-1574bc384355}, ! Handle
+  000_Exterior Door,                      ! Name
+  ,                                       ! Surface Rendering Name
+  {d3334a85-911b-4c0d-a851-c078d3b5cc71}, ! Layer 1
+  {32ed204b-7e20-4a8f-8ada-e77642541c32}; ! Layer 2
+
+OS:Construction,
+  {976517a8-a5ee-4a33-bc20-62109632e994}, ! Handle
+  000_Exterior Window,                    ! Name
+  ,                                       ! Surface Rendering Name
+  {7d14f8e5-01fa-4143-9f6c-21ae4b449755}, ! Layer 1
+  {f05f3259-446a-48b1-a741-e8e7b2804ce4}, ! Layer 2
+  {7d14f8e5-01fa-4143-9f6c-21ae4b449755}; ! Layer 3
+
+OS:Construction,
+  {bf97c466-eb15-4607-a45d-e917a94f0274}, ! Handle
+  000_Interior Window,                    ! Name
+  ,                                       ! Surface Rendering Name
+  {7d14f8e5-01fa-4143-9f6c-21ae4b449755}; ! Layer 1
+
+OS:Construction,
+  {bb3a47db-1a94-49cf-9369-3181d4d9d153}, ! Handle
+  000_Interior Door,                      ! Name
+  ,                                       ! Surface Rendering Name
+  {ba0629fc-7661-4262-a4be-1ce2345e9f29}; ! Layer 1
+
+OS:Material,
+  {ba0629fc-7661-4262-a4be-1ce2345e9f29}, ! Handle
+  000_G05 25mm wood,                      ! Name
+  MediumSmooth,                           ! Roughness
+  0.025399999999999999,                   ! Thickness
+  0.14999999999999999,                    ! Conductivity
+  608,                                    ! Density
+  1630;                                   ! Specific Heat
+
+OS:Material,
+  {200209be-0a34-4d67-aed0-3e5dad6fff10}, ! Handle
+  MAT-CC05 4 HW CONCRETE,                 ! Name
+  Rough,                                  ! Roughness
+  0.1016,                                 ! Thickness
+  1.3109999999999999,                     ! Conductivity
+  2240,                                   ! Density
+  836.79999999999995,                     ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.69999999999999996;                    ! Visible Absorptance
+
+OS:Material:NoMass,
+  {ef74cde7-0f19-4d5f-a695-74d7c5d37cb5}, ! Handle
+  CP02 CARPET PAD,                        ! Name
+  VeryRough,                              ! Roughness
+  0.2165,                                 ! Thermal Resistance
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.80000000000000004;                    ! Visible Absorptance
+
+OS:Material:NoMass,
+  {c42a2dce-6215-4f83-9a1c-fb148853668f}, ! Handle
+  MAT-SHEATH,                             ! Name
+  Rough,                                  ! Roughness
+  0.36259999999999998,                    ! Thermal Resistance
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.69999999999999996;                    ! Visible Absorptance
+
+OS:Material,
+  {50ae8755-fa43-40a7-89b0-f68b74c6afb9}, ! Handle
+  Wall Insulation [39],                   ! Name
+  MediumRough,                            ! Roughness
+  0.11840000000000001,                    ! Thickness
+  0.044999999999999998,                   ! Conductivity
+  265,                                    ! Density
+  836.79999999999995,                     ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.69999999999999996;                    ! Visible Absorptance
+
+OS:Material,
+  {56c01bc9-ec31-4195-87b0-fd58c1ab4d0e}, ! Handle
+  1/2IN Gypsum,                           ! Name
+  Smooth,                                 ! Roughness
+  0.012699999999999999,                   ! Thickness
+  0.16,                                   ! Conductivity
+  784.89999999999998,                     ! Density
+  830,                                    ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.92000000000000004,                    ! Solar Absorptance
+  0.92000000000000004;                    ! Visible Absorptance
+
+OS:Material,
+  {a0943ec3-3e75-4957-83ac-eb8047c63cb3}, ! Handle
+  Roof Membrane,                          ! Name
+  VeryRough,                              ! Roughness
+  0.0094999999999999998,                  ! Thickness
+  0.16,                                   ! Conductivity
+  1121.29,                                ! Density
+  1460,                                   ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.69999999999999996;                    ! Visible Absorptance
+
+OS:Material,
+  {7bad3c41-a4f2-43df-aa19-c5019e282338}, ! Handle
+  Roof Insulation [21],                   ! Name
+  MediumRough,                            ! Roughness
+  0.21049999999999999,                    ! Thickness
+  0.049000000000000002,                   ! Conductivity
+  265,                                    ! Density
+  836.79999999999995,                     ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.69999999999999996;                    ! Visible Absorptance
+
+OS:Material,
+  {65d6e89d-58dd-4649-a68c-7380684180f7}, ! Handle
+  Metal Decking,                          ! Name
+  MediumSmooth,                           ! Roughness
+  0.0015,                                 ! Thickness
+  45.006,                                 ! Conductivity
+  7680,                                   ! Density
+  418.39999999999998,                     ! Specific Heat
+  0.90000000000000002,                    ! Thermal Absorptance
+  0.69999999999999996,                    ! Solar Absorptance
+  0.29999999999999999;                    ! Visible Absorptance
+
+OS:Material,
+  {ee177731-3e9f-4b36-ad8b-3b327f8f0458}, ! Handle
+  000_F16 Acoustic tile,                  ! Name
+  MediumSmooth,                           ! Roughness
+  0.019099999999999999,                   ! Thickness
+  0.059999999999999998,                   ! Conductivity
+  368,                                    ! Density
+  590;                                    ! Specific Heat
+
+OS:Material:AirGap,
+  {6d930b1f-bdb1-4397-9a24-8ca3c1952851}, ! Handle
+  000_F05 Ceiling air space resistance,   ! Name
+  0.17999999999999999;                    ! Thermal Resistance
+
+OS:Material,
+  {5c06a811-65eb-4c0d-ba89-8643e65f3f81}, ! Handle
+  000_M11 100mm lightweight concrete,     ! Name
+  MediumRough,                            ! Roughness
+  0.1016,                                 ! Thickness
+  0.53000000000000003,                    ! Conductivity
+  1280,                                   ! Density
+  840;                                    ! Specific Heat
+
+OS:Material,
+  {de0e32d6-29fd-4005-8698-0ab4a9595a01}, ! Handle
+  000_G01a 19mm gypsum board,             ! Name
+  MediumSmooth,                           ! Roughness
+  0.019,                                  ! Thickness
+  0.16,                                   ! Conductivity
+  800,                                    ! Density
+  1090;                                   ! Specific Heat
+
+OS:Material:AirGap,
+  {5591116a-7f3e-42ae-b000-14f6c1e4ed17}, ! Handle
+  000_F04 Wall air space resistance,      ! Name
+  0.14999999999999999;                    ! Thermal Resistance
+
+OS:WindowMaterial:Glazing,
+  {9ba2834b-7d76-4b1f-84b4-6c08646fde12}, ! Handle
+  Theoretical Glass [207],                ! Name
+  SpectralAverage,                        ! Optical Data Type
+  ,                                       ! Window Glass Spectral Data Set Name
+  0.0030000000000000001,                  ! Thickness
+  0.33110000000000001,                    ! Solar Transmittance at Normal Incidence
+  0.61890000000000001,                    ! Front Side Solar Reflectance at Normal Incidence
+  0.61890000000000001,                    ! Back Side Solar Reflectance at Normal Incidence
+  0.44,                                   ! Visible Transmittance at Normal Incidence
+  0.51000000000000001,                    ! Front Side Visible Reflectance at Normal Incidence
+  0.51000000000000001,                    ! Back Side Visible Reflectance at Normal Incidence
+  0,                                      ! Infrared Transmittance at Normal Incidence
+  0.90000000000000002,                    ! Front Side Infrared Hemispherical Emissivity
+  0.90000000000000002,                    ! Back Side Infrared Hemispherical Emissivity
+  0.013299999999999999,                   ! Conductivity
+  1,                                      ! Dirt Correction Factor for Solar and Visible Transmittance
+  No;                                     ! Solar Diffusing
+
+OS:Material,
+  {d3334a85-911b-4c0d-a851-c078d3b5cc71}, ! Handle
+  000_F08 Metal surface,                  ! Name
+  Smooth,                                 ! Roughness
+  0.00080000000000000004,                 ! Thickness
+  45.280000000000001,                     ! Conductivity
+  7824,                                   ! Density
+  500;                                    ! Specific Heat
+
+OS:Material,
+  {32ed204b-7e20-4a8f-8ada-e77642541c32}, ! Handle
+  000_I01 25mm insulation board,          ! Name
+  MediumRough,                            ! Roughness
+  0.025399999999999999,                   ! Thickness
+  0.029999999999999999,                   ! Conductivity
+  43,                                     ! Density
+  1210;                                   ! Specific Heat
+
+OS:WindowMaterial:Glazing,
+  {7d14f8e5-01fa-4143-9f6c-21ae4b449755}, ! Handle
+  000_Clear 3mm,                          ! Name
+  SpectralAverage,                        ! Optical Data Type
+  ,                                       ! Window Glass Spectral Data Set Name
+  0.0030000000000000001,                  ! Thickness
+  0.83699999999999997,                    ! Solar Transmittance at Normal Incidence
+  0.074999999999999997,                   ! Front Side Solar Reflectance at Normal Incidence
+  0.074999999999999997,                   ! Back Side Solar Reflectance at Normal Incidence
+  0.89800000000000002,                    ! Visible Transmittance at Normal Incidence
+  0.081000000000000003,                   ! Front Side Visible Reflectance at Normal Incidence
+  0.081000000000000003,                   ! Back Side Visible Reflectance at Normal Incidence
+  0,                                      ! Infrared Transmittance at Normal Incidence
+  0.83999999999999997,                    ! Front Side Infrared Hemispherical Emissivity
+  0.83999999999999997,                    ! Back Side Infrared Hemispherical Emissivity
+  0.90000000000000002,                    ! Conductivity
+  ,                                       ! Dirt Correction Factor for Solar and Visible Transmittance
+  ;                                       ! Solar Diffusing
+
+OS:WindowMaterial:Gas,
+  {f05f3259-446a-48b1-a741-e8e7b2804ce4}, ! Handle
+  000_Air 13mm,                           ! Name
+  Air,                                    ! Gas Type
+  0.012699999999999999;                   ! Thickness
+
+OS:Building,
+  {ca0f47ed-7317-4540-9565-98d7712a0577}, !- Handle
+  Building 1,                             !- Name
+  ,                                       !- Building Sector Type
+  ,                                       !- North Axis {deg}
+  ,                                       !- Nominal Floor to Floor Height {m}
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Space Type Name
+  {34e7058c-9698-49ca-9d64-b68d4ddfc445}, !- Default Construction Set Name
+  ;                                       !- Default Schedule Set Name
+
+OS:Construction,
+  {2c560e95-adba-4bdb-8868-54494896037a}, ! Handle
+  Air_Wall,                               ! Name
+  ,                                       ! Surface Rendering Name
+  {4647d060-a47e-4910-ac98-0ca6748de1a2}; ! Layer 1
+
+OS:Material:AirWall,
+  {4647d060-a47e-4910-ac98-0ca6748de1a2}, ! Handle
+  OS:Material:AirWall 1;                  ! Name
+
+OS:SpaceType,
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Handle
+  Baseline Model Space Type,              !- Name
+  ,                                       !- Default Construction Set Name
+  {6d641299-d85f-4474-af6c-3e9dfbab9ca5}, !- Default Schedule Set Name
+  ,                                       !- Group Rendering Name
+  {a3e4e11a-660e-4559-b503-7ccd7ce42258}; !- Design Specification Outdoor Air Object Name
+
+OS:DefaultScheduleSet,
+  {6d641299-d85f-4474-af6c-3e9dfbab9ca5}, !- Handle
+  Baseline Model Schedule Set,            !- Name
+  ,                                       !- Hours of Operation Schedule Name
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Number of People Schedule Name
+  {0051d100-8db1-4502-8ac9-ad048c59e2e0}, !- People Activity Level Schedule Name
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Lighting Schedule Name
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Electric Equipment Schedule Name
+  ,                                       !- Gas Equipment Schedule Name
+  ,                                       !- Hot Water Equipment Schedule Name
+  {ab3886f8-63a4-43a5-82cf-79b1819cd163}, !- Infiltration Schedule Name
+  ,                                       !- Steam Equipment Schedule Name
+  ;                                       !- Other Equipment Schedule Name
+
+OS:Schedule:Ruleset,
+  {ab3886f8-63a4-43a5-82cf-79b1819cd163}, !- Handle
+  Baseline Model Infiltration Schedule,   !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  {49ff6624-f5fe-4902-9ebf-738313c044e7}, !- Default Day Schedule Name
+  {74382f6a-8286-42ed-a8ad-1796552aa13e}, !- Summer Design Day Schedule Name
+  {c0bb9764-3660-4180-af00-3e8fddb5f9df}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {49ff6624-f5fe-4902-9ebf-738313c044e7}, !- Handle
+  Baseline Model Infiltration Schedule Schedule All Days, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  6,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  22,                                     !- Hour 2
+  0,                                      !- Minute 2
+  0.25,                                   !- Value Until Time 2
+  24,                                     !- Hour 3
+  0,                                      !- Minute 3
+  1;                                      !- Value Until Time 3
+
+OS:Schedule:Day,
+  {4b7b8867-4085-4e8b-9854-7c8c003667ef}, !- Handle
+  Schedule Day 2,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {c0bb9764-3660-4180-af00-3e8fddb5f9df}, !- Handle
+  Baseline Model Infiltration Schedule Winter Design Day, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {99d394a1-f6d6-4dec-b4f3-15a297c0dbb4}, !- Handle
+  Schedule Day 3,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {74382f6a-8286-42ed-a8ad-1796552aa13e}, !- Handle
+  Baseline Model Infiltration Schedule Summer Design Day, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:ScheduleTypeLimits,
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Handle
+  Fractional,                             !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Continuous;                             !- Numeric Type
+
+OS:Schedule:Ruleset,
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Handle
+  Baseline Model People Lights and Equipment Schedule, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  {8b36811a-4c0b-467b-8a60-c727de41fea9}, !- Default Day Schedule Name
+  {1cc8b576-e7f9-4891-a609-d18ace25018d}, !- Summer Design Day Schedule Name
+  {ea0546bb-1afc-48c3-bb73-adaf145e7597}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {8b36811a-4c0b-467b-8a60-c727de41fea9}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Schedule Week Day, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  6,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0,                                      !- Value Until Time 1
+  7,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.1,                                    !- Value Until Time 2
+  8,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.2,                                    !- Value Until Time 3
+  12,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.95,                                   !- Value Until Time 4
+  13,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.5,                                    !- Value Until Time 5
+  17,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.95,                                   !- Value Until Time 6
+  18,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.7,                                    !- Value Until Time 7
+  20,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.4,                                    !- Value Until Time 8
+  22,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.1,                                    !- Value Until Time 9
+  24,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.05;                                   !- Value Until Time 10
+
+OS:Schedule:Day,
+  {0b0303b1-88b7-4b3d-bcd9-bba8db83048d}, !- Handle
+  Schedule Day 4,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {ea0546bb-1afc-48c3-bb73-adaf145e7597}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Winter Design Day, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {c004c358-a54d-4b70-8ce5-1598254ceace}, !- Handle
+  Schedule Day 5,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {1cc8b576-e7f9-4891-a609-d18ace25018d}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Summer Design Day, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Rule,
+  {d64f1c46-5988-470a-9d5e-f655cd0002d4}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Saturday Rule, !- Name
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Schedule Ruleset Name
+  1,                                      !- Rule Order
+  {43bde385-95a9-4915-879f-d0a1f740fb50}, !- Day Schedule Name
+  ,                                       !- Apply Sunday
+  ,                                       !- Apply Monday
+  ,                                       !- Apply Tuesday
+  ,                                       !- Apply Wednesday
+  ,                                       !- Apply Thursday
+  ,                                       !- Apply Friday
+  Yes;                                    !- Apply Saturday
+
+OS:Schedule:Day,
+  {43bde385-95a9-4915-879f-d0a1f740fb50}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Saturday, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  6,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.1,                                    !- Value Until Time 2
+  14,                                     !- Hour 3
+  0,                                      !- Minute 3
+  0.5,                                    !- Value Until Time 3
+  17,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.1,                                    !- Value Until Time 4
+  24,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0;                                      !- Value Until Time 5
+
+OS:Schedule:Rule,
+  {cdc89c4e-70a9-4b57-afa7-08886100249c}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Sunday Rule, !- Name
+  {db66802b-93fb-4f3d-a474-e213a482d2ca}, !- Schedule Ruleset Name
+  0,                                      !- Rule Order
+  {0439972d-eafb-4698-bb94-483aabc35337}, !- Day Schedule Name
+  Yes;                                    !- Apply Sunday
+
+OS:Schedule:Day,
+  {0439972d-eafb-4698-bb94-483aabc35337}, !- Handle
+  Baseline Model People Lights and Equipment Schedule Schedule Sunday, !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0;                                      !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {0051d100-8db1-4502-8ac9-ad048c59e2e0}, !- Handle
+  Baseline Model People Activity Schedule, !- Name
+  {47933dcb-84a7-4afa-b0f6-b68e5b77febb}, !- Schedule Type Limits Name
+  {1e2ad8d6-b25e-439a-83e8-025921940c13}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {1e2ad8d6-b25e-439a-83e8-025921940c13}, !- Handle
+  Baseline Model People Activity Schedule Default, !- Name
+  {47933dcb-84a7-4afa-b0f6-b68e5b77febb}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  120;                                    !- Value Until Time 1
+
+OS:ScheduleTypeLimits,
+  {47933dcb-84a7-4afa-b0f6-b68e5b77febb}, !- Handle
+  ActivityLevel,                          !- Name
+  0,                                      !- Lower Limit Value
+  ,                                       !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  ActivityLevel;                          !- Unit Type
+
+OS:DesignSpecification:OutdoorAir,
+  {a3e4e11a-660e-4559-b503-7ccd7ce42258}, !- Handle
+  Baseline Model OA,                      !- Name
+  Sum,                                    !- Outdoor Air Method
+  0.009438948864,                         !- Outdoor Air Flow per Person {m3/s-person}
+  ,                                       !- Outdoor Air Flow per Floor Area {m3/s-m2}
+  ,                                       !- Outdoor Air Flow Rate {m3/s}
+  ,                                       !- Outdoor Air Flow Air Changes per Hour {1/hr}
+  ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
+
+OS:SpaceInfiltration:DesignFlowRate,
+  {ca987815-89b5-4374-94d6-c09595540c4c}, !- Handle
+  Baseline Model Infiltration,            !- Name
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Space or SpaceType Name
+  ,                                       !- Schedule Name
+  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
+  ,                                       !- Design Flow Rate {m3/s}
+  ,                                       !- Flow per Space Floor Area {m3/s-m2}
+  0.0003048,                              !- Flow per Exterior Surface Area {m3/s-m2}
+  ,                                       !- Air Changes per Hour {1/hr}
+  ,                                       !- Constant Term Coefficient
+  ,                                       !- Temperature Term Coefficient
+  ,                                       !- Velocity Term Coefficient
+  ;                                       !- Velocity Squared Term Coefficient
+
+OS:People:Definition,
+  {86e1ce09-b060-4310-a2a4-ab60c1a18643}, !- Handle
+  Baseline Model People Definition,       !- Name
+  People/Area,                            !- Number of People Calculation Method
+  ,                                       !- Number of People {people}
+  0.0538195520835486,                     !- People per Space Floor Area {person/m2}
+  ,                                       !- Space Floor Area per Person {m2/person}
+  0.3;                                    !- Fraction Radiant
+
+OS:People,
+  {6d5d2c0f-ff70-4dcd-af4b-d3f617ca1845}, !- Handle
+  Baseline Model People,                  !- Name
+  {86e1ce09-b060-4310-a2a4-ab60c1a18643}, !- People Definition Name
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Space or SpaceType Name
+  ,                                       !- Number of People Schedule Name
+  ,                                       !- Activity Level Schedule Name
+  ,                                       !- Surface Name/Angle Factor List Name
+  ,                                       !- Work Efficiency Schedule Name
+  ,                                       !- Clothing Insulation Schedule Name
+  ,                                       !- Air Velocity Schedule Name
+  1;                                      !- Multiplier
+
+OS:Lights:Definition,
+  {b0816ed1-a3a7-41e3-9872-567db01acef6}, !- Handle
+  Baseline Model Lights Definition,       !- Name
+  Watts/Area,                             !- Design Level Calculation Method
+  ,                                       !- Lighting Level {W}
+  10.7639104167097,                       !- Watts per Space Floor Area {W/m2}
+  ;                                       !- Watts per Person {W/person}
+
+OS:Lights,
+  {7876dbdf-ab5c-476a-a619-22d2c87d3c81}, !- Handle
+  Baseline Model Lights,                  !- Name
+  {b0816ed1-a3a7-41e3-9872-567db01acef6}, !- Lights Definition Name
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Space or SpaceType Name
+  {a8eb05dc-790e-4f88-a79a-983a3712d5b8}, !- Schedule Name
+  1,                                      !- Fraction Replaceable
+  ,                                       !- Multiplier
+  General;                                !- End-Use Subcategory
+
+OS:ElectricEquipment:Definition,
+  {2aacf12f-9295-4e02-8c1c-0af0c38afdfc}, !- Handle
+  Baseline Model Electric Equipment Definition, !- Name
+  Watts/Area,                             !- Design Level Calculation Method
+  ,                                       !- Design Level {W}
+  10.7639104167097,                       !- Watts per Space Floor Area {W/m2}
+  ;                                       !- Watts per Person {W/person}
+
+OS:ElectricEquipment,
+  {c0a30598-7c9a-4096-a816-8e17fb998c50}, !- Handle
+  Baseline Model Electric Equipment,      !- Name
+  {2aacf12f-9295-4e02-8c1c-0af0c38afdfc}, !- Electric Equipment Definition Name
+  {4b80b62d-4ed4-4bd1-aaf7-b488869632ef}, !- Space or SpaceType Name
+  ,                                       !- Schedule Name
+  ,                                       !- Multiplier
+  General;                                !- End-Use Subcategory
+
+OS:SizingPeriod:DesignDay,
+  {6bd3035b-914c-43ff-8503-444354562df5}, !- Handle
+  Chicago Ohare Intl Ap Ann Clg .4% Condns DB=>MWB, !- Name
+  33.3,                                   !- Maximum Dry-Bulb Temperature {C}
+  10.5,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
+  23.7,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb
+  98934,                                  !- Barometric Pressure {Pa}
+  5.2,                                    !- Wind Speed {m/s}
+  230,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  0,                                      !- Rain Indicator
+  0,                                      !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  0,                                      !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Indicating Type
+  ,                                       !- Humidity Indicating Day Schedule Name
+  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ASHRAETau,                              !- Solar Model Indicator
+  ,                                       !- Beam Solar Day Schedule Name
+  ,                                       !- Diffuse Solar Day Schedule Name
+  0.455,                                  !- ASHRAE Taub {dimensionless}
+  2.05;                                   !- ASHRAE Taud {dimensionless}
+
+OS:SizingPeriod:DesignDay,
+  {efa3ef65-7e32-4245-8918-487e9f66880e}, !- Handle
+  Chicago Ohare Intl Ap Ann Htg 99.6% Condns DB, !- Name
+  -20,                                    !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  -20,                                    !- Humidity Indicating Conditions at Maximum Dry-Bulb
+  98934,                                  !- Barometric Pressure {Pa}
+  4.9,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  0,                                      !- Rain Indicator
+  0,                                      !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  0,                                      !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Indicating Type
+  ,                                       !- Humidity Indicating Day Schedule Name
+  DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:SimulationControl,
+  {808ebd04-627e-47e1-8b77-9ee0ade50328}, !- Handle
+  ,                                       !- Do Zone Sizing Calculation
+  ,                                       !- Do System Sizing Calculation
+  ,                                       !- Do Plant Sizing Calculation
+  No,                                     !- Run Simulation for Sizing Periods
+  Yes;                                    !- Run Simulation for Weather File Run Periods
+
+OS:Timestep,
+  {7e058771-d67a-46e1-9f53-51e7c1d60d47}, !- Handle
+  4;                                      !- Number of Timesteps per Hour
+
+OS:YearDescription,
+  {8360427e-9b7c-4fc2-a2d0-afaefbb66fde}, !- Handle
+  2013,                                   !- Calendar Year
+  ,                                       !- Day of Week for Start Day
+  ;                                       !- Is Leap Year
+
+OS:External:File,
+  {c9e073c4-1b69-4cc7-a834-04cf26f193be}, !- Handle
+  External File 1,                        !- Name
+  schedulefile.csv;                       !- File Name
+
+OS:Schedule:File,
+  {a8eb05dc-790e-4f88-a79a-983a3712d5b8}, !- Handle
+  Schedule File 1,                        !- Name
+  {b38fc8ca-f4d1-43d2-bc64-afdc27fbe68d}, !- Schedule Type Limits Name
+  {c9e073c4-1b69-4cc7-a834-04cf26f193be}, !- External File Name
+  3,                                      !- Column Number
+  1;                                      !- Rows to Skip at Top
+

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -329,7 +329,7 @@ def sim_test(filename, options = {})
                             'model/simulationtests/lib/schedulefile.csv')
       sch_ori_path = File.realpath(sch_ori_path)
 
-      sch_target_path  = File.join(dir, File.basename(ssch_ori_path))
+      sch_target_path  = File.join(dir, File.basename(sch_ori_path))
       FileUtils.cp(sch_ori_path, sch_target_path)
     end
 
@@ -1426,15 +1426,13 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('schedule_file.rb')
   end
 
-  # TODO : To be added once the next official release
-  # including this object is out : 2.7.0
-  #def test_schedule_file_osm
-    # Note: there is a special case in sim_test for this test to copy the
+  def test_schedule_file_osm
+    # Note JM: there is a special case in sim_test for this test to copy the
     # necessary CSV file to the testruns/schedule_file.osm/ folder
     # We cannot do it here since sim_test starts by deleting and recreating
     # this folder
-    #result = sim_test('schedule_file.osm')
-  #end
+    result = sim_test('schedule_file.osm')
+  end
 
   def test_setpoint_managers_rb
     result = sim_test('setpoint_managers.rb')

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1302,10 +1302,9 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('multiple_loops_w_plenums.rb')
   end
 
-  # TODO: add when official 2.7.0 is out
-  # def test_multiple_loops_w_plenums_osm
-  #   result = sim_test('multiple_loops_w_plenums.osm')
-  # end
+  def test_multiple_loops_w_plenums_osm
+    result = sim_test('multiple_loops_w_plenums.osm')
+  end
 
   def test_photovoltaics_rb
     result = sim_test('photovoltaics.rb')

--- a/test/multiple_loops_w_plenums.osm_2.7.0_out.osw
+++ b/test/multiple_loops_w_plenums.osm_2.7.0_out.osw
@@ -1,0 +1,1096 @@
+{
+  "completed_status": "Success",
+  "current_step": 1,
+  "eplusout_err": [
+    "Program Version,EnergyPlus, Version 9.0.1-bb7ca4f0da, ",
+    "   ************* Beginning Zone Sizing Calculations",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 2\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 3\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 4\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 5\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS OFF DISCRETE\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS ON CONTINUOUS\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** GetHTSurfaceData: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.",
+    "   **   ~~~   ** Found first in surface=SURFACE 25",
+    "   **   ~~~   ** Defaults, constant throughout the year of (18.0) will be used.",
+    "   ** Warning ** CheckUsedConstructions: There are 6 nominally unused constructions in input.",
+    "   **   ~~~   ** For explicit details on each unused construction, use Output:Diagnostics,DisplayExtraWarnings;",
+    "   ************* Beginning System Sizing Calculations",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 4",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 11",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 1",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 2",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 3",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 10",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 5",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 12",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 8",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 15",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 6",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 13",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 7",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 14",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 9",
+    "   ** Warning ** Since Zone Minimum Air Flow Input Method = CONSTANT, input for Fixed Minimum Air Flow Rate will be ignored.",
+    "   **   ~~~   ** Occurs in AirTerminal:SingleDuct:VAV:Reheat = AIR TERMINAL SINGLE DUCT VAV REHEAT 16",
+    "   ************* Beginning Plant Sizing Calculations",
+    "   ** Warning ** Zone name = STORY 1 NORTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 1 NORTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 1 SOUTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 1 SOUTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 1 EAST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 1 EAST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 1 WEST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 1 WEST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 2 NORTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 2 NORTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 2 SOUTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 2 SOUTH PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 2 EAST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 2 EAST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Zone name = STORY 2 WEST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** Ventilation per unit floor area has not been specified for this zone, which is connected to",
+    "   **   ~~~   ** the air loop served by Controller:OutdoorAir = CONTROLLER OUTDOOR AIR 2. Simulation will continue...",
+    "   ** Warning ** PEOPLE object for zone = STORY 2 WEST PERIMETER THERMAL ZONE is not accounted for by Controller:MechanicalVentilation object name = CONTROLLER MECHANICAL VENTILATION 2",
+    "   **   ~~~   ** A \"PEOPLE\" object has been specified in the idf for this zone, but it is not included in this Controller:MechanicalVentilation Object.",
+    "   **   ~~~   ** Check Controller:MechanicalVentilation object. Simulation will continue.",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTCOOLING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTHEATING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Electricity:Facility\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr",
+    "   ************* Testing Individual Branch Integrity",
+    "   ************* All Branches passed integrity testing",
+    "   ************* Testing Individual Supply Air Path Integrity",
+    "   ************* All Supply Air Paths passed integrity testing",
+    "   ************* Testing Individual Return Air Path Integrity",
+    "   ************* All Return Air Paths passed integrity testing",
+    "   ************* No node connection errors were found.",
+    "   ************* Beginning Simulation",
+    "   ** Warning ** Processing Monthly Tabular Reports: Variable names not valid for this simulation",
+    "   **   ~~~   ** ...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual variables.",
+    "   ** Warning ** Plant Loop: CONDENSER WATER LOOP Demand Side is storing excess heat the majority of the time.",
+    "   ** Warning ** Plant Loop: CONDENSER WATER LOOP Supply Side is storing excess heat the majority of the time.",
+    "   ** Warning ** Plant Loop: CONDENSER WATER LOOP 1 Demand Side is storing excess heat the majority of the time.",
+    "   ** Warning ** Plant Loop: CONDENSER WATER LOOP 1 Supply Side is storing excess heat the majority of the time.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-ELECTRICITY\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-DISTILLATE OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-RESIDUAL OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-NATURAL GAS\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-COAL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ************* Simulation Error Summary *************",
+    "   ************* There are 2 unused schedules in input.",
+    "   ************* There are 2 unused week schedules in input.",
+    "   ************* There are 6 unused day schedules in input.",
+    "   ************* Use Output:Diagnostics,DisplayUnusedSchedules; to see them.",
+    "   *************",
+    "   ************* ===== Final Error Summary =====",
+    "   ************* The following error categories occurred.  Consider correcting or noting.",
+    "   ************* Nominally Unused Constructions",
+    "   ************* ..The nominally unused constructions warning is provided to alert you to potential conditions that can cause",
+    "   ************* ..extra time during simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm",
+    "   ************* ..object. You may remove the constructions indicated (when you use the DisplayExtraWarnings option).",
+    "   *************",
+    "   ************* EnergyPlus Warmup Error Summary. During Warmup: 0 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Sizing Error Summary. During Sizing: 24 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Completed Successfully-- 53 Warning; 0 Severe Errors; "
+  ],
+  "seed_file": "in.osm",
+  "steps": [
+    {
+      "arguments": {
+      },
+      "measure_dir_name": "openstudio_results",
+      "result": {
+        "measure_class_name": "OpenStudioResults",
+        "measure_display_name": "OpenStudio Results",
+        "measure_name": "openstudio_results",
+        "measure_taxonomy": "Reporting.QAQC",
+        "measure_type": "ReportingMeasure",
+        "measure_uid": "a25386cd-60e4-46bc-8b11-c755f379d916",
+        "measure_version_id": "02ad7007-fe7b-4747-bd7a-29d697c4d91a",
+        "measure_version_modified": "20180711T183039Z",
+        "measure_xml_checksum": "557BF06F",
+        "stderr": "",
+        "stdout": "",
+        "step_errors": [
+
+        ],
+        "step_final_condition": "Generated report with 21 sections to ./report.html.",
+        "step_info": [
+
+        ],
+        "step_initial_condition": "Gathering data from EnergyPlus SQL file and OSM model.",
+        "step_result": "Success",
+        "step_values": [
+          {
+            "name": "building_summary_section",
+            "value": true
+          },
+          {
+            "name": "annual_overview_section",
+            "value": true
+          },
+          {
+            "name": "monthly_overview_section",
+            "value": true
+          },
+          {
+            "name": "utility_bills_rates_section",
+            "value": true
+          },
+          {
+            "name": "envelope_section_section",
+            "value": true
+          },
+          {
+            "name": "space_type_breakdown_section",
+            "value": true
+          },
+          {
+            "name": "space_type_details_section",
+            "value": true
+          },
+          {
+            "name": "interior_lighting_section",
+            "value": true
+          },
+          {
+            "name": "plug_loads_section",
+            "value": true
+          },
+          {
+            "name": "exterior_light_section",
+            "value": true
+          },
+          {
+            "name": "water_use_section",
+            "value": true
+          },
+          {
+            "name": "hvac_load_profile",
+            "value": true
+          },
+          {
+            "name": "zone_condition_section",
+            "value": true
+          },
+          {
+            "name": "zone_summary_section",
+            "value": true
+          },
+          {
+            "name": "zone_equipment_detail_section",
+            "value": true
+          },
+          {
+            "name": "air_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "plant_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "outdoor_air_section",
+            "value": true
+          },
+          {
+            "name": "cost_summary_section",
+            "value": true
+          },
+          {
+            "name": "source_energy_section",
+            "value": true
+          },
+          {
+            "name": "schedules_overview_section",
+            "value": true
+          },
+          {
+            "name": "standards_gem_version",
+            "value": "0.2.6"
+          },
+          {
+            "name": "workflow_gem_version",
+            "value": "1.3.3"
+          },
+          {
+            "display_name": "Building 1",
+            "name": "building_name",
+            "value": "n/a"
+          },
+          {
+            "name": "total_site_energy",
+            "units": "kBtu",
+            "value": 6685892.49
+          },
+          {
+            "name": "net_site_energy",
+            "units": "kBtu",
+            "value": 6685892.49
+          },
+          {
+            "name": "total_building_area",
+            "units": "ft^2",
+            "value": 107639.1
+          },
+          {
+            "name": "total_site_eui",
+            "units": "kBtu/ft^2",
+            "value": 62.11
+          },
+          {
+            "name": "eui",
+            "units": "kBtu/ft^2",
+            "value": 62.11
+          },
+          {
+            "name": "unmet_hours_during_heating",
+            "units": "hr",
+            "value": 1034.75
+          },
+          {
+            "name": "unmet_hours_during_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_during_occupied_heating",
+            "units": "hr",
+            "value": 275.5
+          },
+          {
+            "name": "unmet_hours_during_occupied_cooling",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_tolerance_heating",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "unmet_hours_tolerance_cooling",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "end_use_heating",
+            "units": "kBtu",
+            "value": 4296606.66
+          },
+          {
+            "name": "end_use_cooling",
+            "units": "kBtu",
+            "value": 1095885.11
+          },
+          {
+            "name": "end_use_interior_lighting",
+            "units": "kBtu",
+            "value": 180511.77
+          },
+          {
+            "name": "end_use_exterior_lighting",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_interior_equipment",
+            "units": "kBtu",
+            "value": 180511.77
+          },
+          {
+            "name": "end_use_exterior_equipment",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_fans",
+            "units": "kBtu",
+            "value": 53561.15
+          },
+          {
+            "name": "end_use_pumps",
+            "units": "kBtu",
+            "value": 606868.35
+          },
+          {
+            "name": "end_use_heat_rejection",
+            "units": "kBtu",
+            "value": 271947.69
+          },
+          {
+            "name": "end_use_humidification",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_heat_recovery",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_water_systems",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_refrigeration",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_generators",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_electricity",
+            "units": "kBtu",
+            "value": 2389285.83
+          },
+          {
+            "name": "fuel_natural_gas",
+            "units": "kBtu",
+            "value": 4296606.66
+          },
+          {
+            "name": "fuel_additional_fuel",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_cooling",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_heating",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heating",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_cooling",
+            "units": "kWh",
+            "value": 321172.22
+          },
+          {
+            "name": "end_use_electricity_interior_lighting",
+            "units": "kWh",
+            "value": 52902.78
+          },
+          {
+            "name": "end_use_electricity_exterior_lighting",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_interior_equipment",
+            "units": "kWh",
+            "value": 52902.78
+          },
+          {
+            "name": "end_use_electricity_exterior_equipment",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_fans",
+            "units": "kWh",
+            "value": 15697.22
+          },
+          {
+            "name": "end_use_electricity_pumps",
+            "units": "kWh",
+            "value": 177855.56
+          },
+          {
+            "name": "end_use_electricity_heat_rejection",
+            "units": "kWh",
+            "value": 79700
+          },
+          {
+            "name": "end_use_electricity_humidification",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heat_recovery",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_water_systems",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_refrigeration",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_generators",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heating",
+            "units": "therms",
+            "value": 42974.36
+          },
+          {
+            "name": "end_use_natural_gas_cooling",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_fans",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_pumps",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_rejection",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_humidification",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_recovery",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_water_systems",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_refrigeration",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_generators",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "electricity_heating_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_cooling_ip",
+            "units": "kWh",
+            "value": 321173.36
+          },
+          {
+            "name": "electricity_interior_lighting_ip",
+            "units": "kWh",
+            "value": 52902.28
+          },
+          {
+            "name": "electricity_exterior_lighting_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_interior_equipment_ip",
+            "units": "kWh",
+            "value": 52902.28
+          },
+          {
+            "name": "electricity_exterior_equipment_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_fans_ip",
+            "units": "kWh",
+            "value": 15697.64
+          },
+          {
+            "name": "electricity_pumps_ip",
+            "units": "kWh",
+            "value": 177854.61
+          },
+          {
+            "name": "electricity_heat_rejection_ip",
+            "units": "kWh",
+            "value": 79701.13
+          },
+          {
+            "name": "electricity_humidification_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_heat_recovery_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_water_systems_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_refrigeration_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_generators_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_ip",
+            "units": "kWh",
+            "value": 700231.3
+          },
+          {
+            "name": "natural_gas_heating_ip",
+            "units": "MBtu",
+            "value": 4296.6
+          },
+          {
+            "name": "natural_gas_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_ip",
+            "units": "MBtu",
+            "value": 4296.6
+          },
+          {
+            "name": "additional_fuel_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_roof_iead_climate_zone_2_5",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_wall_steel_frame_climate_zone_4_8",
+            "units": "ft^2",
+            "value": 15500.03
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_window_climate_zone_4_5",
+            "units": "ft^2",
+            "value": 10333.35
+          },
+          {
+            "name": "gross_window_wall_ratio",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "gross_window_wall_ratio_conditioned",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "skylight_roof_ratio",
+            "units": "%",
+            "value": 0
+          },
+          {
+            "name": "space_type_baseline_model_space_type",
+            "units": "ft^2",
+            "value": 18600.04
+          },
+          {
+            "name": "space_type_plenum_space_type",
+            "units": "ft^2",
+            "value": 0
+          },
+          {
+            "name": "exterior_lighting_total_power",
+            "units": "W",
+            "value": 0
+          },
+          {
+            "name": "exterior_lighting_total_consumption",
+            "units": "kWh",
+            "value": 1959441.67
+          },
+          {
+            "name": "inflation_approach",
+            "value": "Constant Dollar"
+          },
+          {
+            "name": "analysis_length",
+            "units": "yrs",
+            "value": 25
+          },
+          {
+            "name": "annual_peak_electric_demand",
+            "units": "kW",
+            "value": 126.57
+          },
+          {
+            "name": "first_year_capital_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "annual_utility_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "total_lifecycle_cost",
+            "units": "$",
+            "value": 0
+          }
+        ],
+        "step_warnings": [
+          "EnergyPlus reported area is 10000 (m^2). OpenStudio reported area is 1728 (m^2)."
+        ]
+      }
+    }
+  ],
+  "weather_file": "../../weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw"
+}

--- a/test/schedule_file.osm_2.7.0_out.osw
+++ b/test/schedule_file.osm_2.7.0_out.osw
@@ -1,0 +1,1194 @@
+{
+  "completed_status": "Success",
+  "current_step": 1,
+  "eplusout_err": [
+    "Program Version,EnergyPlus, Version 9.0.1-bb7ca4f0da, ",
+    "   ************* Beginning Zone Sizing Calculations",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 2\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 3\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 4\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Day:Interval=\"SCHEDULE DAY 5\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS OFF DISCRETE\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** ProcessScheduleInput: Schedule:Constant=\"ALWAYS ON CONTINUOUS\", Blank Schedule Type Limits Name input -- will not be validated.",
+    "   ** Warning ** GetHTSurfaceData: Surfaces with interface to Ground found but no \"Ground Temperatures\" were input.",
+    "   **   ~~~   ** Found first in surface=SURFACE 25",
+    "   **   ~~~   ** Defaults, constant throughout the year of (18.0) will be used.",
+    "   ** Warning ** CheckUsedConstructions: There are 6 nominally unused constructions in input.",
+    "   **   ~~~   ** For explicit details on each unused construction, use Output:Diagnostics,DisplayExtraWarnings;",
+    "   ** Warning ** GetSimpleAirModelInputs: ZoneInfiltration:DesignFlowRate=\"STORY 1 CORE THERMAL ZONE BASELINE MODEL INFILTRATION\", Design Flow Rate Calculation Method specifies Flow per Exterior Surface Area, but Exterior Surface Area = 0.  0 Infiltration will result.",
+    "   ************* Beginning System Sizing Calculations",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTCOOLING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter: invalid Key Name=\"DISTRICTHEATING:FACILITY\" - not found.",
+    "   ** Warning ** Output:Meter:MeterFileOnly requested for \"Electricity:Facility\" (TimeStep), already on \"Output:Meter\". Will report to both eplusout.eso and eplusout.mtr",
+    "   ************* Testing Individual Branch Integrity",
+    "   ************* All Branches passed integrity testing",
+    "   ************* Testing Individual Supply Air Path Integrity",
+    "   ************* All Supply Air Paths passed integrity testing",
+    "   ************* Testing Individual Return Air Path Integrity",
+    "   ************* All Return Air Paths passed integrity testing",
+    "   ************* No node connection errors were found.",
+    "   ************* Beginning Simulation",
+    "   ** Warning ** Processing Monthly Tabular Reports: Variable names not valid for this simulation",
+    "   **   ~~~   ** ...use Output:Diagnostics,DisplayExtraWarnings; to show more details on individual variables.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 4\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -6.70",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/01 09:53 - 10:00",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 4\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -2.76 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/01 09:53 - 10:00",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 21.684 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 9\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -5.43",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/01 10:38 - 10:45",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 9\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -2.35 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/01 10:38 - 10:45",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 22.094 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 2\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -0.83",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/10 09:08 - 09:15",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 2\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -2.36 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/10 09:08 - 09:15",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 22.033 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 7\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -1.71 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/10 09:50 - 09:55",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 22.677 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 5\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -1.68 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/10 13:08 - 13:15",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 22.251 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 10\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -1.38 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/10 13:53 - 14:00",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 22.749 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 5\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -0.25",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/10 16:15 - 16:20",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 10\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -0.68",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/10 16:30 - 16:35",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 6\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -3.49 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/11 13:10 - 13:15",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 18.446 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 1\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = -3.90 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 01/21 13:23 - 13:30",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 14.518 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 6\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -0.80",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 01/22 17:15 - 17:19",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 8\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = 1.00 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 02/11 13:20 - 13:25",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 23.298 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 3\" - Full load outlet air dry-bulb temperature < 2C. This indicates the possibility of coil frost/freeze. Outlet temperature = 1.21 C.",
+    "   **   ~~~   **  ...Occurrence info = RUN PERIOD 1, 02/11 14:23 - 14:30",
+    "   **   ~~~   ** ... Possible reasons for low outlet air dry-bulb temperatures are: This DX coil",
+    "   **   ~~~   **    1) may have a low inlet air dry-bulb temperature. Inlet air temperature = 23.243 C.",
+    "   **   ~~~   **    2) may have a low air flow rate per watt of cooling capacity. Check inputs.",
+    "   **   ~~~   **    3) is used as part of a HX assisted cooling coil which uses a high sensible effectiveness. Check inputs.",
+    "   ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed \"COIL COOLING DX SINGLE SPEED 7\" - Air-cooled condenser inlet dry-bulb temperature below 0 C. Outdoor dry-bulb temperature = -7.63",
+    "   **   ~~~   **  ... Occurrence info = RUN PERIOD 1, 02/15 09:38 - 09:45",
+    "   **   ~~~   ** ... Operation at low ambient temperatures may require special performance curves.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-ELECTRICITY\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-DISTILLATE OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-RESIDUAL OIL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-NATURAL GAS\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ** Warning ** The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-COAL\" has no energy cost. ",
+    "   **   ~~~   ** ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
+    "   ************* Simulation Error Summary *************",
+    "   ************* There are 2 unused schedules in input.",
+    "   ************* There are 2 unused week schedules in input.",
+    "   ************* There are 6 unused day schedules in input.",
+    "   ************* Use Output:Diagnostics,DisplayUnusedSchedules; to see them.",
+    "   *************",
+    "   ************* ===== Recurring Error Summary =====",
+    "   ************* The following recurring error messages occurred.",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 4\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 700 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-2.500000E-002 [C]  Min=-16.4 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 4\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 2176 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.999337  Min=-3.912193",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 9\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 532 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.15 [C]  Min=-16.1 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 9\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 1699 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.999635  Min=-3.058547",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 2\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 48 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-2.500000E-002 [C]  Min=-8.475 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 2\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 825 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.999233  Min=-2.837511",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 7\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 646 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.996654  Min=-2.504888",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 5\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 651 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.998989  Min=-2.902773",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 10\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 561 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.995236  Min=-2.150106",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 5\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 59 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.1 [C]  Min=-9.025 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 10\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 26 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.425 [C]  Min=-6.4 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 6\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 814 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.998239  Min=-5.428345",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 1\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 174 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.97164  Min=-7.475897",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 6\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 3 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-0.8 [C]  Min=-1.15 [C]",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 8\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 196 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.991534  Min=-1.391479",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 3\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:",
+    "   *************  **   ~~~   **   This error occurred 130 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=1.988369  Min=-1.517961",
+    "   *************",
+    "   *************  ** Warning ** CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 7\" - Low condenser dry-bulb temperature error continues...",
+    "   *************  **   ~~~   **   This error occurred 18 total times;",
+    "   *************  **   ~~~   **   during Warmup 0 times;",
+    "   *************  **   ~~~   **   during Sizing 0 times.",
+    "   *************  **   ~~~   **   Max=-2.500000E-002 [C]  Min=-7.625 [C]",
+    "   *************",
+    "   *************",
+    "   ************* ===== Final Error Summary =====",
+    "   ************* The following error categories occurred.  Consider correcting or noting.",
+    "   ************* Nominally Unused Constructions",
+    "   ************* ..The nominally unused constructions warning is provided to alert you to potential conditions that can cause",
+    "   ************* ..extra time during simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm",
+    "   ************* ..object. You may remove the constructions indicated (when you use the DisplayExtraWarnings option).",
+    "   *************",
+    "   ************* EnergyPlus Warmup Error Summary. During Warmup: 0 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Sizing Error Summary. During Sizing: 9 Warning; 0 Severe Errors.",
+    "   ************* EnergyPlus Completed Successfully-- 9276 Warning; 0 Severe Errors; "
+  ],
+  "seed_file": "in.osm",
+  "steps": [
+    {
+      "arguments": {
+      },
+      "measure_dir_name": "openstudio_results",
+      "result": {
+        "measure_class_name": "OpenStudioResults",
+        "measure_display_name": "OpenStudio Results",
+        "measure_name": "openstudio_results",
+        "measure_taxonomy": "Reporting.QAQC",
+        "measure_type": "ReportingMeasure",
+        "measure_uid": "a25386cd-60e4-46bc-8b11-c755f379d916",
+        "measure_version_id": "02ad7007-fe7b-4747-bd7a-29d697c4d91a",
+        "measure_version_modified": "20180711T183039Z",
+        "measure_xml_checksum": "557BF06F",
+        "stderr": "",
+        "stdout": "",
+        "step_errors": [
+
+        ],
+        "step_final_condition": "Generated report with 21 sections to ./report.html.",
+        "step_info": [
+
+        ],
+        "step_initial_condition": "Gathering data from EnergyPlus SQL file and OSM model.",
+        "step_result": "Success",
+        "step_values": [
+          {
+            "name": "building_summary_section",
+            "value": true
+          },
+          {
+            "name": "annual_overview_section",
+            "value": true
+          },
+          {
+            "name": "monthly_overview_section",
+            "value": true
+          },
+          {
+            "name": "utility_bills_rates_section",
+            "value": true
+          },
+          {
+            "name": "envelope_section_section",
+            "value": true
+          },
+          {
+            "name": "space_type_breakdown_section",
+            "value": true
+          },
+          {
+            "name": "space_type_details_section",
+            "value": true
+          },
+          {
+            "name": "interior_lighting_section",
+            "value": true
+          },
+          {
+            "name": "plug_loads_section",
+            "value": true
+          },
+          {
+            "name": "exterior_light_section",
+            "value": true
+          },
+          {
+            "name": "water_use_section",
+            "value": true
+          },
+          {
+            "name": "hvac_load_profile",
+            "value": true
+          },
+          {
+            "name": "zone_condition_section",
+            "value": true
+          },
+          {
+            "name": "zone_summary_section",
+            "value": true
+          },
+          {
+            "name": "zone_equipment_detail_section",
+            "value": true
+          },
+          {
+            "name": "air_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "plant_loops_detail_section",
+            "value": true
+          },
+          {
+            "name": "outdoor_air_section",
+            "value": true
+          },
+          {
+            "name": "cost_summary_section",
+            "value": true
+          },
+          {
+            "name": "source_energy_section",
+            "value": true
+          },
+          {
+            "name": "schedules_overview_section",
+            "value": true
+          },
+          {
+            "name": "standards_gem_version",
+            "value": "0.2.6"
+          },
+          {
+            "name": "workflow_gem_version",
+            "value": "1.3.3"
+          },
+          {
+            "display_name": "Building 1",
+            "name": "building_name",
+            "value": "n/a"
+          },
+          {
+            "name": "total_site_energy",
+            "units": "kBtu",
+            "value": 6911548.79
+          },
+          {
+            "name": "net_site_energy",
+            "units": "kBtu",
+            "value": 6911548.79
+          },
+          {
+            "name": "total_building_area",
+            "units": "ft^2",
+            "value": 107639.1
+          },
+          {
+            "name": "total_site_eui",
+            "units": "kBtu/ft^2",
+            "value": 64.21
+          },
+          {
+            "name": "eui",
+            "units": "kBtu/ft^2",
+            "value": 64.21
+          },
+          {
+            "name": "unmet_hours_during_heating",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_during_cooling",
+            "units": "hr",
+            "value": 2.25
+          },
+          {
+            "name": "unmet_hours_during_occupied_heating",
+            "units": "hr",
+            "value": 0
+          },
+          {
+            "name": "unmet_hours_during_occupied_cooling",
+            "units": "hr",
+            "value": 2.25
+          },
+          {
+            "name": "unmet_hours_tolerance_heating",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "unmet_hours_tolerance_cooling",
+            "units": "F",
+            "value": 0.36
+          },
+          {
+            "name": "end_use_heating",
+            "units": "kBtu",
+            "value": 3584814.96
+          },
+          {
+            "name": "end_use_cooling",
+            "units": "kBtu",
+            "value": 211894.0
+          },
+          {
+            "name": "end_use_interior_lighting",
+            "units": "kBtu",
+            "value": 1599725.74
+          },
+          {
+            "name": "end_use_exterior_lighting",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_interior_equipment",
+            "units": "kBtu",
+            "value": 1044617.68
+          },
+          {
+            "name": "end_use_exterior_equipment",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_fans",
+            "units": "kBtu",
+            "value": 470496.42
+          },
+          {
+            "name": "end_use_pumps",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_heat_rejection",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_humidification",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_heat_recovery",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_water_systems",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_refrigeration",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_generators",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_electricity",
+            "units": "kBtu",
+            "value": 3326743.31
+          },
+          {
+            "name": "fuel_natural_gas",
+            "units": "kBtu",
+            "value": 3584814.96
+          },
+          {
+            "name": "fuel_additional_fuel",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_cooling",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "fuel_district_heating",
+            "units": "kBtu",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heating",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_cooling",
+            "units": "kWh",
+            "value": 62100
+          },
+          {
+            "name": "end_use_electricity_interior_lighting",
+            "units": "kWh",
+            "value": 468833.33
+          },
+          {
+            "name": "end_use_electricity_exterior_lighting",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_interior_equipment",
+            "units": "kWh",
+            "value": 306147.22
+          },
+          {
+            "name": "end_use_electricity_exterior_equipment",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_fans",
+            "units": "kWh",
+            "value": 137888.89
+          },
+          {
+            "name": "end_use_electricity_pumps",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heat_rejection",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_humidification",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_heat_recovery",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_water_systems",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_refrigeration",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_electricity_generators",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heating",
+            "units": "therms",
+            "value": 35855.07
+          },
+          {
+            "name": "end_use_natural_gas_cooling",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_lighting",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_interior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_exterior_equipment",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_fans",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_pumps",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_rejection",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_humidification",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_heat_recovery",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_water_systems",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_refrigeration",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "end_use_natural_gas_generators",
+            "units": "therms",
+            "value": 0
+          },
+          {
+            "name": "electricity_heating_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_cooling_ip",
+            "units": "kWh",
+            "value": 62101.32
+          },
+          {
+            "name": "electricity_interior_lighting_ip",
+            "units": "kWh",
+            "value": 468832.78
+          },
+          {
+            "name": "electricity_exterior_lighting_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_interior_equipment_ip",
+            "units": "kWh",
+            "value": 306147.14
+          },
+          {
+            "name": "electricity_exterior_equipment_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_fans_ip",
+            "units": "kWh",
+            "value": 137890.22
+          },
+          {
+            "name": "electricity_pumps_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_heat_rejection_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_humidification_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_heat_recovery_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_water_systems_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_refrigeration_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_generators_ip",
+            "units": "kWh",
+            "value": 0
+          },
+          {
+            "name": "electricity_ip",
+            "units": "kWh",
+            "value": 974971.46
+          },
+          {
+            "name": "natural_gas_heating_ip",
+            "units": "MBtu",
+            "value": 3584.81
+          },
+          {
+            "name": "natural_gas_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "natural_gas_ip",
+            "units": "MBtu",
+            "value": 3584.81
+          },
+          {
+            "name": "additional_fuel_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "additional_fuel_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "district_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heating_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_cooling_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_lighting_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_interior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_exterior_equipment_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_fans_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_pumps_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_rejection_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_humidification_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_heat_recovery_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_water_systems_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_refrigeration_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_generators_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "water_ip",
+            "units": "MBtu",
+            "value": 0
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_roof_iead_climate_zone_2_5",
+            "units": "ft^2",
+            "value": 53819.55
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_wall_steel_frame_climate_zone_4_8",
+            "units": "ft^2",
+            "value": 15500.03
+          },
+          {
+            "name": "ashrae_189_1_2009_ext_window_climate_zone_4_5",
+            "units": "ft^2",
+            "value": 10333.35
+          },
+          {
+            "name": "gross_window_wall_ratio",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "gross_window_wall_ratio_conditioned",
+            "units": "%",
+            "value": 40
+          },
+          {
+            "name": "skylight_roof_ratio",
+            "units": "%",
+            "value": 0
+          },
+          {
+            "name": "space_type_baseline_model_space_type",
+            "units": "ft^2",
+            "value": 107639.1
+          },
+          {
+            "name": "exterior_lighting_total_power",
+            "units": "W",
+            "value": 0
+          },
+          {
+            "name": "exterior_lighting_total_consumption",
+            "units": "kWh",
+            "value": 2025575
+          },
+          {
+            "name": "inflation_approach",
+            "value": "Constant Dollar"
+          },
+          {
+            "name": "analysis_length",
+            "units": "yrs",
+            "value": 25
+          },
+          {
+            "name": "annual_peak_electric_demand",
+            "units": "kW",
+            "value": 350.43
+          },
+          {
+            "name": "first_year_capital_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "annual_utility_cost",
+            "units": "$",
+            "value": 0
+          },
+          {
+            "name": "total_lifecycle_cost",
+            "units": "$",
+            "value": 0
+          }
+        ],
+        "step_warnings": [
+
+        ]
+      }
+    }
+  ],
+  "weather_file": "../../weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw"
+}


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

Link to relevant GitHub Issue(s) if appropriate:

This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.

> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO : To be added once the next official release
            # including this object is out : 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

