### PR TITLE
Wrap ZoneProperty:UserViewFactors:bySurfaceName object

### DIFF
--- a/model/simulationtests/zone_property_user_view_factors_by_surface_name.rb
+++ b/model/simulationtests/zone_property_user_view_factors_by_surface_name.rb
@@ -1,0 +1,89 @@
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+#make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({"length" => 100,
+                    "width" => 50,
+                    "num_floors" => 2,
+                    "floor_to_floor_height" => 4,
+                    "plenum_height" => 1,
+                    "perimeter_zone_depth" => 3})
+                    
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                   "offset" => 1,
+                   "application_type" => "Above Floor"})
+
+#add ASHRAE System type 01, PTAC, Residential
+model.add_hvac({"ashrae_sys_num" => '01'})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 24,
+                       "cooling_setpoint" => 28})
+                       
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# assign user view factors to all surfaces in a single thermal zone
+thermal_zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+thermal_zone = thermal_zones[1] # ensure a perimeter zone
+
+# create the zone property user view factors by surface name object
+zone_property_user_view_factors_by_surface_name = thermal_zone.getZonePropertyUserViewFactorsBySurfaceName
+
+# get all spaces in the zone
+spaces = thermal_zone.spaces.sort_by{|s| s.name.to_s}
+
+# get all surfaces and subsurfaces in the zone
+surfaces = []
+sub_surfaces = []
+spaces.each do |space|
+  space.surfaces.each do |surface|
+    surfaces << surface
+    surface.subSurfaces.each do |sub_surface|
+      sub_surfaces << sub_surface
+    end
+  end
+end
+
+# view factors for surfaces to surfaces
+surfaces = surfaces.uniq.sort_by{|s| s.name.to_s}
+surfaces.each do |surface1|
+  surfaces.each do |surface2|
+    view_factor = 0.0
+    if surface1 != surface2
+      view_factor = 0.25
+    end
+    zone_property_user_view_factors_by_surface_name.addViewFactor(surface1, surface2, view_factor)
+  end
+end
+
+# view factors for subsurfaces to subsurfaces
+sub_surfaces = sub_surfaces.uniq.sort_by{|s| s.name.to_s}
+sub_surfaces.each do |sub_surface1|
+  sub_surfaces.each do |sub_surface2|
+    view_factor = 0.0
+    if sub_surface1 != sub_surface2
+      view_factor = -0.75
+    end
+    zone_property_user_view_factors_by_surface_name.addViewFactor(sub_surface1, sub_surface2, view_factor)
+  end
+end
+
+# view factors for surfaces to subsurfaces
+surfaces.each do |surface|
+  sub_surfaces.each do |sub_surface|
+    zone_property_user_view_factors_by_surface_name.addViewFactor(surface, sub_surface, 0.5)
+  end
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd, "osm_name" => "in.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1895,6 +1895,16 @@ class ModelTests < MiniTest::Unit::TestCase
     result = sim_test('zone_mixing.rb')
   end
 
+  def test_zone_property_user_view_factors_by_surface_name_rb
+    result = sim_test('zone_property_user_view_factors_by_surface_name.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object's latest changes is out : 2.9.0
+  #def test_zone_property_user_view_factors_by_surface_name_osm
+  #  result = sim_test('zone_property_user_view_factors_by_surface_name.osm')
+  #end
+
   def test_afn_single_zone_nv_rb
     result = sim_test('afn_single_zone_nv.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

This adds a functional test for NREL/OpenStudio#3664.

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.

> This pull request is in relation with the Pull Request [NREL/OpenStudio#3671], and will specifically test for the following classes:
> * `ZonePropertyUserViewFactorsBySurfaceName`

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO : To be added once the next official release
            # including this object is out : 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```
----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

