### PR TITLE
Test for new Fields in AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass

### DIFF
--- a/model/simulationtests/unitary_vav_bypass_plenum.rb
+++ b/model/simulationtests/unitary_vav_bypass_plenum.rb
@@ -6,20 +6,20 @@ m = BaselineModel.new
 
 #make a 2 story, 100m X 50m, 2 zone core/perimeter building
 m.add_geometry({"length" => 100,
-                    "width" => 50,
-                    "num_floors" => 2,
-                    "floor_to_floor_height" => 4,
-                    "plenum_height" => 1,
-                    "perimeter_zone_depth" => 0})
+                "width" => 50,
+                "num_floors" => 2,
+                "floor_to_floor_height" => 4,
+                "plenum_height" => 1,
+                "perimeter_zone_depth" => 0})
 
 #add windows at a 40% window-to-wall ratio
 m.add_windows({"wwr" => 0.4,
-                   "offset" => 1,
-                   "application_type" => "Above Floor"})
+               "offset" => 1,
+               "application_type" => "Above Floor"})
 
 #add thermostats
 m.add_thermostats({"heating_setpoint" => 24,
-                       "cooling_setpoint" => 28})
+                   "cooling_setpoint" => 28})
 
 #assign constructions from a local library to the walls/windows/etc. in the model
 m.set_constructions()
@@ -74,6 +74,8 @@ unitary.addToNode(a.supplyOutletNode)
 
 unitary.setPlenumorMixer(return_plenum)
 
+unitary.setMinimumRuntimeBeforeOperatingModeChange(0.25)
+
 #save the OpenStudio model (.osm)
-model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
-                           "osm_name" => "in.osm"})
+m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                       "osm_name" => "in.osm"})

--- a/model/simulationtests/unitary_vav_bypass_plenum.rb
+++ b/model/simulationtests/unitary_vav_bypass_plenum.rb
@@ -1,0 +1,79 @@
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+m = BaselineModel.new
+
+#make a 2 story, 100m X 50m, 2 zone core/perimeter building
+m.add_geometry({"length" => 100,
+                    "width" => 50,
+                    "num_floors" => 2,
+                    "floor_to_floor_height" => 4,
+                    "plenum_height" => 1,
+                    "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+m.add_windows({"wwr" => 0.4,
+                   "offset" => 1,
+                   "application_type" => "Above Floor"})
+
+#add thermostats
+m.add_thermostats({"heating_setpoint" => 24,
+                       "cooling_setpoint" => 28})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+m.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+m.set_space_type()
+
+#add design days to the model (Chicago)
+m.add_design_days()
+
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = m.getThermalZones.sort_by{|z| z.name.to_s}
+
+controlled_zone = zones[0]
+plenum_zone = zones[1]
+plenum_zone.resetThermostatSetpointDualSetpoint
+
+# Make a Unitary for zone 1, set zone 2 as plenum, and connect unitary bypass
+# to that plenum
+a = OpenStudio::Model::AirLoopHVAC.new(m)
+
+reheat_coil = OpenStudio::Model::CoilHeatingGas.new(m)
+terminal = OpenStudio::Model::AirTerminalSingleDuctVAVHeatAndCoolReheat.new(m, reheat_coil)
+a.addBranchForZone(controlled_zone, terminal)
+
+controlled_zone.setReturnPlenum(plenum_zone)
+
+mixer = a.zoneMixer
+# Get the Plenum, ensuring we have the one we want (in this case the model only
+# has one so there's just m.getAirLoopHVACReturnPlenums[0] that would work...)
+return_plenum = a.demandComponents(controlled_zone, mixer).select{|c| c.iddObjectType == "OS:AirLoopHVAC:ReturnPlenum".to_IddObjectType}[0]
+return_plenum = return_plenum.to_AirLoopHVACReturnPlenum.get
+
+fan = OpenStudio::Model::FanConstantVolume.new(m)
+cc = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(m)
+hc = OpenStudio::Model::CoilHeatingGas.new(m)
+unitary = OpenStudio::Model::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.new(m, fan, cc, hc)
+
+
+# Connecting to a Plenum / Mixer is meant to be used with an external Outdoor
+# Air System, setting the internal one to zero
+unitary.setOutdoorAirFlowRateDuringCoolingOperation(0.0)
+unitary.setOutdoorAirFlowRateDuringHeatingOperation(0.0)
+unitary.setOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded(0.0)
+controllerOutdoorAir = OpenStudio::Model::ControllerOutdoorAir.new(m)
+outdoorAirSystem = OpenStudio::Model::AirLoopHVACOutdoorAirSystem.new(m, controllerOutdoorAir)
+
+outdoorAirSystem.addToNode(a.supplyOutletNode)
+unitary.addToNode(a.supplyOutletNode)
+
+unitary.setPlenumorMixer(return_plenum)
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "in.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1780,6 +1780,15 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('unitary_vav_bypass.osm')
   end
 
+  def test_unitary_vav_bypass_plenum_rb
+    result = sim_test('unitary_vav_bypass_plenum.rb')
+  end
+
+  # TODO: add once 2.9.0 is out
+  # def test_unitary_vav_bypass_plenum_osm
+  #   result = sim_test('unitary_vav_bypass_plenum.osm')
+  # end
+
   def test_unitary_systems_airloop_and_zonehvac_rb
     result = sim_test('unitary_systems_airloop_and_zonehvac.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

Link to relevant GitHub Issue(s) if appropriate:

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

This pull request is in relation with the Pull Request https://github.com/NREL/OpenStudio/pull/3672, and adds testing for newly added capabilities in the existing class `AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass` especially the ability to connect the bypass duct to a plenum or mixer inlet node.


#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/3672
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO : To be added once the next official release
            # including this object is out : 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

