### PR TITLE
Add a test for #4175 - ELCD without generators

### DIFF
--- a/model/simulationtests/elcd_no_generators.rb
+++ b/model/simulationtests/elcd_no_generators.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# This test aims to test the new 'Adiabatic Surface Construction Name' field
+# added in the OS:DefaultConstructionSet
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+
+# create the distribution system
+elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
+
+# We set the bussType to DirectCurrentWithInverterDCStorage meaning we need
+# an inverter, a storage converter, and a storage object
+elcd.setElectricalBussType('DirectCurrentWithInverterDCStorage')
+
+
+# create the inverter
+inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
+inverter.setName('Default Eplus PV Inverter LookUpTable')
+inverter.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
+# inverter.setThermalZone
+inverter.setRadiativeFraction(0.25)
+inverter.setRatedMaximumContinuousOutputPower(14000)
+inverter.setNightTareLossPower(200)
+inverter.setNominalVoltageInput(368)
+inverter.setEfficiencyAt10PowerAndNominalVoltage(0.839)
+inverter.setEfficiencyAt20PowerAndNominalVoltage(0.897)
+inverter.setEfficiencyAt30PowerAndNominalVoltage(0.916)
+inverter.setEfficiencyAt50PowerAndNominalVoltage(0.931)
+inverter.setEfficiencyAt75PowerAndNominalVoltage(0.934)
+inverter.setEfficiencyAt100PowerAndNominalVoltage(0.93)
+
+elcd.setInverter(inverter)
+
+# We need a storage object (Battery or Simple)
+# We will model a 200 kWh battery with 100 kW charge/discharge power
+storage = OpenStudio::Model::ElectricLoadCenterStorageSimple.new(model)
+
+z.setName("#{z.name} With Battery")
+storage.setThermalZone(z)
+# Showcase its attribute setters
+storage.setRadiativeFractionforZoneHeatGains(0.1)
+storage.setMaximumStorageCapacity(OpenStudio.convert(200, 'kWh', 'J').get)
+storage.setMaximumPowerforDischarging(100000)
+storage.setMaximumPowerforCharging(100000)
+storage.setNominalEnergeticEfficiencyforCharging(0.8)
+storage.setNominalDischargingEnergeticEfficiency(0.8)
+storage.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
+# Start at half charge
+storage.setInitialStateofCharge(storage.maximumStorageCapacity / 2.0)
+
+# Add it to the ELCD
+elcd.setElectricalStorage(storage)
+
+# We need a storage converter
+storage_conv = OpenStudio::Model::ElectricLoadCenterStorageConverter.new(model)
+storage_conv.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
+storage_conv.setSimpleFixedEfficiency(0.95)
+# 20 W of standby
+storage_conv.setAncillaryPowerConsumedInStandby(20)
+storage_conv.setThermalZone(z)
+storage_conv.setRadiativeFraction(0.25)
+# We used SimpleFixedEfficiency, so neither of these fields are used:
+# storage_conv.setDesignMaximumContinuousInputPower
+# storage_conv.setEfficiencyFunctionofPowerCurve
+
+# Add it to the ELCD
+elcd.setStorageConverter(storage_conv)
+
+# Some parameters for the battery are set on the ELCD, including the min/max
+# State of Charge (SoC). In our case we assume the SoC is bound by 0.04 / 0.96
+# Meaning the lowest the battery can store is 0.04*200=0.8 kWh,
+# max is 0.96*200=192 kWh and the total usable energy is 184 kWh
+elcd.setMinimumStorageStateofChargeFraction(0.04)
+elcd.setMaximumStorageStateofChargeFraction(0.96)
+elcd.setDesignStorageControlChargePower(100000)
+elcd.setDesignStorageControlDischargePower(100000)
+
+# Try to level demand to 250 kW (peak was 326 kW with PV and no storage)
+# Note: there was a bug prior to 2.4.2 that will make this fail on older
+elcd.setStorageOperationScheme('FacilityDemandLeveling')
+elcd.setStorageControlUtilityDemandTarget(250000)
+
+# I had also added a convenience method called validityCheck because this
+# object has many fields that depend on values selected for \choices fields
+# Eg: if I had not set 'AlternatingCurrent' for buss type, the default is
+# 'DirectCurrentWithInverter', elcd.validityCheck would return false and print
+# a message saying the buss type requires and inverter while I didn't set one
+if !elcd.validityCheck
+  raise 'Electric Load Center is not valid'
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'out.osm' })

--- a/model/simulationtests/elcd_no_generators.rb
+++ b/model/simulationtests/elcd_no_generators.rb
@@ -48,7 +48,6 @@ elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
 # an inverter, a storage converter, and a storage object
 elcd.setElectricalBussType('DirectCurrentWithInverterDCStorage')
 
-
 # create the inverter
 inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
 inverter.setName('Default Eplus PV Inverter LookUpTable')

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -289,6 +289,15 @@ class ModelTests < Minitest::Test
     result = sim_test('ducts_and_pipes.osm')
   end
 
+  def test_elcd_no_generators_rb
+    result = sim_test('elcd_no_generators.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_elcd_no_generators_osm
+  #   result = sim_test('elcd_no_generators.osm')
+  # end
+
   def test_electric_equipment_ITE_rb
     result = sim_test('electric_equipment_ITE.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

ref https://github.com/NREL/OpenStudio/pull/4180 @joseph-robertson

<!---  **Note**: You can open a specific PR template directly by appending `?template=xxx` argument with the value `newtest.md`, `testfix.md` or `newtestforexisting.md`. -->

Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/pull/4180

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4180/OpenStudio-3.1.1-alpha%2Ba08a7ee0a9-Linux.deb


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.




----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

`ElectricLoadCenterDistribution` in https://github.com/NREL/OpenStudio/pull/4180 wwas change to allow **not* having any generators which was a limitation that E+ doesn't actually have. This tests ensures that an ELCD with a storage, inverter, and storage converter but no generators actually runs fine in E+.

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions: N/A, it requires > 3.1.0
 - [x] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version): N/A, `PendingOSM` has been added though.

 - [x] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
