### PR TITLE
Add test for #4184 - Wrap "PhotovoltaicPerformance:Sandia" in OS SDK

### DIFF
--- a/model/simulationtests/photovoltaics_sandia.rb
+++ b/model/simulationtests/photovoltaics_sandia.rb
@@ -78,12 +78,65 @@ inverter.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
 inverter.setRadiativeFraction(0.0)
 inverter.setInverterEfficiency(1.0)
 
+
+# The above CTor has already filled up the data,
+# but demonstrate the API nonetheless
+sandiaPerf = panel.photovoltaicPerformance.to_PhotovoltaicPerformanceSandia.get
+sandiaPerf.setName("Aleo S16 165 [2007 (E)]")
+sandiaPerf = panel.photovoltaicPerformance.to_PhotovoltaicPerformanceSandia.get
+sandiaPerf.setActiveArea(1.378)
+sandiaPerf.setNumberofCellsinSeries(50) # Int
+sandiaPerf.setNumberofCellsinParallel(1) # Int
+sandiaPerf.setShortCircuitCurrent(7.9)
+sandiaPerf.setOpenCircuitVoltage(30.0)
+sandiaPerf.setCurrentatMaximumPowerPoint(7.08)
+sandiaPerf.setVoltageatMaximumPowerPoint(23.3)
+sandiaPerf.setSandiaDatabaseParameteraIsc(0.0008)
+sandiaPerf.setSandiaDatabaseParameteraImp(-0.0003)
+sandiaPerf.setSandiaDatabaseParameterc0(0.99)
+sandiaPerf.setSandiaDatabaseParameterc1(0.01)
+sandiaPerf.setSandiaDatabaseParameterBVoc0(-0.11)
+sandiaPerf.setSandiaDatabaseParametermBVoc(0.0)
+sandiaPerf.setSandiaDatabaseParameterBVmp0(-0.115)
+sandiaPerf.setSandiaDatabaseParametermBVmp(0.0)
+sandiaPerf.setDiodeFactor(1.35)
+sandiaPerf.setSandiaDatabaseParameterc2(-0.12)
+sandiaPerf.setSandiaDatabaseParameterc3(-11.08)
+sandiaPerf.setSandiaDatabaseParametera0(0.924)
+sandiaPerf.setSandiaDatabaseParametera1(0.06749)
+sandiaPerf.setSandiaDatabaseParametera2(-0.012549)
+sandiaPerf.setSandiaDatabaseParametera3(0.0010049)
+sandiaPerf.setSandiaDatabaseParametera4(-2.8797e-05)
+sandiaPerf.setSandiaDatabaseParameterb0(1.0)
+sandiaPerf.setSandiaDatabaseParameterb1(-0.002438)
+sandiaPerf.setSandiaDatabaseParameterb2(0.0003103)
+sandiaPerf.setSandiaDatabaseParameterb3(-1.246e-05)
+sandiaPerf.setSandiaDatabaseParameterb4(2.11e-07)
+sandiaPerf.setSandiaDatabaseParameterb5(-1.36e-09)
+sandiaPerf.setSandiaDatabaseParameterDeltaTc(3.0)
+sandiaPerf.setSandiaDatabaseParameterfd(1.0)
+sandiaPerf.setSandiaDatabaseParametera(-3.56)
+sandiaPerf.setSandiaDatabaseParameterb(-0.075)
+sandiaPerf.setSandiaDatabaseParameterc4(0.995)
+sandiaPerf.setSandiaDatabaseParameterc5(0.005)
+sandiaPerf.setSandiaDatabaseParameterIx0(7.8)
+sandiaPerf.setSandiaDatabaseParameterIxx0(4.92)
+sandiaPerf.setSandiaDatabaseParameterc6(1.15)
+sandiaPerf.setSandiaDatabaseParameterc7(-0.15)
+
+panel.setNumberOfModulesInParallel(3)
+panel.setNumberOfModulesInSeries(6)
+panel.setRatedElectricPowerOutput(20000)
+panel.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
+
 # create the distribution system
 elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
 elcd.setName("PV ELCD")
 elcd.addGenerator(panel)
+elcd.setGeneratorOperationSchemeType('Baseload')
 elcd.setElectricalBussType("DirectCurrentWithInverter")
 elcd.setInverter(inverter)
+elcd.setDemandLimitSchemePurchasedElectricDemandLimit(0.0)
 
 #save the OpenStudio model (.osm)
 model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,

--- a/model/simulationtests/photovoltaics_sandia.rb
+++ b/model/simulationtests/photovoltaics_sandia.rb
@@ -5,51 +5,50 @@ require 'lib/baseline_model'
 
 model = BaselineModel.new
 
-
 model = BaselineModel.new
 
-#make a 1 story, 100m X 50m, 1 zone building
-model.add_geometry({"length" => 100,
-                    "width" => 50,
-                    "num_floors" => 1,
-                    "floor_to_floor_height" => 4,
-                    "plenum_height" => 0,
-                    "perimeter_zone_depth" => 0})
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
 
-#add windows at a 40% window-to-wall ratio
-model.add_windows({"wwr" => 0.4,
-                  "offset" => 1,
-                  "application_type" => "Above Floor"})
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
 
-#add thermostats
-model.add_thermostats({"heating_setpoint" => 19,
-                       "cooling_setpoint" => 26})
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
 
-#assign constructions from a local library to the walls/windows/etc. in the model
-model.set_constructions()
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
 
-#set whole building space type; simplified 90.1-2004 Large Office Whole Building
-model.set_space_type()
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
 
-#add design days to the model (Chicago)
-model.add_design_days()
+# add design days to the model (Chicago)
+model.add_design_days
 
 # In order to produce more consistent results between different runs,
 # we sort the zones by names
 # (There's only one here, but just in case this would be copy pasted somewhere
 # else...)
-zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 z = zones[0]
 z.setUseIdealAirLoads(true)
 
 # make a shading surface
 vertices = OpenStudio::Point3dVector.new
-vertices << OpenStudio::Point3d.new(0,0,0)
-vertices << OpenStudio::Point3d.new(10,0,0)
-vertices << OpenStudio::Point3d.new(10,4,0)
-vertices << OpenStudio::Point3d.new(0,4,0)
-rotation = OpenStudio::createRotation(OpenStudio::Vector3d.new(1,0,0), OpenStudio::degToRad(30))
-vertices = rotation*vertices
+vertices << OpenStudio::Point3d.new(0, 0, 0)
+vertices << OpenStudio::Point3d.new(10, 0, 0)
+vertices << OpenStudio::Point3d.new(10, 4, 0)
+vertices << OpenStudio::Point3d.new(0, 4, 0)
+rotation = OpenStudio.createRotation(OpenStudio::Vector3d.new(1, 0, 0), OpenStudio.degToRad(30))
+vertices = rotation * vertices
 
 group = OpenStudio::Model::ShadingSurfaceGroup.new(model)
 group.setXOrigin(20)
@@ -64,11 +63,11 @@ shade.setShadingSurfaceGroup(group)
 # in the embedded sandia Database
 # panel = OpenStudio::Model::GeneratorPhotovoltaic::sandia(model)
 
-#/// Factory method to creates a GeneratorPhotovoltaic object with PhotovoltaicPerformanceSandia by looking up characteristics in the embedded
-#// Sandia database by its name. Please use the PhotovoltaicPerformanceSandia::sandiaModulePerformanceNames() static method
+# /// Factory method to creates a GeneratorPhotovoltaic object with PhotovoltaicPerformanceSandia by looking up characteristics in the embedded
+# // Sandia database by its name. Please use the PhotovoltaicPerformanceSandia::sandiaModulePerformanceNames() static method
 # / to look up the valid names as it will throw if it cannot find it
-sandiaModulePerformanceName = OpenStudio::Model::PhotovoltaicPerformanceSandia::sandiaModulePerformanceNames.sort.reverse[0]
-panel = OpenStudio::Model::GeneratorPhotovoltaic::fromSandiaDatabase(model, sandiaModulePerformanceName);
+sandiaModulePerformanceName = OpenStudio::Model::PhotovoltaicPerformanceSandia.sandiaModulePerformanceNames.sort.reverse[0]
+panel = OpenStudio::Model::GeneratorPhotovoltaic.fromSandiaDatabase(model, sandiaModulePerformanceName)
 
 panel.setSurface(shade)
 
@@ -78,11 +77,10 @@ inverter.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
 inverter.setRadiativeFraction(0.0)
 inverter.setInverterEfficiency(1.0)
 
-
 # The above CTor has already filled up the data,
 # but demonstrate the API nonetheless
 sandiaPerf = panel.photovoltaicPerformance.to_PhotovoltaicPerformanceSandia.get
-sandiaPerf.setName("Aleo S16 165 [2007 (E)]")
+sandiaPerf.setName('Aleo S16 165 [2007 (E)]')
 sandiaPerf = panel.photovoltaicPerformance.to_PhotovoltaicPerformanceSandia.get
 sandiaPerf.setActiveArea(1.378)
 sandiaPerf.setNumberofCellsinSeries(50) # Int
@@ -131,13 +129,13 @@ panel.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
 
 # create the distribution system
 elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
-elcd.setName("PV ELCD")
+elcd.setName('PV ELCD')
 elcd.addGenerator(panel)
 elcd.setGeneratorOperationSchemeType('Baseload')
-elcd.setElectricalBussType("DirectCurrentWithInverter")
+elcd.setElectricalBussType('DirectCurrentWithInverter')
 elcd.setInverter(inverter)
 elcd.setDemandLimitSchemePurchasedElectricDemandLimit(0.0)
 
-#save the OpenStudio model (.osm)
-model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
-                           "osm_name" => "out.osm"})
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'out.osm' })

--- a/model/simulationtests/photovoltaics_sandia.rb
+++ b/model/simulationtests/photovoltaics_sandia.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+
+model = BaselineModel.new
+
+#make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({"length" => 100,
+                    "width" => 50,
+                    "num_floors" => 1,
+                    "floor_to_floor_height" => 4,
+                    "plenum_height" => 0,
+                    "perimeter_zone_depth" => 0})
+
+#add windows at a 40% window-to-wall ratio
+model.add_windows({"wwr" => 0.4,
+                  "offset" => 1,
+                  "application_type" => "Above Floor"})
+
+#add thermostats
+model.add_thermostats({"heating_setpoint" => 19,
+                       "cooling_setpoint" => 26})
+
+#assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+#set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+#add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by{|z| z.name.to_s}
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+# make a shading surface
+vertices = OpenStudio::Point3dVector.new
+vertices << OpenStudio::Point3d.new(0,0,0)
+vertices << OpenStudio::Point3d.new(10,0,0)
+vertices << OpenStudio::Point3d.new(10,4,0)
+vertices << OpenStudio::Point3d.new(0,4,0)
+rotation = OpenStudio::createRotation(OpenStudio::Vector3d.new(1,0,0), OpenStudio::degToRad(30))
+vertices = rotation*vertices
+
+group = OpenStudio::Model::ShadingSurfaceGroup.new(model)
+group.setXOrigin(20)
+group.setYOrigin(10)
+group.setZOrigin(8)
+
+shade = OpenStudio::Model::ShadingSurface.new(vertices, model)
+shade.setShadingSurfaceGroup(group)
+
+# create the panel
+# This creates a panel with the Sandia parameters for one random (static) entry
+# in the embedded sandia Database
+# panel = OpenStudio::Model::GeneratorPhotovoltaic::sandia(model)
+
+#/// Factory method to creates a GeneratorPhotovoltaic object with PhotovoltaicPerformanceSandia by looking up characteristics in the embedded
+#// Sandia database by its name. Please use the PhotovoltaicPerformanceSandia::sandiaModulePerformanceNames() static method
+# / to look up the valid names as it will throw if it cannot find it
+sandiaModulePerformanceName = OpenStudio::Model::PhotovoltaicPerformanceSandia::sandiaModulePerformanceNames.sort.reverse[0]
+panel = OpenStudio::Model::GeneratorPhotovoltaic::fromSandiaDatabase(model, sandiaModulePerformanceName);
+
+panel.setSurface(shade)
+
+# create the inverter
+inverter = OpenStudio::Model::ElectricLoadCenterInverterSimple.new(model)
+inverter.setAvailabilitySchedule(model.alwaysOnDiscreteSchedule)
+inverter.setRadiativeFraction(0.0)
+inverter.setInverterEfficiency(1.0)
+
+# create the distribution system
+elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
+elcd.setName("PV ELCD")
+elcd.addGenerator(panel)
+elcd.setElectricalBussType("DirectCurrentWithInverter")
+elcd.setInverter(inverter)
+
+#save the OpenStudio model (.osm)
+model.save_openstudio_osm({"osm_save_directory" => Dir.pwd,
+                           "osm_name" => "out.osm"})

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -633,6 +633,15 @@ class ModelTests < Minitest::Test
     result = sim_test('photovoltaics.osm')
   end
 
+  def test_photovoltaics_sandia_rb
+    result = sim_test('photovoltaics_sandia.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_photovoltaics_sandia_osm
+  #   result = sim_test('photovoltaics_sandia.osm')
+  # end
+
   def test_plant_op_schemes_rb
     result = sim_test('plant_op_schemes.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------



Link to relevant GitHub Issue(s) if appropriate: 
* Issue: https://github.com/NREL/OpenStudio/issues/4184
* PR: https://github.com/NREL/OpenStudio/pull/4194

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release. 
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4194/OpenStudio-3.1.1-alpha%2Be35f6b22f8-Linux.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): With PR https://github.com/NREL/OpenStudio/pull/4194
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO: https://github.com/NREL/OpenStudio-resources/blob/1edac5fb2f353f2aa216ba8f8e563e250c829415/model_tests.rb#L636-L643
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        python process_results.py test-stability clean
        python process_results.py test-stability run -n test_photovoltaics_sandia_rb --os_cli=$os_build/Products/openstudio
        
        $ python process_results.py test-status --tagged
        OK: No Failing tests were found

       $ python process_results.py heatmap --tagged
       OK: There are NO differences at all

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
