### PR TITLE
Add test for ZoneVentilationWindAndStackArea

### DIFF
--- a/model/simulationtests/zoneventilation_windandstackopenarea.rb
+++ b/model/simulationtests/zoneventilation_windandstackopenarea.rb
@@ -1,0 +1,79 @@
+require 'openstudio'
+require 'lib/baseline_model'
+
+m = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone core/perimeter building
+m.add_geometry({"length" => 100,
+                "width" => 50,
+                "num_floors" => 1,
+                "floor_to_floor_height" => 4,
+                "plenum_height" => 1,
+                "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+m.add_windows({"wwr" => 0.4,
+               "offset" => 1,
+               "application_type" => "Above Floor"})
+
+#add thermostats
+m.add_thermostats({"heating_setpoint" => 24,
+                   "cooling_setpoint" => 28})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+m.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+m.set_space_type()
+
+#add design days to the model (Chicago)
+m.add_design_days()
+
+#add ASHRAE System type 03, PSZ-AC
+m.add_hvac({"ashrae_sys_num" => '03'})
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names (only one here anyways...)
+zones = m.getThermalZones.sort_by{|z| z.name.to_s}
+zone = zones[0]
+
+zv = OpenStudio::Model::ZoneVentilationWindandStackOpenArea.new(m)
+zv.addToThermalZone(zone)
+
+zv.setOpeningArea(10.0)
+zv.setOpeningAreaFractionSchedule(m.alwaysOnDiscreteSchedule)
+zv.setOpeningEffectiveness(0.5)
+zv.setEffectiveAngle(90)
+zv.setHeightDifference(10)
+zv.setDischargeCoefficientforOpening(0.3)
+
+zv.setMinimumIndoorTemperature(10.0)
+minIndoorTempSch = OpenStudio::Model::ScheduleConstant.new(m)
+minIndoorTempSch.setValue(-10.0)
+zv.setMinimumIndoorTemperatureSchedule(minIndoorTempSch)
+
+zv.setMaximumIndoorTemperature(30.0)
+maxIndoorTempSch = OpenStudio::Model::ScheduleConstant.new(m)
+maxIndoorTempSch.setValue(30.0)
+zv.setMaximumIndoorTemperatureSchedule(maxIndoorTempSch)
+
+zv.setDeltaTemperature(3.0)
+deltaTempSch = OpenStudio::Model::ScheduleConstant.new(m)
+deltaTempSch.setValue(3.0)
+zv.setDeltaTemperatureSchedule(deltaTempSch)
+
+zv.setMinimumOutdoorTemperature(10.0)
+minOutdoorTempSch = OpenStudio::Model::ScheduleConstant.new(m)
+minOutdoorTempSch.setValue(-10.0)
+zv.setMinimumOutdoorTemperatureSchedule(minOutdoorTempSch)
+
+zv.setMaximumOutdoorTemperature(-20.0)
+maxOutdoorTempSch = OpenStudio::Model::ScheduleConstant.new(m)
+maxOutdoorTempSch.setValue(20.0)
+zv.setMaximumOutdoorTemperatureSchedule(maxOutdoorTempSch)
+
+zv.setMaximumWindSpeed(15.0)
+
+#save the OpenStudio model (.osm)
+m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                       "osm_name" => "in.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -889,6 +889,16 @@ class ModelTests < Minitest::Test
     result = sim_test('zone_mixing.rb')
   end
 
+  def test_zoneventilation_windandstackopenarea_rb
+    result = sim_test('zoneventilation_windandstackopenarea.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object is out: 3.0.0 (https://github.com/NREL/OpenStudio/pull/3788)
+  #def test_zoneventilation_windandstackopenarea_osm
+  #  result = sim_test('zoneventilation_windandstackopenarea.osm')
+  #end
+
   def test_zone_property_user_view_factors_by_surface_name_rb
     result = sim_test('zone_property_user_view_factors_by_surface_name.rb')
   end


### PR DESCRIPTION
Supersedes #87 following the big merge

Pull request overview
---------------------

Add test for `ZoneVentilationWindAndStackArea`

Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/pull/3788

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

This pull request is in relation with the Pull Request https://github.com/NREL/OpenStudio/pull/3788, and  will specifically test for the following classes:

* `ZoneVentilationWindAndStackArea`

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current **develop3** (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        python process_results.py test-stability clean
        python process_results.py test-stability run -n test_zoneventilation_windandstackopenarea_rb --os_cli=$os_build/Products/openstudio

        python process_results.py test-status --tagged
        # => OK: No Failing tests were found

        python process_results.py heatmap --tagged
        # => OK: There are NO differences at all
        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

