### PR TITLE
Addresses #1972, add Humidifier:Steam:Gas

### DIFF
--- a/model/simulationtests/humidity_control_2.rb
+++ b/model/simulationtests/humidity_control_2.rb
@@ -5,10 +5,10 @@ require 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 10 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
-                     'num_floors' => 2,
+                     'num_floors' => 1,
                      'floor_to_floor_height' => 4,
                      'plenum_height' => 1,
                      'perimeter_zone_depth' => 3 })

--- a/model/simulationtests/humidity_control_2.rb
+++ b/model/simulationtests/humidity_control_2.rb
@@ -42,7 +42,6 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 # Try out all 3 different types of humidity setpoint managers
 # on three different airloops in the same model.
 3.times do |i|
-
   zone = zones[i]
 
   # Add a humidistat at 50% RH to the zone
@@ -82,7 +81,6 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
     spm = OpenStudio::Model::SetpointManagerMultiZoneMinimumHumidityAverage.new(model)
     spm.addToNode(humidifier_outlet_node)
   end
-
 end
 
 # add output reports

--- a/model/simulationtests/humidity_control_2.rb
+++ b/model/simulationtests/humidity_control_2.rb
@@ -18,6 +18,15 @@ model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
 # add ASHRAE System type 03, PSZ-AC
 model.add_hvac({ 'ashrae_sys_num' => '03' })
 
@@ -93,14 +102,6 @@ if add_out_vars
     outputVariable.setReportingFrequency(reporting_frequency)
   end
 end
-# assign constructions from a local library to the walls/windows/etc. in the model
-model.set_constructions
-
-# set whole building space type; simplified 90.1-2004 Large Office Whole Building
-model.set_space_type
-
-# add design days to the model (Chicago)
-model.add_design_days
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/humidity_control_2.rb
+++ b/model/simulationtests/humidity_control_2.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 2,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 03, PSZ-AC
+model.add_hvac({ 'ashrae_sys_num' => '03' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# pick out on of the zone/system pairs and add a humidifier
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+# Try out all 3 different types of humidity setpoint managers
+# on three different airloops in the same model.
+for i in 0..2
+
+  zone = zones[i]
+
+  # Add a humidistat at 50% RH to the zone
+  dehumidify_sch = OpenStudio::Model::ScheduleConstant.new(model)
+  dehumidify_sch.setValue(50)
+  humidistat = OpenStudio::Model::ZoneControlHumidistat.new(model)
+  humidistat.setHumidifyingRelativeHumiditySetpointSchedule(dehumidify_sch)
+  zone.setZoneControlHumidistat(humidistat)
+
+  air_system = zone.airLoopHVAC.get
+  humidifier_outlet_node = nil
+
+  if i == 0
+    # Add a humidifier after the gas heating coil and before the fan
+    htg_coil = air_system.supplyComponents(OpenStudio::Model::CoilHeatingGas.iddObjectType).first.to_CoilHeatingGas.get
+    htg_coil_outlet_node = htg_coil.outletModelObject.get.to_Node.get
+    humidifier = OpenStudio::Model::HumidifierSteamGas.new(model)
+    humidifier.addToNode(htg_coil_outlet_node)
+    humidifier_outlet_node = humidifier.outletModelObject.get.to_Node.get
+  else
+    # Add a humidifier after all other components
+    humidifier = OpenStudio::Model::HumidifierSteamGas.new(model)
+    humidifier.addToNode(air_system.supplyOutletNode)
+    humidifier_outlet_node = humidifier.outletModelObject.get.to_Node.get
+  end
+
+  # Try out all 3 different types of humidity setpoint managers
+  # by adding them to the humidifier outlet node.
+  case i
+  when 0
+    spm = OpenStudio::Model::SetpointManagerSingleZoneHumidityMinimum.new(model)
+    spm.addToNode(humidifier_outlet_node)
+  when 1
+    spm = OpenStudio::Model::SetpointManagerMultiZoneHumidityMinimum.new(model)
+    spm.addToNode(humidifier_outlet_node)
+  when 2
+    spm = OpenStudio::Model::SetpointManagerMultiZoneMinimumHumidityAverage.new(model)
+    spm.addToNode(humidifier_outlet_node)
+  end
+
+end
+
+# add output reports
+add_out_vars = false
+if add_out_vars
+  # Request timeseries data for debugging
+  reporting_frequency = 'hourly'
+  var_names << 'System Node Setpoint Temperature'
+  var_names << 'System Node Setpoint Minimum Humidity Ratio'
+  var_names << 'System Node Setpoint Humidity Ratio'
+  var_names << 'Zone Mean Air Humidity Ratio'
+  var_names << 'Zone Mean Air Temperature'
+  var_names << 'Zone Air Relative Humidity'
+  var_names << 'Humidifier Water Volume Flow Rate'
+  var_names.each do |var_name|
+    outputVariable = OpenStudio::Model::OutputVariable.new(var_name, model)
+    outputVariable.setReportingFrequency(reporting_frequency)
+  end
+end
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/humidity_control_2.rb
+++ b/model/simulationtests/humidity_control_2.rb
@@ -41,7 +41,7 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 
 # Try out all 3 different types of humidity setpoint managers
 # on three different airloops in the same model.
-for i in 0..2
+3.times do |i|
 
   zone = zones[i]
 

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -445,6 +445,14 @@ class ModelTests < Minitest::Test
     result = sim_test('humidity_control.osm')
   end
 
+  def test_humidity_control_2_rb
+    result = sim_test('humidity_control_2.rb')
+  end
+
+  # def test_humidity_control_2_osm
+    # result = sim_test('humidity_control_2.osm')
+  # end
+
   def test_ideal_plant_rb
     result = sim_test('ideal_plant.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -450,7 +450,7 @@ class ModelTests < Minitest::Test
   end
 
   # def test_humidity_control_2_osm
-    # result = sim_test('humidity_control_2.osm')
+  # result = sim_test('humidity_control_2.osm')
   # end
 
   def test_ideal_plant_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -449,8 +449,9 @@ class ModelTests < Minitest::Test
     result = sim_test('humidity_control_2.rb')
   end
 
+  # TODO: To be added in the next official release after: 3.1.0
   # def test_humidity_control_2_osm
-  # result = sim_test('humidity_control_2.osm')
+  #   result = sim_test('humidity_control_2.osm')
   # end
 
   def test_ideal_plant_rb


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4155

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
