### PR TITLE
Addresses #2958, add ZoneHVAC:CoolingPanel:RadiantConvective:Water to OpenStudio

### DIFF
--- a/model/simulationtests/zone_hvac_cooling_panel.rb
+++ b/model/simulationtests/zone_hvac_cooling_panel.rb
@@ -5,22 +5,41 @@ require 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 1 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 1 zone building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,
                      'floor_to_floor_height' => 4,
-                     'plenum_height' => 1,
-                     'perimeter_zone_depth' => 3 })
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
 
 # add windows at a 40% window-to-wall ratio
 model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
 # add thermostats
 model.add_thermostats({ 'heating_setpoint' => 24,
                         'cooling_setpoint' => 28 })
+
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+
 
 # Chilled Water Plant
 chw_loop = OpenStudio::Model::PlantLoop.new(model)
@@ -49,6 +68,7 @@ pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
 pri_chw_pump.setMotorEfficiency(0.9)
 pri_chw_pump.setPumpControlType('Intermittent')
 pri_chw_pump.addToNode(chw_loop.supplyInletNode)
+
 # Secondary chilled water pump
 sec_chw_pump = OpenStudio::Model::HeaderedPumpsVariableSpeed.new(model)
 sec_chw_pump.setName('Chilled Water Loop Secondary Pump')
@@ -56,6 +76,7 @@ sec_chw_pump_head_ft_h2o = 45
 sec_chw_pump_head_press_pa = OpenStudio.convert(sec_chw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
 sec_chw_pump.setRatedPumpHead(sec_chw_pump_head_press_pa)
 sec_chw_pump.setMotorEfficiency(0.9)
+
 # Curve makes it perform like variable speed pump
 sec_chw_pump.setFractionofMotorInefficienciestoFluidStream(0)
 sec_chw_pump.setCoefficient1ofthePartLoadPerformanceCurve(0)
@@ -64,6 +85,7 @@ sec_chw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0.4101)
 sec_chw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0.5753)
 sec_chw_pump.setPumpControlType('Intermittent')
 sec_chw_pump.addToNode(chw_loop.demandInletNode)
+
 # Change the chilled water loop to have a two-way common pipes
 chw_loop.setCommonPipeSimulation('CommonPipe')
 
@@ -71,24 +93,12 @@ chw_loop.setCommonPipeSimulation('CommonPipe')
 chiller = OpenStudio::Model::ChillerElectricEIR.new(model)
 chw_loop.addSupplyBranchForComponent(chiller)
 
-# assign constructions from a local library to the walls/windows/etc. in the model
-model.set_constructions
-
-# set whole building space type; simplified 90.1-2004 Large Office Whole Building
-model.set_space_type
-
-# add design days to the model (Chicago)
-model.add_design_days
-
-# assign thermal zones to variables
-story_1_core_thermal_zone = model.getThermalZoneByName('Story 1 Core Thermal Zone').get
-
 # Add ZoneHVACCoolingPanelRadiantConvectiveWater
 zoneHVACCoolingPanelRadiantConvectiveWater = OpenStudio::Model::ZoneHVACCoolingPanelRadiantConvectiveWater.new(model)
 panel_coil = zoneHVACCoolingPanelRadiantConvectiveWater.coolingCoil.to_CoilCoolingWaterPanelRadiant.get
 panel_coil.setCoolingDesignCapacity(600.0)
 chw_loop.addDemandBranchForComponent(panel_coil)
-zoneHVACCoolingPanelRadiantConvectiveWater.addToThermalZone(story_1_core_thermal_zone)
+zoneHVACCoolingPanelRadiantConvectiveWater.addToThermalZone(z)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/zone_hvac_cooling_panel.rb
+++ b/model/simulationtests/zone_hvac_cooling_panel.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 3 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# chilled Water Temp Schedule
+osTime = OpenStudio::Time.new(0, 24, 0, 0)
+# Schedule Ruleset
+chilled_water_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+chilled_water_temp_sch.setName('Chilled_Water_Temperature')
+# Winter Design Day
+chilled_water_temp_schWinter = OpenStudio::Model::ScheduleDay.new(model)
+chilled_water_temp_sch.setWinterDesignDaySchedule(chilled_water_temp_schWinter)
+chilled_water_temp_sch.winterDesignDaySchedule.setName('Chilled_Water_Temperature_Winter_Design_Day')
+chilled_water_temp_sch.winterDesignDaySchedule.addValue(osTime, 6.7)
+# Summer Design Day
+chilled_water_temp_schSummer = OpenStudio::Model::ScheduleDay.new(model)
+chilled_water_temp_sch.setSummerDesignDaySchedule(chilled_water_temp_schSummer)
+chilled_water_temp_sch.summerDesignDaySchedule.setName('Chilled_Water_Temperature_Summer_Design_Day')
+chilled_water_temp_sch.summerDesignDaySchedule.addValue(osTime, 6.7)
+# All other days
+chilled_water_temp_sch.defaultDaySchedule.setName('Chilled_Water_Temperature_Default')
+chilled_water_temp_sch.defaultDaySchedule.addValue(osTime, 6.7)
+
+# Chilled Water Plant
+chilledWaterPlant = OpenStudio::Model::PlantLoop.new(model)
+chilledWaterPlant.setName('Chilled Water Plant')
+chilledWaterSizing = chilledWaterPlant.sizingPlant
+chilledWaterSizing.setLoopType('Cooling')
+chilledWaterSizing.setDesignLoopExitTemperature(7.22)
+chilledWaterSizing.setLoopDesignTemperatureDifference(6.67)
+chilledWaterOutletNode = chilledWaterPlant.supplyOutletNode
+chilledWaterInletNode = chilledWaterPlant.supplyInletNode
+chilledWaterDemandOutletNode = chilledWaterPlant.demandOutletNode
+chilledWaterDemandInletNode = chilledWaterPlant.demandInletNode
+chilledWaterSPM = OpenStudio::Model::SetpointManagerScheduled.new(model, chilled_water_temp_sch)
+chilledWaterSPM.addToNode(chilledWaterOutletNode)
+
+# pump
+chilledWaterPump = OpenStudio::Model::PumpVariableSpeed.new(model)
+chilledWaterPump.addToNode(chilledWaterInletNode)
+
+# district cooling
+district_cooling = OpenStudio::Model::DistrictCooling.new(model)
+chilledWaterPlant.addSupplyBranchForComponent(district_cooling)
+
+chilledWaterDemandBypass = OpenStudio::Model::PipeAdiabatic.new(model)
+chilledWaterPlant.addSupplyBranchForComponent(chilledWaterDemandBypass)
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# assign thermal zones to variables
+story_1_core_thermal_zone = model.getThermalZoneByName('Story 1 Core Thermal Zone').get
+
+# Add ZoneHVACCoolingPanelRadiantConvectiveWater
+zoneHVACCoolingPanelRadiantConvectiveWater = OpenStudio::Model::ZoneHVACCoolingPanelRadiantConvectiveWater.new(model)
+panel_coil = zoneHVACCoolingPanelRadiantConvectiveWater.coolingCoil
+chilledWaterPlant.addDemandBranchForComponent(panel_coil)
+zoneHVACCoolingPanelRadiantConvectiveWater.addToThermalZone(story_1_core_thermal_zone)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/zone_hvac_cooling_panel.rb
+++ b/model/simulationtests/zone_hvac_cooling_panel.rb
@@ -5,7 +5,7 @@ require 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 3 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 10 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,
@@ -22,49 +22,54 @@ model.add_windows({ 'wwr' => 0.4,
 model.add_thermostats({ 'heating_setpoint' => 24,
                         'cooling_setpoint' => 28 })
 
-# chilled Water Temp Schedule
-osTime = OpenStudio::Time.new(0, 24, 0, 0)
-# Schedule Ruleset
-chilled_water_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
-chilled_water_temp_sch.setName('Chilled_Water_Temperature')
-# Winter Design Day
-chilled_water_temp_schWinter = OpenStudio::Model::ScheduleDay.new(model)
-chilled_water_temp_sch.setWinterDesignDaySchedule(chilled_water_temp_schWinter)
-chilled_water_temp_sch.winterDesignDaySchedule.setName('Chilled_Water_Temperature_Winter_Design_Day')
-chilled_water_temp_sch.winterDesignDaySchedule.addValue(osTime, 6.7)
-# Summer Design Day
-chilled_water_temp_schSummer = OpenStudio::Model::ScheduleDay.new(model)
-chilled_water_temp_sch.setSummerDesignDaySchedule(chilled_water_temp_schSummer)
-chilled_water_temp_sch.summerDesignDaySchedule.setName('Chilled_Water_Temperature_Summer_Design_Day')
-chilled_water_temp_sch.summerDesignDaySchedule.addValue(osTime, 6.7)
-# All other days
-chilled_water_temp_sch.defaultDaySchedule.setName('Chilled_Water_Temperature_Default')
-chilled_water_temp_sch.defaultDaySchedule.addValue(osTime, 6.7)
-
 # Chilled Water Plant
-chilledWaterPlant = OpenStudio::Model::PlantLoop.new(model)
-chilledWaterPlant.setName('Chilled Water Plant')
-chilledWaterSizing = chilledWaterPlant.sizingPlant
-chilledWaterSizing.setLoopType('Cooling')
-chilledWaterSizing.setDesignLoopExitTemperature(7.22)
-chilledWaterSizing.setLoopDesignTemperatureDifference(6.67)
-chilledWaterOutletNode = chilledWaterPlant.supplyOutletNode
-chilledWaterInletNode = chilledWaterPlant.supplyInletNode
-chilledWaterDemandOutletNode = chilledWaterPlant.demandOutletNode
-chilledWaterDemandInletNode = chilledWaterPlant.demandInletNode
-chilledWaterSPM = OpenStudio::Model::SetpointManagerScheduled.new(model, chilled_water_temp_sch)
-chilledWaterSPM.addToNode(chilledWaterOutletNode)
+chw_loop = OpenStudio::Model::PlantLoop.new(model)
+chw_loop.setName('Chilled Water Loop')
+chw_loop.setMaximumLoopTemperature(98)
+chw_loop.setMinimumLoopTemperature(1)
+chw_temp_f = 44
+chw_delta_t_r = 10.1 # 10.1F delta-T
+chw_temp_c = OpenStudio.convert(chw_temp_f, 'F', 'C').get
+chw_delta_t_k = OpenStudio.convert(chw_delta_t_r, 'R', 'K').get
+chw_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+chw_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), chw_temp_c)
+chw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(model, chw_temp_sch)
+chw_stpt_manager.addToNode(chw_loop.supplyOutletNode)
+sizing_plant = chw_loop.sizingPlant
+sizing_plant.setLoopType('Cooling')
+sizing_plant.setDesignLoopExitTemperature(chw_temp_c)
+sizing_plant.setLoopDesignTemperatureDifference(chw_delta_t_k)
 
-# pump
-chilledWaterPump = OpenStudio::Model::PumpVariableSpeed.new(model)
-chilledWaterPump.addToNode(chilledWaterInletNode)
+# Primary chilled water pump
+pri_chw_pump = OpenStudio::Model::HeaderedPumpsConstantSpeed.new(model)
+pri_chw_pump.setName('Chilled Water Loop Primary Pump')
+pri_chw_pump_head_ft_h2o = 15
+pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
+pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
+pri_chw_pump.setMotorEfficiency(0.9)
+pri_chw_pump.setPumpControlType('Intermittent')
+pri_chw_pump.addToNode(chw_loop.supplyInletNode)
+# Secondary chilled water pump
+sec_chw_pump = OpenStudio::Model::HeaderedPumpsVariableSpeed.new(model)
+sec_chw_pump.setName('Chilled Water Loop Secondary Pump')
+sec_chw_pump_head_ft_h2o = 45
+sec_chw_pump_head_press_pa = OpenStudio.convert(sec_chw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
+sec_chw_pump.setRatedPumpHead(sec_chw_pump_head_press_pa)
+sec_chw_pump.setMotorEfficiency(0.9)
+# Curve makes it perform like variable speed pump
+sec_chw_pump.setFractionofMotorInefficienciestoFluidStream(0)
+sec_chw_pump.setCoefficient1ofthePartLoadPerformanceCurve(0)
+sec_chw_pump.setCoefficient2ofthePartLoadPerformanceCurve(0.0205)
+sec_chw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0.4101)
+sec_chw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0.5753)
+sec_chw_pump.setPumpControlType('Intermittent')
+sec_chw_pump.addToNode(chw_loop.demandInletNode)
+# Change the chilled water loop to have a two-way common pipes
+chw_loop.setCommonPipeSimulation('CommonPipe')
 
-# district cooling
-district_cooling = OpenStudio::Model::DistrictCooling.new(model)
-chilledWaterPlant.addSupplyBranchForComponent(district_cooling)
-
-chilledWaterDemandBypass = OpenStudio::Model::PipeAdiabatic.new(model)
-chilledWaterPlant.addSupplyBranchForComponent(chilledWaterDemandBypass)
+# Cooling equipment
+chiller = OpenStudio::Model::ChillerElectricEIR.new(model)
+chw_loop.addSupplyBranchForComponent(chiller)
 
 # assign constructions from a local library to the walls/windows/etc. in the model
 model.set_constructions
@@ -80,8 +85,9 @@ story_1_core_thermal_zone = model.getThermalZoneByName('Story 1 Core Thermal Zon
 
 # Add ZoneHVACCoolingPanelRadiantConvectiveWater
 zoneHVACCoolingPanelRadiantConvectiveWater = OpenStudio::Model::ZoneHVACCoolingPanelRadiantConvectiveWater.new(model)
-panel_coil = zoneHVACCoolingPanelRadiantConvectiveWater.coolingCoil
-chilledWaterPlant.addDemandBranchForComponent(panel_coil)
+panel_coil = zoneHVACCoolingPanelRadiantConvectiveWater.coolingCoil.to_CoilCoolingWaterPanelRadiant.get
+panel_coil.setCoolingDesignCapacity(600.0)
+chw_loop.addDemandBranchForComponent(panel_coil)
 zoneHVACCoolingPanelRadiantConvectiveWater.addToThermalZone(story_1_core_thermal_zone)
 
 # save the OpenStudio model (.osm)

--- a/model/simulationtests/zone_hvac_cooling_panel.rb
+++ b/model/simulationtests/zone_hvac_cooling_panel.rb
@@ -18,7 +18,6 @@ model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
-
 # assign constructions from a local library to the walls/windows/etc. in the model
 model.set_constructions
 
@@ -32,14 +31,12 @@ model.add_design_days
 model.add_thermostats({ 'heating_setpoint' => 24,
                         'cooling_setpoint' => 28 })
 
-
 # In order to produce more consistent results between different runs,
 # we sort the zones by names
 # (There's only one here, but just in case this would be copy pasted somewhere
 # else...)
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 z = zones[0]
-
 
 # Chilled Water Plant
 chw_loop = OpenStudio::Model::PlantLoop.new(model)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1010,7 +1010,7 @@ class ModelTests < Minitest::Test
   end
 
   # def test_zone_hvac_cooling_panel_osm
-    # result = sim_test('zone_hvac_cooling_panel.osm')
+  # result = sim_test('zone_hvac_cooling_panel.osm')
   # end
 
   def test_zone_hvac_equipment_list_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1005,6 +1005,14 @@ class ModelTests < Minitest::Test
     result = sim_test('zone_hvac2.osm')
   end
 
+  def test_zone_hvac_cooling_panel_rb
+    result = sim_test('zone_hvac_cooling_panel.rb')
+  end
+
+  # def test_zone_hvac_cooling_panel_osm
+    # result = sim_test('zone_hvac_cooling_panel.osm')
+  # end
+
   def test_zone_hvac_equipment_list_rb
     result = sim_test('zone_hvac_equipment_list.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1036,8 +1036,9 @@ class ModelTests < Minitest::Test
     result = sim_test('zone_hvac_cooling_panel.rb')
   end
 
+  # TODO: To be added in the next official release after: 3.1.0
   # def test_zone_hvac_cooling_panel_osm
-  # result = sim_test('zone_hvac_cooling_panel.osm')
+  #   result = sim_test('zone_hvac_cooling_panel.osm')
   # end
 
   def test_zone_hvac_equipment_list_rb


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4157

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-3.1.1-alpha%2Bae47a41ab6-Linux.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
