### PR TITLE
Addresses #4223, wrap the new ElectricLoadCenter:Storage:LiIonNMCBattery object in the OS SDK

### DIFF
--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# This test aims to test the new 'Adiabatic Surface Construction Name' field
+# added in the OS:DefaultConstructionSet
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+
+# create the distribution system
+elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
+elcd.setElectricalBussType('DirectCurrentWithInverterDCStorage')
+
+# create a generator
+generator = OpenStudio::Model::GeneratorPhotovoltaic.simple(model)
+
+# create the inverter
+inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
+
+# create the storage
+storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model)
+storage.setRadiativeFraction(0)
+storage.setLifetimeModel("KandlerSmith")
+storage.setNumberofCellsinSeries(139)
+storage.setNumberofStringsinParallel(25)
+storage.setInitialFractionalStateofCharge(0.7)
+storage.setDCtoDCChargingEfficiency(0.95)
+storage.setBatteryMass(342)
+storage.setBatterySurfaceArea(4.26)
+storage.setBatterySpecificHeatCapacity(1500)
+storage.setHeatTransferCoefficientBetweenBatteryandAmbient(7.5)
+storage.setFullyChargedCellVoltage(4.2)
+storage.setCellVoltageatEndofExponentialZone(3.53)
+storage.setCellVoltageatEndofNominalZone(3.342)
+storage.setDefaultNominalCellVoltage(3.342)
+storage.setFullyChargedCellCapacity(3.2)
+storage.setFractionofCellCapacityRemovedattheEndofExponentialZone(0.8075)
+storage.setFractionofCellCapacityRemovedattheEndofNominalZone(0.976875)
+storage.setChargeRateatWhichVoltagevsCapacityCurveWasGenerated(1)
+storage.setBatteryCellInternalElectricalResistance(0.09)
+
+# Add them to the ELCD
+elcd.addGenerator(generator)
+elcd.setInverter(inverter)
+elcd.setElectricalStorage(storage)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'out.osm' })

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -52,17 +52,17 @@ generator = OpenStudio::Model::GeneratorPhotovoltaic.simple(model)
 inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
 
 # create the storage
-storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model)
+nSeries = 139
+nParallel = 25
+mass = 342.0
+surfaceArea = 4.26
+storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model, nSeries, nParallel, mass, surfaceArea)
 # storage.setAvailabilitySchedule()
 # storage.setThermalZone()
 storage.setRadiativeFraction(0)
 storage.setLifetimeModel('KandlerSmith')
-storage.setNumberofCellsinSeries(139)
-storage.setNumberofStringsinParallel(25)
 storage.setInitialFractionalStateofCharge(0.7)
 storage.setDCtoDCChargingEfficiency(0.95)
-storage.setBatteryMass(342)
-storage.setBatterySurfaceArea(4.26)
 storage.setBatterySpecificHeatCapacity(1500)
 storage.setHeatTransferCoefficientBetweenBatteryandAmbient(7.5)
 storage.setFullyChargedCellVoltage(4.2)

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -54,7 +54,7 @@ inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
 # create the storage
 storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model)
 storage.setRadiativeFraction(0)
-storage.setLifetimeModel("KandlerSmith")
+storage.setLifetimeModel('KandlerSmith')
 storage.setNumberofCellsinSeries(139)
 storage.setNumberofStringsinParallel(25)
 storage.setInitialFractionalStateofCharge(0.7)

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# This test aims to test the new 'Adiabatic Surface Construction Name' field
-# added in the OS:DefaultConstructionSet
-
 require 'openstudio'
 require 'lib/baseline_model'
 
@@ -36,8 +33,6 @@ model.add_design_days
 
 # In order to produce more consistent results between different runs,
 # we sort the zones by names
-# (There's only one here, but just in case this would be copy pasted somewhere
-# else...)
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 zones.each_with_index do |zone, i|
   # create the distribution system

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -40,7 +40,6 @@ model.add_design_days
 # else...)
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 zones.each_with_index do |zone, i|
-
   # create the distribution system
   elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
   elcd.setElectricalBussType('DirectCurrentWithInverterDCStorage')

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -53,6 +53,8 @@ inverter = OpenStudio::Model::ElectricLoadCenterInverterLookUpTable.new(model)
 
 # create the storage
 storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model)
+# storage.setAvailabilitySchedule()
+# storage.setThermalZone()
 storage.setRadiativeFraction(0)
 storage.setLifetimeModel('KandlerSmith')
 storage.setNumberofCellsinSeries(139)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -892,6 +892,15 @@ class ModelTests < Minitest::Test
     result = sim_test('space_load_instances.osm')
   end
 
+  def test_storage_liion_battery_rb
+    result = sim_test('elcd_no_generators.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_storage_liion_battery_osm
+  #   result = sim_test('storage_liion_battery.osm')
+  # end
+
   def test_surfacecontrol_moveableinsulation_rb
     result = sim_test('surfacecontrol_moveableinsulation.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -893,7 +893,7 @@ class ModelTests < Minitest::Test
   end
 
   def test_storage_liion_battery_rb
-    result = sim_test('elcd_no_generators.rb')
+    result = sim_test('storage_liion_battery.rb')
   end
 
   # TODO: To be added in the next official release after: 3.1.0


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4225.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4225/OpenStudio-3.1.1-alpha%2B278e228646-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
