### PR TITLE
#94 - Add test for OutputDiagnostics, OutputDebuggingData, OutputJSON, and OutputTableSummaryReports

### DIFF
--- a/model/simulationtests/output_objects.rb
+++ b/model/simulationtests/output_objects.rb
@@ -1,0 +1,103 @@
+# This test aims to test the new **Unique** ModelObjects related to Output
+# added in 3.0.0:
+# * OutputDiagnostics,
+# * OutputDebuggingData,
+# * OutputJSON, and
+# * OutputTableSummaryReports
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+
+model = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({"length" => 100,
+                    "width" => 50,
+                    "num_floors" => 1,
+                    "floor_to_floor_height" => 4,
+                    "plenum_height" => 0,
+                    "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                  "offset" => 1,
+                  "application_type" => "Above Floor"})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 19,
+                       "cooling_setpoint" => 26})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+###############################################################################
+#                             OUTPUT:DIAGNOSTICS                              #
+###############################################################################
+
+output_diagnostics = model.getOutputDiagnostics
+# Helper to add the most common report: "DisplayExtraWarnings"
+output_diagnostics.enableDisplayExtraWarnings()
+# To find the possible choices:
+# OpenStudio::Model::OutputDiagnostics::keyValues
+# OpenStudio::Model::OutputDiagnostics::validKeyValues
+output_diagnostics.addKey("DisplayAdvancedReportVariables")
+# Or you can directly use a list (it calls clearKeys() before setting the new
+# keys)
+# NOTE: until https://github.com/NREL/EnergyPlus/issues/7742 is addressed
+# You can only add maximum TWO diagnostics
+output_diagnostics.setKeys(["DisplayExtraWarnings",
+                            "ReportDuringWarmup",
+#                            "DisplayAdvancedReportVariables"
+                            ])
+
+###############################################################################
+#                                 OUTPUT:JSON                                 #
+###############################################################################
+
+output_json = model.getOutputJSON
+# OpenStudio::Model::OutputJSON::optionTypeValues
+output_json.setOptionType("TimeSeriesAndTabular")
+output_json.setOutputJSON(true)
+output_json.setOutputCBOR(false)
+output_json.setOutputMessagePack(false)
+
+###############################################################################
+#                            OUTPUT:DEBUGGINGDATA                             #
+###############################################################################
+
+output_debugging = model.getOutputDebuggingData
+output_debugging.setReportDebuggingData(true)
+output_debugging.setReportDuringWarmup(true)
+
+###############################################################################
+#                         OUTPUT:TABLE:SUMMARYREPORTS                         #
+###############################################################################
+
+output_table = model.getOutputTableSummaryReports
+# OpenStudio::Model::OutputTableSummaryReports::reportNameValues
+# Convenience to add the most common (and default if you don't manually
+# instantiate the OutputTableSummaryReports manually): "AllSummary"
+output_table.enableAllSummaryReport()
+output_table.addSummaryReport("AdaptiveComfortSummary")
+output_table.addSummaryReports(["OutdoorAirSummary", "ObjectCountSummary"])
+# output_table.getSummaryReport(1).get == "AdaptiveComfortSummary"
+# output_table.summaryReportIndex("AdaptiveComfortSummary").get == 1
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "out.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -508,6 +508,16 @@ class ModelTests < Minitest::Test
     result = sim_test('multiple_loops_w_plenums.osm')
   end
 
+  def test_output_objects_rb
+    result = sim_test('output_objects.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object is out : 3.0.0
+  # def test_output_objects_osm
+  #   result = sim_test('output_objects.osm')
+  # end
+
   def test_performanceprecisiontradeoffs_rb
     result = sim_test('performanceprecisiontradeoffs.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

Link to relevant GitHub Issue(s) if appropriate:
* Fix #94
* NREL/OpenStudio#3875
* NREL/OpenStudio#3882

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
 * NREL/OpenStudio#3875: 
    * https://github.com/NREL/OpenStudio/blob/92c9f11baf755c907e5b4c07df367f4dc9dcbbef/src/model/OutputJSON.hpp#L46
    * https://github.com/NREL/OpenStudio/blob/92c9f11baf755c907e5b4c07df367f4dc9dcbbef/src/model/OutputDebuggingData.hpp#L46
    * https://github.com/NREL/OpenStudio/blob/92c9f11baf755c907e5b4c07df367f4dc9dcbbef/src/model/OutputDiagnostics.hpp#L46
* NREL/OpenStudio#3882: OutputTableSummaryReports

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): NREL/OpenStudio#3882
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO: https://github.com/NREL/OpenStudio-resources/pull/96/files#diff-536a4c547820b9578f15e5f1fda2844dR515-R519
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
         $ python process_results.py test-stability clean
         $ python process_results.py test-stability run -n test_output_objects_rb --os_cli=$os_build/Products/openstudio
         $ python process_results.py test-status --tagged
         OK: No Failing tests were found

          $ python process_results.py heatmap --tagged
          OK: There are NO differences at all
        ```
----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` if needed

