### PR TITLE
Align PTAC and PTHP coils with EnergyPlus

### DIFF
--- a/model/simulationtests/ptac_othercoils.rb
+++ b/model/simulationtests/ptac_othercoils.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 01, PTAC, Residential
+model.add_hvac({ 'ashrae_sys_num' => '01' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+alwaysOn = model.alwaysOnDiscreteSchedule
+
+[zones[0], zones[1], zones[2]].each_with_index do |zone, i|
+  if i == 0
+    # CoilCoolingDXSingleSpeed
+    htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOffDiscreteSchedule)
+    clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
+    ptac.addToThermalZone(zone)
+  elsif i == 1
+    # CoilCoolingDXVariableSpeed
+    htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOffDiscreteSchedule)
+    clg_coil = OpenStudio::Model::CoilCoolingDXVariableSpeed.new(model)
+    clg_coil_data = OpenStudio::Model::CoilCoolingDXVariableSpeedSpeedData.new(model)
+    clg_coil.addSpeed(clg_coil_data)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
+    ptac.addToThermalZone(zone)
+  elsif i == 2
+    # CoilSystemCoolingDXHeatExchangerAssisted
+    htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOffDiscreteSchedule)
+    clg_coil = OpenStudio::Model::CoilSystemCoolingDXHeatExchangerAssisted.new(model)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
+    ptac.addToThermalZone(zone)
+  end
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/ptac_othercoils.rb
+++ b/model/simulationtests/ptac_othercoils.rb
@@ -45,7 +45,7 @@ alwaysOn = model.alwaysOnDiscreteSchedule
     # CoilCoolingDXSingleSpeed
     htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOffDiscreteSchedule)
     clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
-    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
     ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
     ptac.addToThermalZone(zone)
   elsif i == 1
@@ -54,14 +54,14 @@ alwaysOn = model.alwaysOnDiscreteSchedule
     clg_coil = OpenStudio::Model::CoilCoolingDXVariableSpeed.new(model)
     clg_coil_data = OpenStudio::Model::CoilCoolingDXVariableSpeedSpeedData.new(model)
     clg_coil.addSpeed(clg_coil_data)
-    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
     ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
     ptac.addToThermalZone(zone)
   elsif i == 2
     # CoilSystemCoolingDXHeatExchangerAssisted
     htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOffDiscreteSchedule)
     clg_coil = OpenStudio::Model::CoilSystemCoolingDXHeatExchangerAssisted.new(model)
-    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
     ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, alwaysOn, fan, htg_coil, clg_coil)
     ptac.addToThermalZone(zone)
   end

--- a/model/simulationtests/ptac_othercoils.rb
+++ b/model/simulationtests/ptac_othercoils.rb
@@ -5,7 +5,7 @@ require_relative 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,

--- a/model/simulationtests/pthp_othercoils.rb
+++ b/model/simulationtests/pthp_othercoils.rb
@@ -47,7 +47,7 @@ alwaysOn = model.alwaysOnDiscreteSchedule
     htg_coil = OpenStudio::Model::CoilHeatingDXSingleSpeed.new(model)
     clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
     supp_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, alwaysOn)
-    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
     pthp = OpenStudio::Model::ZoneHVACPackagedTerminalHeatPump.new(model, alwaysOn, fan, htg_coil, clg_coil, supp_htg_coil)
     pthp.addToThermalZone(zone)
   elsif i == 1

--- a/model/simulationtests/pthp_othercoils.rb
+++ b/model/simulationtests/pthp_othercoils.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 01, PTAC, Residential
+model.add_hvac({ 'ashrae_sys_num' => '01' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+alwaysOn = model.alwaysOnDiscreteSchedule
+
+[zones[0], zones[1], zones[2]].each_with_index do |zone, i|
+  if i == 0
+    # CoilHeatingDXSingleSpeed
+    # CoilCoolingDXSingleSpeed
+    htg_coil = OpenStudio::Model::CoilHeatingDXSingleSpeed.new(model)
+    clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
+    supp_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, alwaysOn)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)    
+    pthp = OpenStudio::Model::ZoneHVACPackagedTerminalHeatPump.new(model, alwaysOn, fan, htg_coil, clg_coil, supp_htg_coil)
+    pthp.addToThermalZone(zone)
+  elsif i == 1
+    # CoilHeatingDXVariableSpeed
+    # CoilCoolingDXVariableSpeed
+    htg_coil = OpenStudio::Model::CoilHeatingDXVariableSpeed.new(model)
+    htg_coil_data = OpenStudio::Model::CoilHeatingDXVariableSpeedSpeedData.new(model)
+    htg_coil.addSpeed(htg_coil_data)
+    clg_coil = OpenStudio::Model::CoilCoolingDXVariableSpeed.new(model)
+    clg_coil_data = OpenStudio::Model::CoilCoolingDXVariableSpeedSpeedData.new(model)
+    clg_coil.addSpeed(clg_coil_data)
+    supp_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, alwaysOn)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
+    pthp = OpenStudio::Model::ZoneHVACPackagedTerminalHeatPump.new(model, alwaysOn, fan, htg_coil, clg_coil, supp_htg_coil)
+    pthp.addToThermalZone(zone)
+  elsif i == 2
+    # CoilHeatingDXSingleSpeed
+    # CoilSystemCoolingDXHeatExchangerAssisted
+    htg_coil = OpenStudio::Model::CoilHeatingDXSingleSpeed.new(model)
+    clg_coil = OpenStudio::Model::CoilSystemCoolingDXHeatExchangerAssisted.new(model)
+    supp_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model, alwaysOn)
+    fan = OpenStudio::Model::FanOnOff.new(model, alwaysOn)
+    pthp = OpenStudio::Model::ZoneHVACPackagedTerminalHeatPump.new(model, alwaysOn, fan, htg_coil, clg_coil, supp_htg_coil)
+    pthp.addToThermalZone(zone)
+  end
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/pthp_othercoils.rb
+++ b/model/simulationtests/pthp_othercoils.rb
@@ -5,7 +5,7 @@ require_relative 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -77,6 +77,24 @@ class ModelTests < Minitest::Test
     result = sim_test('airloop_and_zonehvac.osm')
   end
 
+  def test_ptac_othercoils_rb
+    result = sim_test('ptac_othercoils.rb')
+  end
+
+  # TODO
+  # def test_ptac_othercoils_osm
+    # result = sim_test('ptac_othercoils.osm')
+  # end
+
+  def test_pthp_othercoils_rb
+    result = sim_test('pthp_othercoils.rb')
+  end
+
+  # TODO
+  # def test_pthp_othercoils_osm
+    # result = sim_test('pthp_othercoils.osm')
+  # end
+
   def test_airloop_avms_rb
     result = sim_test('airloop_avms.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -83,7 +83,7 @@ class ModelTests < Minitest::Test
 
   # TODO
   # def test_ptac_othercoils_osm
-    # result = sim_test('ptac_othercoils.osm')
+  # result = sim_test('ptac_othercoils.osm')
   # end
 
   def test_pthp_othercoils_rb
@@ -92,7 +92,7 @@ class ModelTests < Minitest::Test
 
   # TODO
   # def test_pthp_othercoils_osm
-    # result = sim_test('pthp_othercoils.osm')
+  # result = sim_test('pthp_othercoils.osm')
   # end
 
   def test_airloop_avms_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -81,7 +81,7 @@ class ModelTests < Minitest::Test
     result = sim_test('ptac_othercoils.rb')
   end
 
-  # TODO
+  # TODO: To be added in the next official release after: 3.1.0
   # def test_ptac_othercoils_osm
   # result = sim_test('ptac_othercoils.osm')
   # end
@@ -90,7 +90,7 @@ class ModelTests < Minitest::Test
     result = sim_test('pthp_othercoils.rb')
   end
 
-  # TODO
+  # TODO: To be added in the next official release after: 3.1.0
   # def test_pthp_othercoils_osm
   # result = sim_test('pthp_othercoils.osm')
   # end


### PR DESCRIPTION
Pull request overview
---------------------

Tests for: https://github.com/NREL/OpenStudio/pull/4123

<!---  **Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`. -->

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-3.1.1-alpha%2Bae47a41ab6-Linux.deb


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
