### PR TITLE
Add test for Supplemental heating coil VRF terminal 

### DIFF
--- a/model/simulationtests/vrf_watercooled.rb
+++ b/model/simulationtests/vrf_watercooled.rb
@@ -43,6 +43,11 @@ vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlow.new(model)
 
 zones.each do |z|
   vrf_terminal = OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow.new(model)
+  # Also test the supplemental heat capability that was added in 2.9.0
+  supHC = OpenStudio::Model::CoilHeatingElectric.new(model)
+  vrf_terminal.setSupplementalHeatingCoil(supHC)
+  vrf_terminal.autosizeMaximumSupplyAirTemperaturefromSupplementalHeater()
+  vrf_terminal.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0)
   vrf_terminal.addToThermalZone(z)
   vrf.addTerminal(vrf_terminal)
 end


### PR DESCRIPTION
https://github.com/NREL/OpenStudio/pull/3687

Supplemental Heating capability is added prior to 2.9.0, and so was the ability to watercool, so I'm extending the vrf_watercooled.rb test in https://github.com/NREL/OpenStudio-resources/pull/75 instead of creating a third one.

I'm purposefully not including the review checklist as it is a minor change.