### PR TITLE
Addresses #3992, chiller ReformulatedEIR model

### DIFF
--- a/model/simulationtests/chiller_reformulated.rb
+++ b/model/simulationtests/chiller_reformulated.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+schedule = model.alwaysOnDiscreteSchedule
+
+_chilledWaterSchedule = OpenStudio::Model::ScheduleRuleset.new(model)
+_chilledWaterSchedule.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 6.7)
+
+# Chilled Water Plant
+chilledWaterPlant = OpenStudio::Model::PlantLoop.new(model)
+sizingPlant = chilledWaterPlant.sizingPlant()
+sizingPlant.setLoopType('Cooling')
+sizingPlant.setDesignLoopExitTemperature(7.22)
+sizingPlant.setLoopDesignTemperatureDifference(6.67)
+
+chilledWaterOutletNode = chilledWaterPlant.supplyOutletNode
+chilledWaterInletNode = chilledWaterPlant.supplyInletNode
+chilledWaterDemandOutletNode = chilledWaterPlant.demandOutletNode
+chilledWaterDemandInletNode = chilledWaterPlant.demandInletNode
+
+chiller = OpenStudio::Model::ChillerElectricReformulatedEIR.new(model)
+
+node = chilledWaterPlant.supplySplitter.lastOutletModelObject.get.to_Node.get
+chiller.addToNode(node)
+
+pipe3 = OpenStudio::Model::PipeAdiabatic.new(model)
+chilledWaterPlant.addSupplyBranchForComponent(pipe3)
+
+pipe4 = OpenStudio::Model::PipeAdiabatic.new(model)
+pipe4.addToNode(chilledWaterOutletNode)
+
+chilledWaterSPM = OpenStudio::Model::SetpointManagerScheduled.new(model, _chilledWaterSchedule)
+chilledWaterSPM.addToNode(chilledWaterOutletNode)
+
+chilledWaterBypass = OpenStudio::Model::PipeAdiabatic.new(model)
+chilledWaterDemandInlet = OpenStudio::Model::PipeAdiabatic.new(model)
+chilledWaterDemandOutlet = OpenStudio::Model::PipeAdiabatic.new(model)
+chilledWaterPlant.addDemandBranchForComponent(chilledWaterBypass)
+chilledWaterDemandOutlet.addToNode(chilledWaterDemandOutletNode)
+chilledWaterDemandInlet.addToNode(chilledWaterDemandInletNode)
+
+# Condenser System
+condenserSystem = OpenStudio::Model::PlantLoop.new(model)
+sizingPlant = condenserSystem.sizingPlant()
+sizingPlant.setLoopType('Condenser')
+sizingPlant.setDesignLoopExitTemperature(29.4)
+sizingPlant.setLoopDesignTemperatureDifference(5.6)
+
+# tower = OpenStudio::Model::CoolingTowerSingleSpeed.new(model)
+# condenserSystem.addSupplyBranchForComponent(tower)
+
+distHeating = OpenStudio::Model::DistrictHeating.new(model)
+condenserSystem.addSupplyBranchForComponent(distHeating)
+
+distCooling = OpenStudio::Model::DistrictCooling.new(model)
+condenserSystem.addSupplyBranchForComponent(distCooling)
+
+condenserSupplyOutletNode = condenserSystem.supplyOutletNode
+condenserSupplyInletNode = condenserSystem.supplyInletNode
+condenserDemandOutletNode = condenserSystem.demandOutletNode
+condenserDemandInletNode = condenserSystem.demandInletNode
+
+pump3 = OpenStudio::Model::PumpVariableSpeed.new(model)
+pump3.addToNode(condenserSupplyInletNode)
+
+condenserSystem.addDemandBranchForComponent(chiller) # TODO: comment out?
+
+condenserSupplyBypass = OpenStudio::Model::PipeAdiabatic.new(model)
+condenserSystem.addSupplyBranchForComponent(condenserSupplyBypass)
+
+condenserSupplyOutlet = OpenStudio::Model::PipeAdiabatic.new(model)
+condenserSupplyOutlet.addToNode(condenserSupplyOutletNode)
+
+condenserBypass = OpenStudio::Model::PipeAdiabatic.new(model)
+condenserDemandInlet = OpenStudio::Model::PipeAdiabatic.new(model)
+condenserDemandOutlet = OpenStudio::Model::PipeAdiabatic.new(model)
+condenserSystem.addDemandBranchForComponent(condenserBypass)
+condenserDemandOutlet.addToNode(condenserDemandOutletNode)
+condenserDemandInlet.addToNode(condenserDemandInletNode)
+
+spm = OpenStudio::Model::SetpointManagerFollowOutdoorAirTemperature.new(model)
+spm.addToNode(condenserSupplyOutletNode)
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+airLoop_3 = OpenStudio::Model::AirLoopHVAC.new(model)
+airLoop_3_supplyNode = airLoop_3.supplyOutletNode
+
+unitary_3 = OpenStudio::Model::AirLoopHVACUnitarySystem.new(model)
+fan_3 = OpenStudio::Model::FanConstantVolume.new(model, schedule)
+cooling_coil_3 = OpenStudio::Model::CoilCoolingWaterToAirHeatPumpEquationFit.new(model)
+chilledWaterPlant.addDemandBranchForComponent(cooling_coil_3)
+heating_coil_3 = OpenStudio::Model::CoilHeatingGas.new(model, schedule)
+unitary_3.setControllingZoneorThermostatLocation(zones[2])
+unitary_3.setFanPlacement('BlowThrough')
+unitary_3.setSupplyAirFanOperatingModeSchedule(schedule)
+unitary_3.setSupplyFan(fan_3)
+unitary_3.setCoolingCoil(cooling_coil_3)
+unitary_3.setHeatingCoil(heating_coil_3)
+
+unitary_3.addToNode(airLoop_3_supplyNode)
+
+air_terminal_3 = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(model, schedule)
+airLoop_3.addBranchForZone(zones[2], air_terminal_3)
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/chiller_reformulated.rb
+++ b/model/simulationtests/chiller_reformulated.rb
@@ -35,6 +35,9 @@ chilledWaterInletNode = chilledWaterPlant.supplyInletNode
 chilledWaterDemandOutletNode = chilledWaterPlant.demandOutletNode
 chilledWaterDemandInletNode = chilledWaterPlant.demandInletNode
 
+pump2 = OpenStudio::Model::PumpVariableSpeed.new(model)
+pump2.addToNode(chilledWaterInletNode)
+
 chiller = OpenStudio::Model::ChillerElectricReformulatedEIR.new(model)
 
 node = chilledWaterPlant.supplySplitter.lastOutletModelObject.get.to_Node.get
@@ -63,9 +66,6 @@ sizingPlant.setLoopType('Condenser')
 sizingPlant.setDesignLoopExitTemperature(29.4)
 sizingPlant.setLoopDesignTemperatureDifference(5.6)
 
-# tower = OpenStudio::Model::CoolingTowerSingleSpeed.new(model)
-# condenserSystem.addSupplyBranchForComponent(tower)
-
 distHeating = OpenStudio::Model::DistrictHeating.new(model)
 condenserSystem.addSupplyBranchForComponent(distHeating)
 
@@ -80,7 +80,7 @@ condenserDemandInletNode = condenserSystem.demandInletNode
 pump3 = OpenStudio::Model::PumpVariableSpeed.new(model)
 pump3.addToNode(condenserSupplyInletNode)
 
-condenserSystem.addDemandBranchForComponent(chiller) # TODO: comment out?
+condenserSystem.addDemandBranchForComponent(chiller)
 
 condenserSupplyBypass = OpenStudio::Model::PipeAdiabatic.new(model)
 condenserSystem.addSupplyBranchForComponent(condenserSupplyBypass)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -193,6 +193,14 @@ class ModelTests < Minitest::Test
     result = sim_test('centralheatpumpsystem.rb')
   end
 
+  def test_chiller_reformulated_rb
+    result = sim_test('chiller_reformulated.rb')
+  end
+
+  # def test_chiller_reformulated_osm
+    # result = sim_test('chiller_reformulated.osm')
+  # end
+
   def test_chillers_tertiary_rb
     result = sim_test('chillers_tertiary.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4186.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
