### PR TITLE
Add regression test for WaterCooled AirConditionerVRF

### DIFF
--- a/model/simulationtests/vrf_watercooled.rb
+++ b/model/simulationtests/vrf_watercooled.rb
@@ -58,8 +58,10 @@ sizingPlant.setDesignLoopExitTemperature(29.4)
 sizingPlant.setLoopDesignTemperatureDifference(5.6)
 
 # Connect VRF to demand side of plant loop
+# We do not hardcode the condenserType, so in the FT it will see that it's
+# connected to a PlantLoop and set it to WaterCooled appropriately.
 condenserSystem.addDemandBranchForComponent(vrf)
-
+# condenserSystem.setCondenserType("WaterCooled")
 
 # Set up supply side of the CW Loop
 pump = OpenStudio::Model::PumpVariableSpeed.new(model)

--- a/model/simulationtests/vrf_watercooled.rb
+++ b/model/simulationtests/vrf_watercooled.rb
@@ -1,0 +1,97 @@
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+#make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({"length" => 100,
+              "width" => 50,
+              "num_floors" => 2,
+              "floor_to_floor_height" => 4,
+              "plenum_height" => 1,
+              "perimeter_zone_depth" => 3})
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                  "offset" => 1,
+                  "application_type" => "Above Floor"})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 24,
+                      "cooling_setpoint" => 28})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+
+# NOTE: if you using this as an example for an actual project, you
+# should change the curves to match a water cooled VRF...
+# You should also control the Condenser Loop more carefully (the loop gets
+# below freezing point...)
+# This watercooled VRF example has +50% site EUI compared to vrf.rb example
+vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlow.new(model)
+
+zones.each do |z|
+  vrf_terminal = OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow.new(model)
+  vrf_terminal.addToThermalZone(z)
+  vrf.addTerminal(vrf_terminal)
+end
+
+
+# Create a dummy loop to connect the VRF to
+# (Controls could be better)
+condenserSystem = OpenStudio::Model::PlantLoop.new(model)
+condenserSystem.setName("CW Loop")
+sizingPlant = condenserSystem.sizingPlant()
+sizingPlant.setLoopType("Condenser")
+sizingPlant.setDesignLoopExitTemperature(29.4)
+sizingPlant.setLoopDesignTemperatureDifference(5.6)
+
+# Connect VRF to demand side of plant loop
+condenserSystem.addDemandBranchForComponent(vrf)
+
+
+# Set up supply side of the CW Loop
+pump = OpenStudio::Model::PumpVariableSpeed.new(model)
+pump.addToNode(condenserSystem.supplyInletNode)
+
+boiler = OpenStudio::Model::BoilerHotWater.new(model)
+condenserSystem.addSupplyBranchForComponent(boiler)
+
+ct = OpenStudio::Model::CoolingTowerSingleSpeed.new(model)
+condenserSystem.addSupplyBranchForComponent(ct)
+
+boilerWaterSchedule = OpenStudio::Model::ScheduleRuleset.new(model, 60)
+boilerWaterSchedule.setName("Boiler Water Schedule 60C")
+lowWaterSchedule = OpenStudio::Model::ScheduleRuleset.new(model, 20)
+lowWaterSchedule.setName("Low Water Schedule 20C")
+highWaterSchedule = OpenStudio::Model::ScheduleRuleset.new(model, 30)
+highWaterSchedule.setName("High Water Schedule 30C")
+
+# This will set the Plant Loop Demand Calculation Scheme to "DualSetpoint"
+# It means you can ONLY use SPM:DualSetpoint on that loop
+loop_spm = OpenStudio::Model::SetpointManagerScheduledDualSetpoint.new(model)
+loop_spm.setControlVariable("Temperature")
+loop_spm.setLowSetpointSchedule(lowWaterSchedule)
+loop_spm.setHighSetpointSchedule(highWaterSchedule)
+loop_spm.addToNode(condenserSystem.supplyOutletNode)
+
+boiler_spm = OpenStudio::Model::SetpointManagerScheduledDualSetpoint.new(model)
+boiler_spm.setControlVariable("Temperature")
+boiler_spm.setLowSetpointSchedule(lowWaterSchedule)
+boiler_spm.setHighSetpointSchedule(boilerWaterSchedule)
+boiler_spm.addToNode(boiler.outletModelObject.get.to_Node.get)
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "in.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1776,6 +1776,15 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('vrf.rb')
   end
 
+  # TODO: Add this once next official version is out (Post 2.8.1)
+  # def test_vrf_watercooled_osm
+  #   result = sim_test('vrf_watercooled.osm')
+  # end
+
+  def test_vrf_watercooled_rb
+    result = sim_test('vrf_watercooled.rb')
+  end
+
   def test_water_economizer_osm
     result = sim_test('water_economizer.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

This test is in conjunction with cf https://github.com/NREL/OpenStudio/pull/3613

It aims to test the newly-added possibility of having a WaterCooled AirConditionerVariableRefrigerantFlow (in 2.8.1 it wasn't possible, see [AirConditionerVariableRefrigerantFlow::addToNode (v2.8.1)](https://github.com/NREL/OpenStudio/blob/v2.8.1/openstudiocore/src/model/AirConditionerVariableRefrigerantFlow.cpp#L1927)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] **Test has been run backwards**: N/A
 - [x] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes: **Pending next official release (post 2.8.1)**

 - [x] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        python process_results.py test-stability clean
        python process_results.py test-stability run -n test_vrf_watercooled_rb --os_cli=/media/Data/Software/Others/OS-build-develop/Products/openstudio
        # Check that they all passed
        python process_results.py test-status --tagged
        => OK: No Failing tests were found
        # Check site kBTU differences
        python process_results.py heatmap --tagged
        => OK: There are NO differences at all
        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed: N/A
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] add `PendingOSM` if needed

