### PR TITLE
Addresses #4230, update AirLoopHVAC:UnitaryHeatPump:AirToAir to support variable speed coils

### DIFF
--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -528,9 +528,9 @@ unitary.setControllingZoneorThermostatLocation(zones[27])
 # Necessary for autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature
 unitary.setControlType('SingleZoneVAV')
 # E+ 9.5.0-IOFreeze crashes when this is blank. https://github.com/NREL/EnergyPlus/issues/8566
-unitary.setSupplyAirFlowRateMethodDuringCoolingOperation("SupplyAirFlowRate")
-unitary.setSupplyAirFlowRateMethodDuringHeatingOperation("SupplyAirFlowRate")
-unitary.setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("SupplyAirFlowRate")
+unitary.setSupplyAirFlowRateMethodDuringCoolingOperation('SupplyAirFlowRate')
+unitary.setSupplyAirFlowRateMethodDuringHeatingOperation('SupplyAirFlowRate')
+unitary.setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired('SupplyAirFlowRate')
 unitary.autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature
 
 term = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, s1)
@@ -947,4 +947,3 @@ end
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
                             'osm_name' => 'in.osm' })
-

--- a/model/simulationtests/heatpump_varspeed.rb
+++ b/model/simulationtests/heatpump_varspeed.rb
@@ -36,8 +36,8 @@ model.add_thermostats({ 'heating_setpoint' => 24,
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 zone = zones[0]
 
-air_loop = OpenStudio::Model::AirLoopHVAC.new(model)
-supplyOutletNode = air_loop.supplyOutletNode
+air_loop_hvac = OpenStudio::Model::AirLoopHVAC.new(model)
+supplyOutletNode = air_loop_hvac.supplyOutletNode
 
 schedule = model.alwaysOnDiscreteSchedule
 fan = OpenStudio::Model::FanOnOff.new(model, schedule)
@@ -55,7 +55,7 @@ unitary = OpenStudio::Model::AirLoopHVACUnitaryHeatPumpAirToAir.new(model, sched
 unitary.addToNode(supplyOutletNode)
 
 terminal = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, schedule)
-air_loop.addBranchForZone(zone, terminal.to_StraightComponent)
+air_loop_hvac.addBranchForZone(zone, terminal.to_StraightComponent)
 unitary.setControllingZone(zone)
 
 # save the OpenStudio model (.osm)

--- a/model/simulationtests/heatpump_varspeed.rb
+++ b/model/simulationtests/heatpump_varspeed.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+zone = zones[0]
+
+air_loop = OpenStudio::Model::AirLoopHVAC.new(model)
+supplyOutletNode = air_loop.supplyOutletNode
+
+schedule = model.alwaysOnDiscreteSchedule
+fan = OpenStudio::Model::FanOnOff.new(model, schedule)
+supp_heating_coil = OpenStudio::Model::CoilHeatingElectric.new(model, schedule)
+
+heating_coil = OpenStudio::Model::CoilHeatingDXVariableSpeed.new(model)
+heating_coil_speed_1 = OpenStudio::Model::CoilHeatingDXVariableSpeedSpeedData.new(model)
+heating_coil.addSpeed(heating_coil_speed_1)
+
+cooling_coil = OpenStudio::Model::CoilCoolingDXVariableSpeed.new(model)
+cooling_coil_speed_1 = OpenStudio::Model::CoilCoolingDXVariableSpeedSpeedData.new(model)
+cooling_coil.addSpeed(cooling_coil_speed_1)
+
+unitary = OpenStudio::Model::AirLoopHVACUnitaryHeatPumpAirToAir.new(model, schedule, fan, heating_coil, cooling_coil, supp_heating_coil)
+unitary.addToNode(supplyOutletNode)
+
+terminal = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, schedule)
+air_loop.addBranchForZone(zone, terminal.to_StraightComponent)
+unitary.setControllingZone(zone)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/heatpump_varspeed.rb
+++ b/model/simulationtests/heatpump_varspeed.rb
@@ -36,8 +36,8 @@ model.add_thermostats({ 'heating_setpoint' => 24,
 zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 zone = zones[0]
 
-air_loop_hvac = OpenStudio::Model::AirLoopHVAC.new(model)
-supplyOutletNode = air_loop_hvac.supplyOutletNode
+air_loop = OpenStudio::Model::AirLoopHVAC.new(model)
+supplyOutletNode = air_loop.supplyOutletNode
 
 schedule = model.alwaysOnDiscreteSchedule
 fan = OpenStudio::Model::FanOnOff.new(model, schedule)
@@ -55,7 +55,7 @@ unitary = OpenStudio::Model::AirLoopHVACUnitaryHeatPumpAirToAir.new(model, sched
 unitary.addToNode(supplyOutletNode)
 
 terminal = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, schedule)
-air_loop_hvac.addBranchForZone(zone, terminal.to_StraightComponent)
+air_loop.addBranchForZone(zone, terminal.to_StraightComponent)
 unitary.setControllingZone(zone)
 
 # save the OpenStudio model (.osm)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -472,7 +472,7 @@ class ModelTests < Minitest::Test
 
   # TODO: To be added in the next official release after: 3.1.0
   # def test_heatpump_varspeed_osm
-    # result = sim_test('heatpump_varspeed.osm')
+  # result = sim_test('heatpump_varspeed.osm')
   # end
 
   def test_hightemprad_rb
@@ -1211,8 +1211,7 @@ class ModelTests < Minitest::Test
     extra_options = { outdir: 'model_articulation1_bundle_git.osw',
                       bundle: gemfile, bundle_path: bundle_path,
                       # TODO: Temp for debug for #134
-                      verbose: true, debug: true,
-    }
+                      verbose: true, debug: true }
     result = sim_test('model_articulation1.osw', extra_options)
 
     # check that we got the right version of standards and workflow

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -466,6 +466,15 @@ class ModelTests < Minitest::Test
     result = sim_test('heatpump_hot_water.osm')
   end
 
+  def test_heatpump_varspeed_rb
+    result = sim_test('heatpump_varspeed.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_heatpump_varspeed_osm
+    # result = sim_test('heatpump_varspeed.osm')
+  # end
+
   def test_hightemprad_rb
     result = sim_test('hightemprad.rb')
   end

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -677,7 +677,7 @@ def sim_test(filename, options = {})
   # command to run the in_osw
   command = "\"#{$OpenstudioCli}\" #{extra_options} run #{extra_run_options} -w \"#{in_osw}\""
   if options[:debug]
-    puts "COMMAND:"
+    puts 'COMMAND:'
     puts command
   end
 


### PR DESCRIPTION
Pull request overview
---------------------

Companion to: https://github.com/NREL/OpenStudio/pull/4234.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4234/OpenStudio-3.1.1-alpha%2Bd44e6c2471-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------


### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
