### PR TITLE
Addresses #3615, wrap Refrigeration:CompressorRack in OpenStudio

### DIFF
--- a/model/simulationtests/refrigeration_system_2.rb
+++ b/model/simulationtests/refrigeration_system_2.rb
@@ -38,7 +38,7 @@ end
 # make a 2 story, 100m X 50m, 10 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
-                     'num_floors' => 2,
+                     'num_floors' => 1,
                      'floor_to_floor_height' => 4,
                      'plenum_height' => 1,
                      'perimeter_zone_depth' => 3 })
@@ -68,39 +68,15 @@ model.add_design_days
 # we sort the zones by names
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 
-boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
-heating_loop = boilers.first.plantLoop.get
-
 i = 0
-
 zones.each do |z|
-  if i == 2
+  if i == 0
     compressor_rack = OpenStudio::Model::RefrigerationCompressorRack.new(model)
     compressor_rack.addCase(add_case(model, z, defrost_sch))
     compressor_rack.addCase(add_case(model, z, defrost_sch))
     compressor_rack.addWalkin(add_walkin(model, z, defrost_sch))
     compressor_rack.addWalkin(add_walkin(model, z, defrost_sch))
-
-    cooling_tower = model.getCoolingTowerSingleSpeeds.first
-    plant = cooling_tower.plantLoop.get
-    plant.addDemandBranchForComponent(compressor_rack)
-
-    water_tank = OpenStudio::Model::WaterHeaterMixed.new(model)
-    water_tank.setAmbientTemperatureIndicator('ThermalZone')
-    water_tank.setAmbientTemperatureThermalZone(z)
-    heating_loop.addSupplyBranchForComponent(water_tank)
-    # Schedule Ruleset
-    setpointTemperatureSchedule = OpenStudio::Model::ScheduleRuleset.new(model)
-    setpointTemperatureSchedule.setName('Setpoint Temperature Schedule')
-    setpointTemperatureSchedule.defaultDaySchedule.setName('Setpoint Temperature Schedule Default')
-    setpointTemperatureSchedule.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 70)
-
-    desuperheater = OpenStudio::Model::CoilWaterHeatingDesuperheater.new(model, setpointTemperatureSchedule)
-    water_tank.setSetpointTemperatureSchedule(setpointTemperatureSchedule)
-    desuperheater.addToHeatRejectionTarget(water_tank)
-    desuperheater.setHeatingSource(compressor_rack)
   end
-
   i += 1
 end
 

--- a/model/simulationtests/refrigeration_system_2.rb
+++ b/model/simulationtests/refrigeration_system_2.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# Schedule Ruleset
+defrost_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+defrost_sch.setName('Refrigeration Defrost Schedule')
+# All other days
+defrost_sch.defaultDaySchedule.setName('Refrigeration Defrost Schedule Default')
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 4, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 4, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 8, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 8, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 12, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 12, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 16, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 16, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 20, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 20, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0)
+
+def add_case(model, thermal_zone, defrost_sch)
+  ref_case = OpenStudio::Model::RefrigerationCase.new(model, defrost_sch)
+  ref_case.setThermalZone(thermal_zone)
+  return ref_case
+end
+
+def add_walkin(model, thermal_zone, defrost_sch)
+  ref_walkin = OpenStudio::Model::RefrigerationWalkIn.new(model, defrost_sch)
+  zone_boundaries = ref_walkin.zoneBoundaries
+  zone_boundaries[0].setThermalZone(thermal_zone)
+  return ref_walkin
+end
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 2,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 07, VAV w/ Reheat
+model.add_hvac({ 'ashrae_sys_num' => '07' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 20,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
+heating_loop = boilers.first.plantLoop.get
+
+i = 0
+
+zones.each do |z|
+  if i == 2
+    compressor_rack = OpenStudio::Model::RefrigerationCompressorRack.new(model)
+    compressor_rack.addCase(add_case(model, z, defrost_sch))
+    compressor_rack.addCase(add_case(model, z, defrost_sch))
+    compressor_rack.addWalkin(add_walkin(model, z, defrost_sch))
+    compressor_rack.addWalkin(add_walkin(model, z, defrost_sch))
+
+    cooling_tower = model.getCoolingTowerSingleSpeeds.first
+    plant = cooling_tower.plantLoop.get
+    plant.addDemandBranchForComponent(compressor_rack)
+
+    water_tank = OpenStudio::Model::WaterHeaterMixed.new(model)
+    water_tank.setAmbientTemperatureIndicator('ThermalZone')
+    water_tank.setAmbientTemperatureThermalZone(z)
+    heating_loop.addSupplyBranchForComponent(water_tank)
+    # Schedule Ruleset
+    setpointTemperatureSchedule = OpenStudio::Model::ScheduleRuleset.new(model)
+    setpointTemperatureSchedule.setName('Setpoint Temperature Schedule')
+    setpointTemperatureSchedule.defaultDaySchedule.setName('Setpoint Temperature Schedule Default')
+    setpointTemperatureSchedule.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 70)
+
+    desuperheater = OpenStudio::Model::CoilWaterHeatingDesuperheater.new(model, setpointTemperatureSchedule)
+    water_tank.setSetpointTemperatureSchedule(setpointTemperatureSchedule)
+    desuperheater.addToHeatRejectionTarget(water_tank)
+    desuperheater.setHeatingSource(compressor_rack)
+  end
+
+  i += 1
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -689,13 +689,21 @@ class ModelTests < Minitest::Test
     result = sim_test('pv_and_storage_demandleveling.osm')
   end
 
+  def test_refrigeration_system_rb
+    result = sim_test('refrigeration_system.rb')
+  end
+
   def test_refrigeration_system_osm
     result = sim_test('refrigeration_system.osm')
   end
 
-  def test_refrigeration_system_rb
-    result = sim_test('refrigeration_system.rb')
+  def test_refrigeration_system_2_rb
+    result = sim_test('refrigeration_system_2.rb')
   end
+
+  # def test_refrigeration_system__2osm
+    # result = sim_test('refrigeration_system_2.osm')
+  # end
 
   def test_roof_vegetation_rb
     result = sim_test('roof_vegetation.rb')


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4159..

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
