### PR TITLE
Addresses #3907, support new object Coil:Cooling:DX and related

### DIFF
--- a/model/simulationtests/coil_cooling_dx.rb
+++ b/model/simulationtests/coil_cooling_dx.rb
@@ -1,0 +1,53 @@
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone core/perimeter building
+model.add_geometry({"length" => 100,
+                "width" => 50,
+                "num_floors" => 1,
+                "floor_to_floor_height" => 4,
+                "plenum_height" => 1,
+                "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+               "offset" => 1,
+               "application_type" => "Above Floor"})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 24,
+                   "cooling_setpoint" => 28})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names (only one here anyways...)
+zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+
+# Use Ideal Air Loads
+zones.each{|z| z.setUseIdealAirLoads(true)}
+
+curve_fit_speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(model)
+curve_fit_speed_2 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(model)
+
+curve_fit_operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(model)
+curve_fit_operating_mode.addSpeed(curve_fit_speed_1)
+curve_fit_operating_mode.addSpeed(curve_fit_speed_2)
+
+curve_fit_performance = OpenStudio::Model::CoilCoolingDXCurveFitPerformance.new(model, curve_fit_operating_mode)
+
+dx = OpenStudio::Model::CoilCoolingDX.new(model, curve_fit_performance)
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "in.osm"})

--- a/model/simulationtests/coil_cooling_dx.rb
+++ b/model/simulationtests/coil_cooling_dx.rb
@@ -67,10 +67,9 @@ end
 constant_biquadratic = curve_biquadratic(m, 1, 0, 0, 0, 0, 0, -100, 100, -100, 100)
 
 # CoilCoolingDXCurveFitSpeed
+# speeds correspond to a variable speed central air conditioner
 speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-# speed_1.setGrossTotalCoolingCapacityFraction(4015.05615933448 / 4015.05615933448)
-# speed_1.setEvaporatorAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
-# speed_1.setCondenserAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
+speed_1.setGrossTotalCoolingCapacityFraction(4015.05615933448 / 4015.05615933448)
 speed_1.setGrossSensibleHeatRatio(0.842150793933333)
 speed_1.setGrossCoolingCOP(5.48021287249984)
 
@@ -88,9 +87,7 @@ speed_1.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_1.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_2 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-# speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
-# speed_2.setEvaporatorAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
-# speed_2.setCondenserAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
+speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
 speed_2.setGrossSensibleHeatRatio(0.80758872085)
 speed_2.setGrossCoolingCOP(5.1989191865934)
 
@@ -108,9 +105,7 @@ speed_2.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_2.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_3 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-# speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
-# speed_3.setEvaporatorAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
-# speed_3.setCondenserAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
+speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
 speed_3.setGrossSensibleHeatRatio(0.7039025016)
 speed_3.setGrossCoolingCOP(4.64414572911775)
 
@@ -128,9 +123,7 @@ speed_3.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_3.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_4 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-# speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
-# speed_4.setEvaporatorAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
-# speed_4.setCondenserAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
+speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
 speed_4.setGrossSensibleHeatRatio(0.712483430089655)
 speed_4.setGrossCoolingCOP(4.0695894950265)
 
@@ -149,9 +142,7 @@ speed_4.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 # CoilCoolingDXCurveFitOperatingMode
 operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(m)
-# operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
-# operating_mode.setRatedEvaporatorAirFlowRate(0.241052070735995)
-# operating_mode.setRatedCondenserAirFlowRate(0.241052070735995)
+operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
 operating_mode.setMaximumCyclingRate(3)
 operating_mode.setRatioofInitialMoistureEvaporationRateandSteadyStateLatentCapacity(1.5)
 operating_mode.setLatentCapacityTimeConstant(45)
@@ -185,25 +176,23 @@ air_loop_unitary.setSupplyFan(fan)
 air_loop_unitary.setFanPlacement("BlowThrough")
 air_loop_unitary.setSupplyAirFanOperatingModeSchedule(m.alwaysOffDiscreteSchedule)
 air_loop_unitary.setSupplyAirFlowRateMethodDuringCoolingOperation("SupplyAirFlowRate")
-# air_loop_unitary.setSupplyAirFlowRateDuringCoolingOperation(0.746842648594057)
 air_loop_unitary.setSupplyAirFlowRateMethodDuringHeatingOperation("SupplyAirFlowRate")
 air_loop_unitary.setMaximumSupplyAirTemperature(48.888889)
 air_loop_unitary.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0)
 
 # AirLoopHVAC
 air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
-# air_loop.setDesignSupplyAirFlowRate(0.888742751826928)
 air_supply_inlet_node = air_loop.supplyInletNode
 air_loop_unitary.addToNode(air_supply_inlet_node)
 
-# SimulationControl
-# m.getSimulationControl.setDoZoneSizingCalculation(true)
+# AirTerminalSingleDuctUncontrolled
+diffuser = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(m, m.alwaysOnDiscreteSchedule)
 
-# Zones
-zones.each do |zone|
-  air_loop_unitary.setControllingZoneorThermostatLocation(zone)
-  air_loop.multiAddBranchForZone(zone)
-end
+# Zone
+zone = zones[0]
+air_loop_unitary.setControllingZoneorThermostatLocation(zone)
+air_loop.multiAddBranchForZone(zone, diffuser)
+air_loop.multiAddBranchForZone(zone)
 
 #save the OpenStudio model (.osm)
 m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,

--- a/model/simulationtests/coil_cooling_dx.rb
+++ b/model/simulationtests/coil_cooling_dx.rb
@@ -30,9 +30,6 @@ m.set_space_type()
 #add design days to the model (Chicago)
 m.add_design_days()
 
-#add ASHRAE System type 07, VAV w/ Reheat
-# m.add_hvac({"ashrae_sys_num" => '07'})
-
 # In order to produce more consistent results between different runs,
 # we sort the zones by names
 zones = m.getThermalZones.sort_by{|z| z.name.to_s}

--- a/model/simulationtests/coil_cooling_dx.rb
+++ b/model/simulationtests/coil_cooling_dx.rb
@@ -68,9 +68,9 @@ constant_biquadratic = curve_biquadratic(m, 1, 0, 0, 0, 0, 0, -100, 100, -100, 1
 
 # CoilCoolingDXCurveFitSpeed
 speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-speed_1.setGrossTotalCoolingCapacityFraction(4015.05615933448 / 4015.05615933448)
-speed_1.setEvaporatorAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
-# speed_1.setCondenserAirFlowRateFraction()
+# speed_1.setGrossTotalCoolingCapacityFraction(4015.05615933448 / 4015.05615933448)
+# speed_1.setEvaporatorAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
+# speed_1.setCondenserAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
 speed_1.setGrossSensibleHeatRatio(0.842150793933333)
 speed_1.setGrossCoolingCOP(5.48021287249984)
 
@@ -88,9 +88,9 @@ speed_1.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_1.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_2 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
-speed_2.setEvaporatorAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
-# speed_2.setCondenserAirFlowRateFraction()
+# speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
+# speed_2.setEvaporatorAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
+# speed_2.setCondenserAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
 speed_2.setGrossSensibleHeatRatio(0.80758872085)
 speed_2.setGrossCoolingCOP(5.1989191865934)
 
@@ -108,9 +108,9 @@ speed_2.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_2.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_3 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
-speed_3.setEvaporatorAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
-# speed_3.setCondenserAirFlowRateFraction()
+# speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
+# speed_3.setEvaporatorAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
+# speed_3.setCondenserAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
 speed_3.setGrossSensibleHeatRatio(0.7039025016)
 speed_3.setGrossCoolingCOP(4.64414572911775)
 
@@ -128,9 +128,9 @@ speed_3.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
 speed_3.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 speed_4 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
-speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
-speed_4.setEvaporatorAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
-# speed_4.setCondenserAirFlowRateFraction()
+# speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
+# speed_4.setEvaporatorAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
+# speed_4.setCondenserAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
 speed_4.setGrossSensibleHeatRatio(0.712483430089655)
 speed_4.setGrossCoolingCOP(4.0695894950265)
 
@@ -149,9 +149,9 @@ speed_4.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 # CoilCoolingDXCurveFitOperatingMode
 operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(m)
-operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
-operating_mode.setRatedEvaporatorAirFlowRate(0.241052070735995)
-# operating_mode.setRatedCondenserAirFlowRate()
+# operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
+# operating_mode.setRatedEvaporatorAirFlowRate(0.241052070735995)
+# operating_mode.setRatedCondenserAirFlowRate(0.241052070735995)
 operating_mode.setMaximumCyclingRate(3)
 operating_mode.setRatioofInitialMoistureEvaporationRateandSteadyStateLatentCapacity(1.5)
 operating_mode.setLatentCapacityTimeConstant(45)
@@ -184,15 +184,26 @@ air_loop_unitary.setSupplyAirFlowRateDuringHeatingOperation(0.0)
 air_loop_unitary.setSupplyFan(fan)
 air_loop_unitary.setFanPlacement("BlowThrough")
 air_loop_unitary.setSupplyAirFanOperatingModeSchedule(m.alwaysOffDiscreteSchedule)
+air_loop_unitary.setSupplyAirFlowRateMethodDuringCoolingOperation("SupplyAirFlowRate")
+# air_loop_unitary.setSupplyAirFlowRateDuringCoolingOperation(0.746842648594057)
+air_loop_unitary.setSupplyAirFlowRateMethodDuringHeatingOperation("SupplyAirFlowRate")
 air_loop_unitary.setMaximumSupplyAirTemperature(48.888889)
 air_loop_unitary.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0)
-air_loop_unitary.setControllingZoneorThermostatLocation(zones[0])
 
 # AirLoopHVAC
 air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
+# air_loop.setDesignSupplyAirFlowRate(0.888742751826928)
 air_supply_inlet_node = air_loop.supplyInletNode
 air_loop_unitary.addToNode(air_supply_inlet_node)
-air_loop.multiAddBranchForZone(zones[0])
+
+# SimulationControl
+# m.getSimulationControl.setDoZoneSizingCalculation(true)
+
+# Zones
+zones.each do |zone|
+  air_loop_unitary.setControllingZoneorThermostatLocation(zone)
+  air_loop.multiAddBranchForZone(zone)
+end
 
 #save the OpenStudio model (.osm)
 m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,

--- a/model/simulationtests/coil_cooling_dx.rb
+++ b/model/simulationtests/coil_cooling_dx.rb
@@ -7,7 +7,7 @@ m = BaselineModel.new
 #make a 2 story, 100m X 50m, 10 zone core/perimeter building
 m.add_geometry({"length" => 100,
                 "width" => 50,
-                "num_floors" => 2,
+                "num_floors" => 1,
                 "floor_to_floor_height" => 4,
                 "plenum_height" => 1,
                 "perimeter_zone_depth" => 3})
@@ -31,35 +31,168 @@ m.set_space_type()
 m.add_design_days()
 
 #add ASHRAE System type 07, VAV w/ Reheat
-m.add_hvac({"ashrae_sys_num" => '07'})
+# m.add_hvac({"ashrae_sys_num" => '07'})
 
 # In order to produce more consistent results between different runs,
 # we sort the zones by names
 zones = m.getThermalZones.sort_by{|z| z.name.to_s}
 
+def curve_biquadratic(model, c_1constant, c_2x, c_3xPOW2, c_4y, c_5yPOW2, c_6xTIMESY, minx, maxx, miny, maxy)
+  curve = OpenStudio::Model::CurveBiquadratic.new(model)
+  curve.setCoefficient1Constant(c_1constant)
+  curve.setCoefficient2x(c_2x)
+  curve.setCoefficient3xPOW2(c_3xPOW2)
+  curve.setCoefficient4y(c_4y)
+  curve.setCoefficient5yPOW2(c_5yPOW2)
+  curve.setCoefficient6xTIMESY(c_6xTIMESY)
+  curve.setMinimumValueofx(minx)
+  curve.setMaximumValueofx(maxx)
+  curve.setMinimumValueofy(miny)
+  curve.setMaximumValueofy(maxy)
+  return curve
+end
+
+def curve_quadratic(model, c_1constant, c_2x, c_3xPOW2, minx, maxx, miny, maxy)
+  curve = OpenStudio::Model::CurveQuadratic.new(model)
+  curve.setCoefficient1Constant(c_1constant)
+  curve.setCoefficient2x(c_2x)
+  curve.setCoefficient3xPOW2(c_3xPOW2)
+  curve.setMinimumValueofx(minx)
+  curve.setMaximumValueofx(maxx)
+  curve.setMinimumCurveOutput(miny)
+  curve.setMaximumCurveOutput(maxy)
+  return curve
+end
+
+constant_biquadratic = curve_biquadratic(m, 1, 0, 0, 0, 0, 0, -100, 100, -100, 100)
+
 # CoilCoolingDXCurveFitSpeed
-curve_fit_speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_1.setGrossTotalCoolingCapacityFraction(4015.05615933448 / 4015.05615933448)
+speed_1.setEvaporatorAirFlowRateFraction(0.241052070735995 / 0.241052070735995)
+# speed_1.setCondenserAirFlowRateFraction()
+speed_1.setGrossSensibleHeatRatio(0.842150793933333)
+speed_1.setGrossCoolingCOP(5.48021287249984)
+
+cool_cap_ft = curve_biquadratic(m, 1.790226088881, -0.0772146982404, 0.00299548780452, 0.0026270330994, -6.81238188e-005, -0.00062105857056, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, -0.1450569952, 0.062239559472, -0.00190953288, -0.012608055432, 0.0010591834752, -0.0003311985672, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_1.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_1.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_1.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_1.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_1.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_1.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_2 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
+speed_2.setEvaporatorAirFlowRateFraction(0.397026940035757 / 0.241052070735995)
+# speed_2.setCondenserAirFlowRateFraction()
+speed_2.setGrossSensibleHeatRatio(0.80758872085)
+speed_2.setGrossCoolingCOP(5.1989191865934)
+
+cool_cap_ft = curve_biquadratic(m, 1.189356223401, -0.0251898606522, 0.0018013099626, 0.004151872233, -4.332993588e-005, -0.0006851085138, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, 1.21042990764, -0.076844452176, 0.00151658244, -0.002526115752, 0.0007214803488, -0.0001603816524, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_2.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_2.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_2.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_2.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_2.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_2.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_3 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
+speed_3.setEvaporatorAirFlowRateFraction(0.472651119090187 / 0.241052070735995)
+# speed_3.setCondenserAirFlowRateFraction()
+speed_3.setGrossSensibleHeatRatio(0.7039025016)
+speed_3.setGrossCoolingCOP(4.64414572911775)
+
+cool_cap_ft = curve_biquadratic(m, -0.300216325722, 0.1194562230534, -0.001862843184, 0.000730227277800001, -3.753475524e-005, -0.00043911348696, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, 0.70183064548, -0.049235917464, 0.00126482472, 0.031408426368, 0.0003622673484, -0.0011050729236, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_3.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_3.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_3.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_3.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_3.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_3.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_4 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
+speed_4.setEvaporatorAirFlowRateFraction(0.562454831717322 / 0.241052070735995)
+# speed_4.setCondenserAirFlowRateFraction()
+speed_4.setGrossSensibleHeatRatio(0.712483430089655)
+speed_4.setGrossCoolingCOP(4.0695894950265)
+
+cool_cap_ft = curve_biquadratic(m, 0.962249880784, -0.0039087090378, 0.00132934689648, 0.0016072565382, -8.342352e-008, -0.00065486142576, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, -0.74798782608, 0.099914996016, -0.00272789532, 0.026966547, 0.0002513297808, -0.0006019728516, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_4.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_4.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_4.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_4.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_4.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_4.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
 
 # CoilCoolingDXCurveFitOperatingMode
-curve_fit_operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(m)
-curve_fit_operating_mode.addSpeed(curve_fit_speed_1)
+operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(m)
+operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
+operating_mode.setRatedEvaporatorAirFlowRate(0.241052070735995)
+# operating_mode.setRatedCondenserAirFlowRate()
+operating_mode.setMaximumCyclingRate(3)
+operating_mode.setRatioofInitialMoistureEvaporationRateandSteadyStateLatentCapacity(1.5)
+operating_mode.setLatentCapacityTimeConstant(45)
+operating_mode.setNominalTimeforCondensateRemovaltoBegin(1000)
+
+operating_mode.addSpeed(speed_1)
+operating_mode.addSpeed(speed_2)
+operating_mode.addSpeed(speed_3)
+operating_mode.addSpeed(speed_4)
+operating_mode.setNominalSpeedNumber(1)
 
 # CoilCoolingDXCurveFitPerformance
-curve_fit_performance = OpenStudio::Model::CoilCoolingDXCurveFitPerformance.new(m, curve_fit_operating_mode)
+performance = OpenStudio::Model::CoilCoolingDXCurveFitPerformance.new(m, operating_mode)
 
 # CoilCoolingDX
-coil = OpenStudio::Model::CoilCoolingDX.new(m, curve_fit_performance)
+coil = OpenStudio::Model::CoilCoolingDX.new(m, performance)
+
+# FanOnOff
+fan = OpenStudio::Model::FanOnOff.new(m, m.alwaysOnDiscreteSchedule)
+fan.setFanEfficiency(0.75)
+fan.setPressureRise(476.748000740096)
+fan.setMotorEfficiency(1.0)
+fan.setMotorInAirstreamFraction(1.0)
 
 # AirLoopHVACUnitarySystem
 air_loop_unitary = OpenStudio::Model::AirLoopHVACUnitarySystem.new(m)
+air_loop_unitary.setAvailabilitySchedule(m.alwaysOnDiscreteSchedule)
+air_loop_unitary.setCoolingCoil(coil)
+air_loop_unitary.setSupplyAirFlowRateDuringHeatingOperation(0.0)
+air_loop_unitary.setSupplyFan(fan)
+air_loop_unitary.setFanPlacement("BlowThrough")
+air_loop_unitary.setSupplyAirFanOperatingModeSchedule(m.alwaysOffDiscreteSchedule)
+air_loop_unitary.setMaximumSupplyAirTemperature(48.888889)
+air_loop_unitary.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0)
+air_loop_unitary.setControllingZoneorThermostatLocation(zones[0])
 
 # AirLoopHVAC
 air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
 air_supply_inlet_node = air_loop.supplyInletNode
-
 air_loop_unitary.addToNode(air_supply_inlet_node)
-air_loop_unitary.setCoolingCoil(coil)
-air_loop_unitary.setControllingZoneorThermostatLocation(zones[0])
+air_loop.multiAddBranchForZone(zones[0])
 
 #save the OpenStudio model (.osm)
 m.save_openstudio_osm({"osm_save_directory" => Dir.pwd,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -176,6 +176,16 @@ class ModelTests < Minitest::Test
     result = sim_test('baseline_sys10.rb')
   end
 
+  def test_coil_cooling_dx_rb
+    result = sim_test('coil_cooling_dx.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object is out : 3.0.1?
+  # def test_coil_cooling_dx_osm
+  #   result = sim_test('coil_cooling_dx.osm')
+  # end
+
   def test_centralheatpumpsystem_osm
     result = sim_test('centralheatpumpsystem.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

**Please change this line to a description of the pull request, with useful supporting information.**

Link to relevant GitHub Issue(s) if appropriate:

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class


This pull request is in relation with the Pull Request [NREL/OpenStudio#3987](https://github.com/NREL/OpenStudio/pull/3987), and  will specifically test for the following classes:
* `CoilCoolingDX`
* `CoilCoolingDXCurveFitPerformance`
* `CoilCoolingDXCurveFitOperatingMode`
* `CoilCoolingDXCurveFitSpeed`

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): [NREL/OpenStudio#3987](https://github.com/NREL/OpenStudio/pull/3987)
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version

 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

