### PR TITLE
#3847 - Chiller:Electric:EIR node API refactor, ChillerAbsorption/ChillerAbsorption tertiary node refactor

### DIFF
--- a/model/simulationtests/chillers_tertiary.rb
+++ b/model/simulationtests/chillers_tertiary.rb
@@ -1,0 +1,76 @@
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({"length" => 100,
+                    "width" => 50,
+                    "num_floors" => 1,
+                    "floor_to_floor_height" => 4,
+                    "plenum_height" => 0,
+                    "perimeter_zone_depth" => 0});
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                  "offset" => 1,
+                  "application_type" => "Above Floor"});
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 19,
+                       "cooling_setpoint" => 26});
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions();
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type();
+
+#add design days to the model (Chicago)
+model.add_design_days();
+
+#add ASHRAE System type 07, VAV w/ Reheat
+model.add_hvac({"ashrae_sys_num" => '07'});
+
+# In order to produce more consistent results between different runs,
+# We ensure we do get the same object each time
+cts = model.getCoolingTowerSingleSpeeds.sort_by{|c| c.name.to_s}
+chillers = model.getChillerElectricEIRs.sort_by{|c| c.name.to_s}
+boilers = model.getBoilerHotWaters.sort_by{|c| c.name.to_s}
+condenser_loop = cts.first.plantLoop.get
+cooling_loop = chillers.first.plantLoop.get
+heating_loop = boilers.first.plantLoop.get
+condenser_loop.setName("CndW Loop")
+heating_loop.setName("HW Loop")
+cooling_loop.setName("ChW Loop")
+
+# ChillerAbsorptionIndirect
+chiller_abs_indirect = OpenStudio::Model::ChillerAbsorptionIndirect.new(model)
+chiller_abs_indirect.setName("Chiller AbsInd")
+cooling_loop.addSupplyBranchForComponent(chiller_abs_indirect)
+condenser_loop.addDemandBranchForComponent(chiller_abs_indirect)
+# Since the Primary loop is already connected (ChW loop) and this is a node on
+# on the supply side of a **different** loop than the primary loop, this will
+# call chiller_abs_indirect.addToTertiaryNode
+heating_loop.addSupplyBranchForComponent(chiller_abs_indirect)
+
+# ChillerElectricEIR: Sys 07 so already water-cooled
+chiller_eir = chillers.first
+chiller_eir.setName("Chiller EIR")
+heating_loop.addSupplyBranchForComponent(chiller_eir)
+
+
+# ChillerAbsorption
+chiller_absorption = OpenStudio::Model::ChillerAbsorption.new(model)
+chiller_absorption.setName("Chiller Abs")
+cooling_loop.addSupplyBranchForComponent(chiller_absorption)
+condenser_loop.addDemandBranchForComponent(chiller_absorption)
+# Connect Generator Inlet/Outlet Nodes
+heating_loop.addSupplyBranchForComponent(chiller_absorption)
+
+model.rename_loop_nodes()
+model.renames_air_nodes()
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "in.osm"})

--- a/model/simulationtests/chillers_tertiary.rb
+++ b/model/simulationtests/chillers_tertiary.rb
@@ -53,6 +53,7 @@ condenser_loop.addDemandBranchForComponent(chiller_abs_indirect)
 # and this is a node on the **demand** side of a **different** loop than the
 # condenser loop, this will call `chiller_abs_indirect.addToTertiaryNode`
 heating_loop.addDemandBranchForComponent(chiller_abs_indirect)
+chiller_abs_indirect.setCondenserInletTemperatureLowerLimit(0.01)
 
 # ChillerAbsorption: on the DEMAND side of a Tertiary Loop (HW/Steam)
 chiller_absorption = OpenStudio::Model::ChillerAbsorption.new(model)

--- a/model/simulationtests/chillers_tertiary.rb
+++ b/model/simulationtests/chillers_tertiary.rb
@@ -44,29 +44,31 @@ condenser_loop.setName("CndW Loop")
 heating_loop.setName("HW Loop")
 cooling_loop.setName("ChW Loop")
 
-# ChillerAbsorptionIndirect
+# ChillerAbsorptionIndirect: on the DEMAND side of a Tertiary Loop (HW/Steam)
 chiller_abs_indirect = OpenStudio::Model::ChillerAbsorptionIndirect.new(model)
 chiller_abs_indirect.setName("Chiller AbsInd")
 cooling_loop.addSupplyBranchForComponent(chiller_abs_indirect)
 condenser_loop.addDemandBranchForComponent(chiller_abs_indirect)
-# Since the Primary loop is already connected (ChW loop) and this is a node on
-# on the supply side of a **different** loop than the primary loop, this will
-# call chiller_abs_indirect.addToTertiaryNode
-heating_loop.addSupplyBranchForComponent(chiller_abs_indirect)
+# Since the secondary loop is already connected (condenser loop)
+# and this is a node on the **demand** side of a **different** loop than the
+# condenser loop, this will call `chiller_abs_indirect.addToTertiaryNode`
+heating_loop.addDemandBranchForComponent(chiller_abs_indirect)
 
-# ChillerElectricEIR: Sys 07 so already water-cooled
-chiller_eir = chillers.first
-chiller_eir.setName("Chiller EIR")
-heating_loop.addSupplyBranchForComponent(chiller_eir)
-
-
-# ChillerAbsorption
+# ChillerAbsorption: on the DEMAND side of a Tertiary Loop (HW/Steam)
 chiller_absorption = OpenStudio::Model::ChillerAbsorption.new(model)
 chiller_absorption.setName("Chiller Abs")
 cooling_loop.addSupplyBranchForComponent(chiller_absorption)
 condenser_loop.addDemandBranchForComponent(chiller_absorption)
 # Connect Generator Inlet/Outlet Nodes
-heating_loop.addSupplyBranchForComponent(chiller_absorption)
+heating_loop.addDemandBranchForComponent(chiller_absorption)
+
+
+# ChillerElectricEIR: on the DEMAND side of a Tertiary Loop (Heat Recovery)
+# Makes sense: the HR isn't "active" is responding to HR load
+# Sys 07 so already water-cooled
+chiller_eir = chillers.first
+chiller_eir.setName("Chiller EIR")
+heating_loop.addDemandBranchForComponent(chiller_eir)
 
 model.rename_loop_nodes()
 model.renames_air_nodes()

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -184,6 +184,16 @@ class ModelTests < Minitest::Test
     result = sim_test('centralheatpumpsystem.rb')
   end
 
+  def test_chillers_tertiary_rb
+    result = sim_test('chillers_tertiary.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object is out : 3.0.0
+  # def test_chillers_tertiary_osm
+  #   result = sim_test('chillers_tertiary.osm')
+  # end
+
   def test_coilsystem_waterhx_rb
     result = sim_test('coilsystem_waterhx.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Link to relevant GitHub Issue(s) if appropriate: NREL/OpenStudio#3487

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

NREL/OpenStudio#3487 refactors & extends node API for ChillerElectrcEIR, ChillerAbsorption and ChillerAbsorptionIndirect. This tests aims specifically to test for connections to tertiary loops (heat recovery / generator loops)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA): NREL/OpenStudio#3488
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO : To be added once the next official release
            # including this object is out : 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

