### PR TITLE
Add test for #4185 - Wrap Fan:ComponentModel in OS SDK

### DIFF
--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -364,7 +364,7 @@ sat_sch = OpenStudio::Model::ScheduleRuleset.new(model)
 sat_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), sat_c)
 sat_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(model, sat_sch)
 sat_stpt_manager.addToNode(out_1)
-fan = OpenStudio::Model::FanVariableVolume.new(model)
+fan = OpenStudio::Model::FanComponentModel.new(model)
 fan.addToNode(in_1)
 oa_controller = OpenStudio::Model::ControllerOutdoorAir.new(model)
 oa_controller.autosizeMinimumOutdoorAirFlowRate # OS has a bad default of zero, which disables autosizing

--- a/model/simulationtests/fan_componentmodel.rb
+++ b/model/simulationtests/fan_componentmodel.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# add ASHRAE System type 07, VAV w/ Reheat
+model.add_hvac({ 'ashrae_sys_num' => '07' })
+
+# In order to produce more consistent results between different runs,
+# We ensure we do get the same object each time
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+airLoops = model.getAirLoopHVACs.sort_by { |a| a.name.to_s }
+regularAirLoopHVAC = airLoops[0]
+
+chillers = model.getChillerElectricEIRs.sort_by { |c| c.name.to_s }
+boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
+
+cooling_loop = chillers.first.plantLoop.get
+heating_loop = boilers.first.plantLoop.get
+
+alwaysOn = model.alwaysOnDiscreteSchedule
+
+
+###############################################################################
+#                       D E M O N S T R A T E    A P I                        #
+###############################################################################
+
+fan = OpenStudio::Model::FanComponentModel.new(model)
+# Demonstrate API
+fan.setName('My FanComponentModel')
+
+# Availability Schedule Name: Required Object
+sch = OpenStudio::Model::ScheduleConstant.new(model)
+sch.setName('Fan Avail Schedule')
+sch.setValue(1.0)
+fan.setAvailabilitySchedule(sch)
+
+
+vSDExample = OpenStudio::Model::CurveFanPressureRise.new(model)
+vSDExample.setName("VSD Example")
+vSDExample.setCoefficient1C1(1446.75833497653)
+vSDExample.setCoefficient2C2(0.0)
+vSDExample.setCoefficient3C3(0.0)
+vSDExample.setCoefficient4C4(1.0)
+vSDExample.setMinimumValueofQfan(0.0)
+vSDExample.setMaximumValueofQfan(100.0)
+vSDExample.setMinimumValueofPsm(62.5)
+vSDExample.setMaximumValueofPsm(300.0)
+vSDExample.setMinimumCurveOutput(0.0)
+vSDExample.setMaximumCurveOutput(5000.0)
+
+diagnosticSPR = OpenStudio::Model::CurveLinear.new(model)
+diagnosticSPR.setName("DiagnosticSPR")
+diagnosticSPR.setCoefficient1Constant(248.84)
+diagnosticSPR.setCoefficient2x(0.0)
+diagnosticSPR.setMinimumValueofx(0.0)
+diagnosticSPR.setMaximumValueofx(100.0)
+diagnosticSPR.setMinimumCurveOutput(62.5)
+diagnosticSPR.setMaximumCurveOutput(248.84)
+# diagnosticSPR.setInputUnitTypeforX("")
+# diagnosticSPR.setOutputUnitType("")
+
+fanEff120CPLANormal = OpenStudio::Model::CurveExponentialSkewNormal.new(model)
+fanEff120CPLANormal.setName("FanEff120CPLANormal")
+fanEff120CPLANormal.setCoefficient1C1(0.072613)
+fanEff120CPLANormal.setCoefficient2C2(0.833213)
+fanEff120CPLANormal.setCoefficient3C3(0.0)
+fanEff120CPLANormal.setCoefficient4C4(0.013911)
+fanEff120CPLANormal.setMinimumValueofx(-4.0)
+fanEff120CPLANormal.setMaximumValueofx(5.0)
+fanEff120CPLANormal.setMinimumCurveOutput(0.1)
+fanEff120CPLANormal.setMaximumCurveOutput(1.0)
+# fanEff120CPLANormal.setInputUnitTypeforx("")
+# fanEff120CPLANormal.setOutputUnitType("")
+
+fanEff120CPLAStall = OpenStudio::Model::CurveExponentialSkewNormal.new(model)
+fanEff120CPLAStall.setName("FanEff120CPLAStall")
+fanEff120CPLAStall.setCoefficient1C1(-1.674931)
+fanEff120CPLAStall.setCoefficient2C2(1.980182)
+fanEff120CPLAStall.setCoefficient3C3(0.0)
+fanEff120CPLAStall.setCoefficient4C4(1.84495)
+fanEff120CPLAStall.setMinimumValueofx(-4.0)
+fanEff120CPLAStall.setMaximumValueofx(5.0)
+fanEff120CPLAStall.setMinimumCurveOutput(0.1)
+fanEff120CPLAStall.setMaximumCurveOutput(1.0)
+# fanEff120CPLAStall.setInputUnitTypeforx("")
+# fanEff120CPLAStall.setOutputUnitType("")
+
+fanDimFlowNormal = OpenStudio::Model::CurveSigmoid.new(model)
+fanDimFlowNormal.setName("FanDimFlowNormal")
+fanDimFlowNormal.setCoefficient1C1(0.0)
+fanDimFlowNormal.setCoefficient2C2(1.001423)
+fanDimFlowNormal.setCoefficient3C3(0.123935)
+fanDimFlowNormal.setCoefficient4C4(-0.476026)
+fanDimFlowNormal.setCoefficient5C5(1.0)
+fanDimFlowNormal.setMinimumValueofx(-4.0)
+fanDimFlowNormal.setMaximumValueofx(5.0)
+fanDimFlowNormal.setMinimumCurveOutput(0.05)
+fanDimFlowNormal.setMaximumCurveOutput(1.0)
+# fanDimFlowNormal.setInputUnitTypeforx("")
+# fanDimFlowNormal.setOutputUnitType("")
+
+fanDimFlowStall = OpenStudio::Model::CurveSigmoid.new(model)
+fanDimFlowStall.setName("FanDimFlowStall")
+fanDimFlowStall.setCoefficient1C1(0.0)
+fanDimFlowStall.setCoefficient2C2(5.924993)
+fanDimFlowStall.setCoefficient3C3(-1.91636)
+fanDimFlowStall.setCoefficient4C4(-0.851779)
+fanDimFlowStall.setCoefficient5C5(1.0)
+fanDimFlowStall.setMinimumValueofx(-4.0)
+fanDimFlowStall.setMaximumValueofx(5.0)
+fanDimFlowStall.setMinimumCurveOutput(0.05)
+fanDimFlowStall.setMaximumCurveOutput(1.0)
+# fanDimFlowStall.setInputUnitTypeforx("")
+# fanDimFlowStall.setOutputUnitType("")
+
+beltMaxEffMedium = OpenStudio::Model::CurveQuartic.new(model)
+beltMaxEffMedium.setName("BeltMaxEffMedium")
+beltMaxEffMedium.setCoefficient1Constant(-0.09504)
+beltMaxEffMedium.setCoefficient2x(0.03415)
+beltMaxEffMedium.setCoefficient3xPOW2(-0.008897)
+beltMaxEffMedium.setCoefficient4xPOW3(0.001159)
+beltMaxEffMedium.setCoefficient5xPOW4(-6.132e-05)
+beltMaxEffMedium.setMinimumValueofx(-1.2)
+beltMaxEffMedium.setMaximumValueofx(6.2)
+beltMaxEffMedium.setMinimumCurveOutput(-4.6)
+beltMaxEffMedium.setMaximumCurveOutput(0.0)
+# beltMaxEffMedium.setInputUnitTypeforX("")
+# beltMaxEffMedium.setOutputUnitType("")
+
+beltPartLoadRegion1 = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
+beltPartLoadRegion1.setName("BeltPartLoadRegion1")
+beltPartLoadRegion1.setCoefficient1C1(0.920797)
+beltPartLoadRegion1.setCoefficient2C2(0.0262686)
+beltPartLoadRegion1.setCoefficient3C3(0.151594)
+beltPartLoadRegion1.setMinimumValueofx(0.0)
+beltPartLoadRegion1.setMaximumValueofx(1.0)
+beltPartLoadRegion1.setMinimumCurveOutput(0.01)
+beltPartLoadRegion1.setMaximumCurveOutput(1.0)
+# beltPartLoadRegion1.setInputUnitTypeforx("")
+# beltPartLoadRegion1.setOutputUnitType("")
+
+beltPartLoadRegion2= OpenStudio::Model::CurveExponentialDecay.new(model)
+beltPartLoadRegion2.setName("BeltPartLoadRegion2")
+beltPartLoadRegion2.setCoefficient1C1(1.011965)
+beltPartLoadRegion2.setCoefficient2C2(-0.339038)
+beltPartLoadRegion2.setCoefficient3C3(-3.43626)
+beltPartLoadRegion2.setMinimumValueofx(0.0)
+beltPartLoadRegion2.setMaximumValueofx(1.0)
+beltPartLoadRegion2.setMinimumCurveOutput(0.01)
+beltPartLoadRegion2.setMaximumCurveOutput(1.0)
+# beltPartLoadRegion2.setInputUnitTypeforx("")
+# beltPartLoadRegion2.setOutputUnitType("")
+
+beltPartLoadRegion3 = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
+beltPartLoadRegion3.setName("BeltPartLoadRegion3")
+beltPartLoadRegion3.setCoefficient1C1(1.037778)
+beltPartLoadRegion3.setCoefficient2C2(0.0103068)
+beltPartLoadRegion3.setCoefficient3C3(-0.0268146)
+beltPartLoadRegion3.setMinimumValueofx(0.0)
+beltPartLoadRegion3.setMaximumValueofx(1.0)
+beltPartLoadRegion3.setMinimumCurveOutput(0.01)
+beltPartLoadRegion3.setMaximumCurveOutput(1.0)
+# beltPartLoadRegion3.setInputUnitTypeforx("")
+# beltPartLoadRegion3.setOutputUnitType("")
+
+motorMaxEffAvg = OpenStudio::Model::CurveRectangularHyperbola1.new(model)
+motorMaxEffAvg.setName("MotorMaxEffAvg")
+motorMaxEffAvg.setCoefficient1C1(0.29228)
+motorMaxEffAvg.setCoefficient2C2(3.368739)
+motorMaxEffAvg.setCoefficient3C3(0.762471)
+motorMaxEffAvg.setMinimumValueofx(0.0)
+motorMaxEffAvg.setMaximumValueofx(7.6)
+motorMaxEffAvg.setMinimumCurveOutput(0.01)
+motorMaxEffAvg.setMaximumCurveOutput(1.0)
+# motorMaxEffAvg.setInputUnitTypeforx("")
+# motorMaxEffAvg.setOutputUnitType("")
+
+motorPartLoad = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
+motorPartLoad.setName("MotorPartLoad")
+motorPartLoad.setCoefficient1C1(1.137209)
+motorPartLoad.setCoefficient2C2(0.0502359)
+motorPartLoad.setCoefficient3C3(-0.0891503)
+motorPartLoad.setMinimumValueofx(0.0)
+motorPartLoad.setMaximumValueofx(1.0)
+motorPartLoad.setMinimumCurveOutput(0.01)
+motorPartLoad.setMaximumCurveOutput(1.0)
+# motorPartLoad.setInputUnitTypeforx("")
+# motorPartLoad.setOutputUnitType("")
+
+vFDPartLoad = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
+vFDPartLoad.setName("VFDPartLoad")
+vFDPartLoad.setCoefficient1C1(0.987405)
+vFDPartLoad.setCoefficient2C2(0.0155361)
+vFDPartLoad.setCoefficient3C3(-0.0059365)
+vFDPartLoad.setMinimumValueofx(0.0)
+vFDPartLoad.setMaximumValueofx(1.0)
+vFDPartLoad.setMinimumCurveOutput(0.01)
+vFDPartLoad.setMaximumCurveOutput(1.0)
+# vFDPartLoad.setInputUnitTypeforx("")
+# vFDPartLoad.setOutputUnitType("")
+
+
+fan.setName("Fan Component Model")
+fan.autosizeMaximumFlowRate()
+fan.autosizeMinimumFlowRate()
+fan.setFanSizingFactor(1.0)
+fan.setFanWheelDiameter(0.3048)
+fan.setFanOutletArea(0.0873288576)
+fan.setMaximumFanStaticEfficiency(0.514)
+fan.setEulerNumberatMaximumFanStaticEfficiency(9.76)
+fan.setMaximumDimensionlessFanAirflow(0.160331811647483)
+fan.autosizeMotorFanPulleyRatio()
+fan.autosizeBeltMaximumTorque()
+fan.setBeltSizingFactor(1.0)
+fan.setBeltFractionalTorqueTransition(0.167)
+fan.setMotorMaximumSpeed(1800.0)
+fan.autosizeMaximumMotorOutputPower()
+fan.setMotorSizingFactor(1.0)
+fan.setMotorInAirstreamFraction(1.0)
+fan.setVFDEfficiencyType("Power")
+fan.autosizeMaximumVFDOutputPower()
+fan.setVFDSizingFactor(1.0)
+fan.setFanPressureRiseCurve(vSDExample)
+fan.setDuctStaticPressureResetCurve(diagnosticSPR)
+fan.setNormalizedFanStaticEfficiencyCurveNonStallRegion(fanEff120CPLANormal)
+fan.setNormalizedFanStaticEfficiencyCurveStallRegion(fanEff120CPLAStall)
+fan.setNormalizedDimensionlessAirflowCurveNonStallRegion(fanDimFlowNormal)
+fan.setNormalizedDimensionlessAirflowCurveStallRegion(fanDimFlowStall)
+fan.setMaximumBeltEfficiencyCurve(beltMaxEffMedium)
+fan.setNormalizedBeltEfficiencyCurveRegion1(beltPartLoadRegion1)
+fan.setNormalizedBeltEfficiencyCurveRegion2(beltPartLoadRegion2)
+fan.setNormalizedBeltEfficiencyCurveRegion3(beltPartLoadRegion3)
+fan.setMaximumMotorEfficiencyCurve(motorMaxEffAvg)
+fan.setNormalizedMotorEfficiencyCurve(motorPartLoad)
+fan.setVFDEfficiencyCurve(vFDPartLoad)
+
+
+
+# Add this fan as the supply fan of a regular AirLoopHVAC, removing the
+# existing FanVariableVolume
+regularAirLoopHVAC.supplyFan.get.remove
+fan.addToNode(regularAirLoopHVAC.supplyOutletNode)
+
+
+# AirLoopHVACUnitarySystem
+unitary_system = OpenStudio::Model::AirLoopHVACUnitarySystem.new(model)
+unitary_system_fan = OpenStudio::Model::FanComponentModel.new(model)
+unitary_system_cc = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
+unitary_system_hc = OpenStudio::Model::CoilHeatingDXSingleSpeed.new(model)
+supp_unitary_system_hc = OpenStudio::Model::CoilHeatingElectric.new(model)
+# unitary_system.setControlType("SetPoint")
+unitary_system.setSupplyAirFanOperatingModeSchedule(alwaysOn)
+unitary_system.setSupplyFan(unitary_system_fan)
+unitary_system.setCoolingCoil(unitary_system_cc)
+unitary_system.setHeatingCoil(unitary_system_hc)
+unitary_system.setSupplementalHeatingCoil(supp_unitary_system_hc)
+unitary_systemAirLoopHVAC = OpenStudio::Model::AirLoopHVAC.new(model)
+unitary_systemAirLoopHVAC.setName('AirLoopHVACUnitarySystem AirLoopHVAC')
+unitary_system.addToNode(unitary_systemAirLoopHVAC.supplyOutletNode)
+
+zones.each_with_index do |z, i|
+  # AirLoopHVACUnitarySystem
+  if i == 0
+
+    air_loop = z.airLoopHVAC.get
+    air_loop.removeBranchForZone(z)
+
+    new_terminal = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, alwaysOn)
+
+    unitary_systemAirLoopHVAC.addBranchForZone(z, new_terminal.to_StraightComponent)
+    unitary_system.setControllingZoneorThermostatLocation(z)
+
+  # ZoneHVACEvaporativeCoolerUnit: not wrapped yet as of 3.1.0
+  # elsif i == 1
+  #   supplyFan = OpenStudio::Model::FanSystemModel.new(model)
+  #   zoneHVACEvaporativeCoolerUnit = OpenStudio::Model::ZoneHVACEvaporativeCoolerUnit.new(model, supplyFan)
+  #   zoneHVACEvaporativeCoolerUnit.addToThermalZone(z)
+
+  end
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/fan_componentmodel.rb
+++ b/model/simulationtests/fan_componentmodel.rb
@@ -49,7 +49,6 @@ heating_loop = boilers.first.plantLoop.get
 
 alwaysOn = model.alwaysOnDiscreteSchedule
 
-
 ###############################################################################
 #                       D E M O N S T R A T E    A P I                        #
 ###############################################################################
@@ -64,9 +63,8 @@ sch.setName('Fan Avail Schedule')
 sch.setValue(1.0)
 fan.setAvailabilitySchedule(sch)
 
-
 vSDExample = OpenStudio::Model::CurveFanPressureRise.new(model)
-vSDExample.setName("VSD Example")
+vSDExample.setName('VSD Example')
 vSDExample.setCoefficient1C1(1446.75833497653)
 vSDExample.setCoefficient2C2(0.0)
 vSDExample.setCoefficient3C3(0.0)
@@ -79,7 +77,7 @@ vSDExample.setMinimumCurveOutput(0.0)
 vSDExample.setMaximumCurveOutput(5000.0)
 
 diagnosticSPR = OpenStudio::Model::CurveLinear.new(model)
-diagnosticSPR.setName("DiagnosticSPR")
+diagnosticSPR.setName('DiagnosticSPR')
 diagnosticSPR.setCoefficient1Constant(248.84)
 diagnosticSPR.setCoefficient2x(0.0)
 diagnosticSPR.setMinimumValueofx(0.0)
@@ -90,7 +88,7 @@ diagnosticSPR.setMaximumCurveOutput(248.84)
 # diagnosticSPR.setOutputUnitType("")
 
 fanEff120CPLANormal = OpenStudio::Model::CurveExponentialSkewNormal.new(model)
-fanEff120CPLANormal.setName("FanEff120CPLANormal")
+fanEff120CPLANormal.setName('FanEff120CPLANormal')
 fanEff120CPLANormal.setCoefficient1C1(0.072613)
 fanEff120CPLANormal.setCoefficient2C2(0.833213)
 fanEff120CPLANormal.setCoefficient3C3(0.0)
@@ -103,7 +101,7 @@ fanEff120CPLANormal.setMaximumCurveOutput(1.0)
 # fanEff120CPLANormal.setOutputUnitType("")
 
 fanEff120CPLAStall = OpenStudio::Model::CurveExponentialSkewNormal.new(model)
-fanEff120CPLAStall.setName("FanEff120CPLAStall")
+fanEff120CPLAStall.setName('FanEff120CPLAStall')
 fanEff120CPLAStall.setCoefficient1C1(-1.674931)
 fanEff120CPLAStall.setCoefficient2C2(1.980182)
 fanEff120CPLAStall.setCoefficient3C3(0.0)
@@ -116,7 +114,7 @@ fanEff120CPLAStall.setMaximumCurveOutput(1.0)
 # fanEff120CPLAStall.setOutputUnitType("")
 
 fanDimFlowNormal = OpenStudio::Model::CurveSigmoid.new(model)
-fanDimFlowNormal.setName("FanDimFlowNormal")
+fanDimFlowNormal.setName('FanDimFlowNormal')
 fanDimFlowNormal.setCoefficient1C1(0.0)
 fanDimFlowNormal.setCoefficient2C2(1.001423)
 fanDimFlowNormal.setCoefficient3C3(0.123935)
@@ -130,7 +128,7 @@ fanDimFlowNormal.setMaximumCurveOutput(1.0)
 # fanDimFlowNormal.setOutputUnitType("")
 
 fanDimFlowStall = OpenStudio::Model::CurveSigmoid.new(model)
-fanDimFlowStall.setName("FanDimFlowStall")
+fanDimFlowStall.setName('FanDimFlowStall')
 fanDimFlowStall.setCoefficient1C1(0.0)
 fanDimFlowStall.setCoefficient2C2(5.924993)
 fanDimFlowStall.setCoefficient3C3(-1.91636)
@@ -144,7 +142,7 @@ fanDimFlowStall.setMaximumCurveOutput(1.0)
 # fanDimFlowStall.setOutputUnitType("")
 
 beltMaxEffMedium = OpenStudio::Model::CurveQuartic.new(model)
-beltMaxEffMedium.setName("BeltMaxEffMedium")
+beltMaxEffMedium.setName('BeltMaxEffMedium')
 beltMaxEffMedium.setCoefficient1Constant(-0.09504)
 beltMaxEffMedium.setCoefficient2x(0.03415)
 beltMaxEffMedium.setCoefficient3xPOW2(-0.008897)
@@ -158,7 +156,7 @@ beltMaxEffMedium.setMaximumCurveOutput(0.0)
 # beltMaxEffMedium.setOutputUnitType("")
 
 beltPartLoadRegion1 = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
-beltPartLoadRegion1.setName("BeltPartLoadRegion1")
+beltPartLoadRegion1.setName('BeltPartLoadRegion1')
 beltPartLoadRegion1.setCoefficient1C1(0.920797)
 beltPartLoadRegion1.setCoefficient2C2(0.0262686)
 beltPartLoadRegion1.setCoefficient3C3(0.151594)
@@ -169,8 +167,8 @@ beltPartLoadRegion1.setMaximumCurveOutput(1.0)
 # beltPartLoadRegion1.setInputUnitTypeforx("")
 # beltPartLoadRegion1.setOutputUnitType("")
 
-beltPartLoadRegion2= OpenStudio::Model::CurveExponentialDecay.new(model)
-beltPartLoadRegion2.setName("BeltPartLoadRegion2")
+beltPartLoadRegion2 = OpenStudio::Model::CurveExponentialDecay.new(model)
+beltPartLoadRegion2.setName('BeltPartLoadRegion2')
 beltPartLoadRegion2.setCoefficient1C1(1.011965)
 beltPartLoadRegion2.setCoefficient2C2(-0.339038)
 beltPartLoadRegion2.setCoefficient3C3(-3.43626)
@@ -182,7 +180,7 @@ beltPartLoadRegion2.setMaximumCurveOutput(1.0)
 # beltPartLoadRegion2.setOutputUnitType("")
 
 beltPartLoadRegion3 = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
-beltPartLoadRegion3.setName("BeltPartLoadRegion3")
+beltPartLoadRegion3.setName('BeltPartLoadRegion3')
 beltPartLoadRegion3.setCoefficient1C1(1.037778)
 beltPartLoadRegion3.setCoefficient2C2(0.0103068)
 beltPartLoadRegion3.setCoefficient3C3(-0.0268146)
@@ -194,7 +192,7 @@ beltPartLoadRegion3.setMaximumCurveOutput(1.0)
 # beltPartLoadRegion3.setOutputUnitType("")
 
 motorMaxEffAvg = OpenStudio::Model::CurveRectangularHyperbola1.new(model)
-motorMaxEffAvg.setName("MotorMaxEffAvg")
+motorMaxEffAvg.setName('MotorMaxEffAvg')
 motorMaxEffAvg.setCoefficient1C1(0.29228)
 motorMaxEffAvg.setCoefficient2C2(3.368739)
 motorMaxEffAvg.setCoefficient3C3(0.762471)
@@ -206,7 +204,7 @@ motorMaxEffAvg.setMaximumCurveOutput(1.0)
 # motorMaxEffAvg.setOutputUnitType("")
 
 motorPartLoad = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
-motorPartLoad.setName("MotorPartLoad")
+motorPartLoad.setName('MotorPartLoad')
 motorPartLoad.setCoefficient1C1(1.137209)
 motorPartLoad.setCoefficient2C2(0.0502359)
 motorPartLoad.setCoefficient3C3(-0.0891503)
@@ -218,7 +216,7 @@ motorPartLoad.setMaximumCurveOutput(1.0)
 # motorPartLoad.setOutputUnitType("")
 
 vFDPartLoad = OpenStudio::Model::CurveRectangularHyperbola2.new(model)
-vFDPartLoad.setName("VFDPartLoad")
+vFDPartLoad.setName('VFDPartLoad')
 vFDPartLoad.setCoefficient1C1(0.987405)
 vFDPartLoad.setCoefficient2C2(0.0155361)
 vFDPartLoad.setCoefficient3C3(-0.0059365)
@@ -229,26 +227,25 @@ vFDPartLoad.setMaximumCurveOutput(1.0)
 # vFDPartLoad.setInputUnitTypeforx("")
 # vFDPartLoad.setOutputUnitType("")
 
-
-fan.setName("Fan Component Model")
-fan.autosizeMaximumFlowRate()
-fan.autosizeMinimumFlowRate()
+fan.setName('Fan Component Model')
+fan.autosizeMaximumFlowRate
+fan.autosizeMinimumFlowRate
 fan.setFanSizingFactor(1.0)
 fan.setFanWheelDiameter(0.3048)
 fan.setFanOutletArea(0.0873288576)
 fan.setMaximumFanStaticEfficiency(0.514)
 fan.setEulerNumberatMaximumFanStaticEfficiency(9.76)
 fan.setMaximumDimensionlessFanAirflow(0.160331811647483)
-fan.autosizeMotorFanPulleyRatio()
-fan.autosizeBeltMaximumTorque()
+fan.autosizeMotorFanPulleyRatio
+fan.autosizeBeltMaximumTorque
 fan.setBeltSizingFactor(1.0)
 fan.setBeltFractionalTorqueTransition(0.167)
 fan.setMotorMaximumSpeed(1800.0)
-fan.autosizeMaximumMotorOutputPower()
+fan.autosizeMaximumMotorOutputPower
 fan.setMotorSizingFactor(1.0)
 fan.setMotorInAirstreamFraction(1.0)
-fan.setVFDEfficiencyType("Power")
-fan.autosizeMaximumVFDOutputPower()
+fan.setVFDEfficiencyType('Power')
+fan.autosizeMaximumVFDOutputPower
 fan.setVFDSizingFactor(1.0)
 fan.setFanPressureRiseCurve(vSDExample)
 fan.setDuctStaticPressureResetCurve(diagnosticSPR)
@@ -264,13 +261,10 @@ fan.setMaximumMotorEfficiencyCurve(motorMaxEffAvg)
 fan.setNormalizedMotorEfficiencyCurve(motorPartLoad)
 fan.setVFDEfficiencyCurve(vFDPartLoad)
 
-
-
 # Add this fan as the supply fan of a regular AirLoopHVAC, removing the
 # existing FanVariableVolume
 regularAirLoopHVAC.supplyFan.get.remove
 fan.addToNode(regularAirLoopHVAC.supplyOutletNode)
-
 
 # AirLoopHVACUnitarySystem
 unitary_system = OpenStudio::Model::AirLoopHVACUnitarySystem.new(model)
@@ -300,11 +294,11 @@ zones.each_with_index do |z, i|
     unitary_systemAirLoopHVAC.addBranchForZone(z, new_terminal.to_StraightComponent)
     unitary_system.setControllingZoneorThermostatLocation(z)
 
-  # ZoneHVACEvaporativeCoolerUnit: not wrapped yet as of 3.1.0
-  # elsif i == 1
-  #   supplyFan = OpenStudio::Model::FanSystemModel.new(model)
-  #   zoneHVACEvaporativeCoolerUnit = OpenStudio::Model::ZoneHVACEvaporativeCoolerUnit.new(model, supplyFan)
-  #   zoneHVACEvaporativeCoolerUnit.addToThermalZone(z)
+    # ZoneHVACEvaporativeCoolerUnit: not wrapped yet as of 3.1.0
+    # elsif i == 1
+    #   supplyFan = OpenStudio::Model::FanSystemModel.new(model)
+    #   zoneHVACEvaporativeCoolerUnit = OpenStudio::Model::ZoneHVACEvaporativeCoolerUnit.new(model, supplyFan)
+    #   zoneHVACEvaporativeCoolerUnit.addToThermalZone(z)
 
   end
 end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -357,6 +357,15 @@ class ModelTests < Minitest::Test
     result = sim_test('fan_systemmodel.rb')
   end
 
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_fan_componentmodel_osm
+  #   result = sim_test('fan_componentmodel.osm')
+  # end
+
+  def test_fan_componentmodel_rb
+    result = sim_test('fan_componentmodel.rb')
+  end
+
   def test_fluid_coolers_rb
     result = sim_test('fluid_coolers.rb')
   end

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -832,7 +832,7 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:ZoneHVAC:LowTemperatureRadiant:VariableFlow' => [
       'autosizedHeatingDesignCapacity', # No OS methods for this field
       'autosizedCoolingDesignCapacity' # No OS methods for this field
-    ],
+    ]
   }
 
   # Aliases for some OS onjects
@@ -889,7 +889,7 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       'autosizedSourceSideOutletHeight'
     ],
     'OS:Fan:ComponentModel' => [
-      'autosizedMinimumFlowRate', # Not in E+ SQL
+      'autosizedMinimumFlowRate' # Not in E+ SQL
     ]
 
   }

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -832,7 +832,7 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:ZoneHVAC:LowTemperatureRadiant:VariableFlow' => [
       'autosizedHeatingDesignCapacity', # No OS methods for this field
       'autosizedCoolingDesignCapacity' # No OS methods for this field
-    ]
+    ],
   }
 
   # Aliases for some OS onjects
@@ -887,6 +887,9 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:ThermalStorage:ChilledWater:Stratified' => [
       'autosizedUseSideInletHeight',
       'autosizedSourceSideOutletHeight'
+    ],
+    'OS:Fan:ComponentModel' => [
+      'autosizedMinimumFlowRate', # Not in E+ SQL
     ]
 
   }


### PR DESCRIPTION
Pull request overview
---------------------
Link to relevant GitHub Issue(s) if appropriate:
* Issue: https://github.com/NREL/OpenStudio/issues/4185
* PR: https://github.com/NREL/OpenStudio/pull/4193

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4193/OpenStudio-3.1.1-alpha%2Bb0441309eb-Linux.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): PR https://github.com/NREL/OpenStudio/pull/4193#
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        python process_results.py test-stability clean
        python process_results.py test-stability run -n test_fan_componentmodel_rb --os_cli=$os_build/Products/openstudio

        $ python process_results.py test-status --tagged
        OK: No Failing tests were found

        $ python process_results.py heatmap --tagged
        OK: There are NO differences at all

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
