### PR TITLE
Fix #4006 - Add SwimmingPool:Indoor to SDK

### DIFF
--- a/model/simulationtests/swimmingpool_indoor.rb
+++ b/model/simulationtests/swimmingpool_indoor.rb
@@ -120,7 +120,7 @@ heating_loop.addDemandBranchForComponent(swimmingPoolIndoor)
 ###
 
 # add output reports
-add_out_vars = true
+add_out_vars = false
 if add_out_vars
 
   freq = 'Detailed'
@@ -131,33 +131,6 @@ if add_out_vars
     outvar.setReportingFrequency(freq)
   end
 
-  vars = ['Indoor Pool Makeup Water Rate',
-   'Indoor Pool Makeup Water Volume',
-   'Indoor Pool Makeup Water Temperature',
-   'Indoor Pool Water Temperature',
-   'Indoor Pool Inlet Water Temperature',
-   'Indoor Pool Inlet Water Mass Flow Rate',
-   'Indoor Pool Miscellaneous Equipment Power',
-   'Indoor Pool Miscellaneous Equipment Energy',
-   'Indoor Pool Water Heating Rate',
-   'Indoor Pool Water Heating Energy',
-   'Indoor Pool Radiant to Convection by Cover',
-   'Indoor Pool People Heat Gain',
-   'Indoor Pool Current Activity Factor',
-   'Indoor Pool Current Cover Factor',
-   'Indoor Pool Saturation Pressure at Pool Temperature',
-   'Indoor Pool Partial Pressure of Water Vapor in Air',
-   'Indoor Pool Current Cover Evaporation Factor',
-   'Indoor Pool Current Cover Convective Factor',
-   'Indoor Pool Current Cover SW Radiation Factor',
-   'Indoor Pool Current Cover LW Radiation Factor',
-   'Indoor Pool Evaporative Heat Loss Rate',
-   'Indoor Pool Evaporative Heat Loss Energy']
-
-  vars.each do |varname|
-    outvar = OpenStudio::Model::OutputVariable.new(varname, model)
-    outvar.setReportingFrequency(freq)
-  end
 end
 
 #save the OpenStudio model (.osm)

--- a/model/simulationtests/swimmingpool_indoor.rb
+++ b/model/simulationtests/swimmingpool_indoor.rb
@@ -116,6 +116,50 @@ swimmingPoolIndoor.setPeopleHeatGainSchedule(poolOccHeatGainSched)
 # Connect the pool to the heating loop
 heating_loop.addDemandBranchForComponent(swimmingPoolIndoor)
 
+
+###
+
+# add output reports
+add_out_vars = true
+if add_out_vars
+
+  freq = 'Detailed'
+
+  # Outputs implemented in the class
+  swimmingPoolIndoor.outputVariableNames.each do |varname|
+    outvar = OpenStudio::Model::OutputVariable.new(varname, model)
+    outvar.setReportingFrequency(freq)
+  end
+
+  vars = ['Indoor Pool Makeup Water Rate',
+   'Indoor Pool Makeup Water Volume',
+   'Indoor Pool Makeup Water Temperature',
+   'Indoor Pool Water Temperature',
+   'Indoor Pool Inlet Water Temperature',
+   'Indoor Pool Inlet Water Mass Flow Rate',
+   'Indoor Pool Miscellaneous Equipment Power',
+   'Indoor Pool Miscellaneous Equipment Energy',
+   'Indoor Pool Heating Rate',
+   'Indoor Pool Heating Energy',
+   'Indoor Pool Radiant to Convection by Cover',
+   'Indoor Pool People Heat Gain',
+   'Indoor Pool Current Activity Factor',
+   'Indoor Pool Current Cover Factor',
+   'Indoor Pool Evaporative Heat Loss Rate',
+   'Indoor Pool Evaporative Heat Loss Energy',
+   'Indoor Pool Saturation Pressure at Pool Temperature',
+   'Indoor Pool Partial Pressure of Water Vapor in Air',
+   'Indoor Pool Current Cover Evaporation Factor',
+   'Indoor Pool Current Cover Convective Factor',
+   'Indoor Pool Current Cover SW Radiation Factor',
+   'Indoor Pool Current Cover LW Radiation Factor']
+
+  vars.each do |varname|
+    outvar = OpenStudio::Model::OutputVariable.new(varname, model)
+    outvar.setReportingFrequency(freq)
+  end
+end
+
 #save the OpenStudio model (.osm)
 model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
                            "osm_name" => "out.osm"})

--- a/model/simulationtests/swimmingpool_indoor.rb
+++ b/model/simulationtests/swimmingpool_indoor.rb
@@ -1,0 +1,121 @@
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 5 zone core/perimeter building
+model.add_geometry({"length" => 100,
+              "width" => 50,
+              "num_floors" => 1,
+              "floor_to_floor_height" => 4,
+              "plenum_height" => 0,
+              "perimeter_zone_depth" => 3})
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                  "offset" => 1,
+                  "application_type" => "Above Floor"})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 19,
+                       "cooling_setpoint" => 26})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# Add ASHRAE System type 07, VAV w/ Reheat, this creates a ChW, a HW loop and a
+# Condenser Loop
+model.add_hvac({"ashrae_sys_num" => '07'})
+
+boilers = model.getBoilerHotWaters.sort_by{|c| c.name.to_s}
+
+heating_loop = boilers.first.plantLoop.get
+
+core_zone = model.getThermalZoneByName("Story 1 Core Thermal Zone").get
+floor_surface = core_zone.spaces[0].surfaces.select{|s| s.surfaceType == 'Floor'}[0]
+
+# Create a SwimmingPoolIndoor. This mimics the 5ZoneSwimmingPool E+ example
+swimmingPoolIndoor = OpenStudio::Model::SwimmingPoolIndoor.new(model, floor_surface)
+
+# Average Depth {m}
+swimmingPoolIndoor.setAverageDepth(1.5)
+
+# Activity Factor Schedule Name
+poolActivitySchedule = OpenStudio::Model::ScheduleRuleset.new(model)
+poolActivitySchedule.setName("PoolActivitySched")
+poolActivityScheduleDay = poolActivitySchedule.defaultDaySchedule()
+poolActivityScheduleDay.addValue(OpenStudio::Time.new(0,6,0,0),0.1)
+poolActivityScheduleDay.addValue(OpenStudio::Time.new(0,20,0,0),0.5)
+poolActivityScheduleDay.addValue(OpenStudio::Time.new(0,24,0,0),0.1)
+swimmingPoolIndoor.setActivityFactorSchedule(poolActivitySchedule)
+
+# Make-up Water Supply Schedule Name
+poolMakeUpWaterSchedule = OpenStudio::Model::ScheduleRuleset.new(model, 16.67)
+poolMakeUpWaterSchedule.setName("MakeUpWaterSched")
+swimmingPoolIndoor.setMakeupWaterSupplySchedule(poolMakeUpWaterSchedule)
+
+# Cover Schedule Name
+poolCoverSchedule = OpenStudio::Model::ScheduleRuleset.new(model)
+poolCoverSchedule.setName("PoolCoverSched")
+poolCoverScheduleDay = poolCoverSchedule.defaultDaySchedule()
+poolCoverScheduleDay.addValue(OpenStudio::Time.new(0,6,0,0),0.5)
+poolCoverScheduleDay.addValue(OpenStudio::Time.new(0,20,0,0),0.0)
+poolCoverScheduleDay.addValue(OpenStudio::Time.new(0,24,0,0),0.5)
+swimmingPoolIndoor.setCoverSchedule(poolCoverSchedule)
+
+# Cover Evaporation Factor
+swimmingPoolIndoor.setCoverEvaporationFactor(0.8)
+
+# Cover Convection Factor
+swimmingPoolIndoor.setCoverConvectionFactor(0.2)
+
+# Cover Short-Wavelength Radiation Factor
+swimmingPoolIndoor.setCoverShortWavelengthRadiationFactor(0.9)
+
+# Cover Long-Wavelength Radiation Factor
+swimmingPoolIndoor.setCoverLongWavelengthRadiationFactor(0.5)
+
+# Pool Heating System Maximum Water Flow Rate {m3/s}
+swimmingPoolIndoor.setPoolHeatingSystemMaximumWaterFlowRate(0.1)
+
+# Pool Miscellaneous Equipment Power {W/(m3/s)}
+swimmingPoolIndoor.setPoolMiscellaneousEquipmentPower(0.6)
+
+# Setpoint Temperature Schedule
+poolSetpointTempSchedule = OpenStudio::Model::ScheduleRuleset.new(model, 27.0)
+poolSetpointTempSchedule.setName("PoolSetpointTempSched")
+swimmingPoolIndoor.setSetpointTemperatureSchedule(poolSetpointTempSchedule)
+
+# Maximum Number of People
+swimmingPoolIndoor.setMaximumNumberofPeople(15.0)
+
+# People Schedule
+poolOccupancySchedule = OpenStudio::Model::ScheduleRuleset.new(model)
+poolOccupancySchedule.setName("PoolOccupancySched")
+poolOccupancyScheduleDay = poolOccupancySchedule.defaultDaySchedule()
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,6,0,0),0.0)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,9,0,0),1.0)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,11,0,0),0.5)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,13,0,0),1.0)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,16,0,0),0.5)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,20,0,0),1.0)
+poolOccupancyScheduleDay.addValue(OpenStudio::Time.new(0,24,0,0),0.0)
+swimmingPoolIndoor.setPeopleSchedule(poolOccupancySchedule)
+
+# People Heat Gain Schedule
+poolOccHeatGainSched = OpenStudio::Model::ScheduleRuleset.new(model, 300.0)
+poolOccHeatGainSched.setName("PoolOccHeatGainSched")
+swimmingPoolIndoor.setPeopleHeatGainSchedule(poolOccHeatGainSched)
+
+# Connect the pool to the heating loop
+heating_loop.addDemandBranchForComponent(swimmingPoolIndoor)
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "out.osm"})

--- a/model/simulationtests/swimmingpool_indoor.rb
+++ b/model/simulationtests/swimmingpool_indoor.rb
@@ -139,20 +139,20 @@ if add_out_vars
    'Indoor Pool Inlet Water Mass Flow Rate',
    'Indoor Pool Miscellaneous Equipment Power',
    'Indoor Pool Miscellaneous Equipment Energy',
-   'Indoor Pool Heating Rate',
-   'Indoor Pool Heating Energy',
+   'Indoor Pool Water Heating Rate',
+   'Indoor Pool Water Heating Energy',
    'Indoor Pool Radiant to Convection by Cover',
    'Indoor Pool People Heat Gain',
    'Indoor Pool Current Activity Factor',
    'Indoor Pool Current Cover Factor',
-   'Indoor Pool Evaporative Heat Loss Rate',
-   'Indoor Pool Evaporative Heat Loss Energy',
    'Indoor Pool Saturation Pressure at Pool Temperature',
    'Indoor Pool Partial Pressure of Water Vapor in Air',
    'Indoor Pool Current Cover Evaporation Factor',
    'Indoor Pool Current Cover Convective Factor',
    'Indoor Pool Current Cover SW Radiation Factor',
-   'Indoor Pool Current Cover LW Radiation Factor']
+   'Indoor Pool Current Cover LW Radiation Factor',
+   'Indoor Pool Evaporative Heat Loss Rate',
+   'Indoor Pool Evaporative Heat Loss Energy']
 
   vars.each do |varname|
     outvar = OpenStudio::Model::OutputVariable.new(varname, model)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -772,6 +772,16 @@ class ModelTests < Minitest::Test
     result = sim_test('surface_properties.rb')
   end
 
+  def test_swimmingpool_indoor_rb
+    result = sim_test('swimmingpool_indoor.rb')
+  end
+
+  # TODO : To be added once the next official release
+  # including this object is out : 3.0.2?
+  # def test_swimmingpool_indoor_osm
+  #   result = sim_test('swimmingpool_indoor.osm')
+  # end
+
   def test_tablemultivariablelookup_rb
     result = sim_test('tablemultivariablelookup.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Add a test for a new object SwimmingPool:Indoor

Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/pull/4009

This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

**Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class


This pull request is in relation with the Pull Request [NREL/OpenStudio#4009](https://github.com/NREL/OpenStudio/pull/4009), and  will specifically test for the following classes:

* `SwimmingPoolIndoor`


#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/4009
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.

        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` if needed

