### PR TITLE
Add test for performance precision tradeoff

### DIFF
--- a/model/simulationtests/performanceprecisiontradeoffs.rb
+++ b/model/simulationtests/performanceprecisiontradeoffs.rb
@@ -1,0 +1,44 @@
+require 'openstudio'
+require 'lib/baseline_model'
+
+m = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone core/perimeter building
+m.add_geometry({"length" => 100,
+                "width" => 50,
+                "num_floors" => 1,
+                "floor_to_floor_height" => 4,
+                "plenum_height" => 1,
+                "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+m.add_windows({"wwr" => 0.4,
+               "offset" => 1,
+               "application_type" => "Above Floor"})
+
+#add thermostats
+m.add_thermostats({"heating_setpoint" => 24,
+                   "cooling_setpoint" => 28})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+m.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+m.set_space_type()
+
+#add design days to the model (Chicago)
+m.add_design_days()
+
+#add ASHRAE System type 03, PSZ-AC
+m.add_hvac({"ashrae_sys_num" => '03'})
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names (only one here anyways...)
+# zones = m.getThermalZones.sort_by{|z| z.name.to_s}
+
+p = m.getPerformancePrecisionTradeoffs
+p.setUseCoilDirectSolutions(true)
+
+#save the OpenStudio model (.osm)
+m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                       "osm_name" => "in.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1546,6 +1546,16 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('multiple_loops_w_plenums.osm')
   end
 
+  def test_performanceprecisiontradeoffs_rb
+    result = sim_test('performanceprecisiontradeoffs.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object's latest changes is out : 2.9.0
+  # def test_performanceprecisiontradeoffs_osm
+  #   result = sim_test('performanceprecisiontradeoffs.osm')
+  # end
+
   def test_photovoltaics_rb
     result = sim_test('photovoltaics.rb')
   end
@@ -1673,19 +1683,19 @@ class ModelTests < MiniTest::Unit::TestCase
     # this folder
     result = sim_test('schedule_file.osm')
   end
-  
+
   def test_schedule_fixed_interval_rb
     result = sim_test('schedule_fixed_interval.rb')
   end
-  
+
   def test_schedule_fixed_interval_osm
     result = sim_test('schedule_fixed_interval.osm')
   end
-  
+
   def test_schedule_fixed_interval_2_rb
     result = sim_test('schedule_fixed_interval_2.rb')
   end
-  
+
   def test_schedule_fixed_interval_2_osm
     result = sim_test('schedule_fixed_interval_2.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

Link to relevant GitHub Issue(s) if appropriate:

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

This pull request is in relation with the Pull Request https://github.com/NREL/OpenStudio/pull/3631, and  will specifically test for the following classes:
* [PerformancePrecisionTradeoffs](https://github.com/NREL/OpenStudio/blob/3d6d9fd89df35804f378bba0d99d271a89a73dae/openstudiocore/src/model/PerformancePrecisionTradeoffs.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): 2e0f8625d3764f417bea2a18be9c98f19eaf8009
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        $ python process_results.py test-stability clean
        $ python process_results.py test-stability run -n performanceprecision --os_cli=$os_build/Products/openstudio
        # Check that they all passed
        $ python process_results.py test-status --tagged
        OK: No Failing tests were found

        # Check site kBTU differences
        $ python process_results.py heatmap --tagged
        OK: There are NO differences at all
        ```


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` if needed

