### PR TITLE
#3905 - Allow ZoneHVAC:TerminalUnit:VariableRefrigerantFlow to connect to AirLoopHVAC

### DIFF
--- a/model/simulationtests/vrf_airloophvac.rb
+++ b/model/simulationtests/vrf_airloophvac.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# This test aims to test the new feature (in E+ 9.3.0) that allows connecting
+# a ZoneHVAC:TerminalUnit:VariableRefrigerantFlow to an AirLoopHVAC / AirLoopHVACOutdoorAirSystem
+# This feature was added in 3.2.0
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 5 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 3,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+# Create an AirLoopHVAC, with an OutdoorAirSystem
+airLoop = OpenStudio::Model::AirLoopHVAC.new(model)
+controllerOutdoorAir = OpenStudio::Model::ControllerOutdoorAir.new(model)
+outdoorAirSystem = OpenStudio::Model::AirLoopHVACOutdoorAirSystem.new(model, controllerOutdoorAir)
+outdoorAirSystem.addToNode(airLoop.supplyOutletNode)
+
+
+vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlow.new(model)
+# E+ now throws when the CoolingEIRLowPLR has a curve minimum value of x which
+# is higher than the Minimum Heat Pump Part-Load Ratio.
+# The curve has a min of 0.5 here, so set the MinimumHeatPumpPartLoadRatio to
+# the same value
+vrf.setMinimumHeatPumpPartLoadRatio(0.5)
+
+zones.each_with_index do |z, i|
+  if i == 0
+    # First zone, we place this VRF Terminal on the main branch of the AirLoopHVAC
+    # The default Ctor has a fan, which we actually need here
+    vrf_terminal = OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow.new(model)
+    vrf_terminal.addToNode(airLoop.supplyOutletNode)
+    vrf_terminal.setControllingZoneorThermostatLocation(z)
+    vrf.addTerminal(vrf_terminal)
+
+    # And we add an ATU Uncontroller for this zone
+    atu = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, model.alwaysOnDiscreteSchedule)
+    airLoop.addBranchForZone(z, atu)
+  else
+    # We add an ATU, for outside air
+    atu = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(model, model.alwaysOnDiscreteSchedule)
+    airLoop.addBranchForZone(z, atu)
+
+    # And a regular (zonehvac) VRF terminal
+    vrf_terminal = OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow.new(model)
+    vrf_terminal.addToThermalZone(z)
+    vrf.addTerminal(vrf_terminal)
+  end
+end
+
+# Now we also create a VRF Terminal to place onto the OutdoorAirSystem, on the OA branch (for preheat/precool)
+oa_vrf_terminal = OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow.new(model)
+oa_vrf_terminal.addToNode(outdoorAirSystem.outboardOANode.get)
+vrf.addTerminal(oa_vrf_terminal)
+
+
+lat_temp_f = 70.0
+lat_temp_c = OpenStudio.convert(lat_temp_f, 'F', 'C').get
+lat_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+lat_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), lat_temp_c)
+lat_stpt_manager1 = OpenStudio::Model::SetpointManagerScheduled.new(model, lat_temp_sch)
+lat_stpt_manager1.addToNode(airLoop.supplyOutletNode)
+
+lat_stpt_manager2 = lat_stpt_manager1.clone(model).to_SetpointManagerScheduled.get
+lat_stpt_manager2.addToNode(oa_vrf_terminal.outletNode.get)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1038,6 +1038,15 @@ class ModelTests < Minitest::Test
     result = sim_test('vrf_watercooled.rb')
   end
 
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_vrf_airloophvac_osm
+  #   result = sim_test('vrf_airloophvac.osm')
+  # end
+
+  def test_vrf_airloophvac_rb
+    result = sim_test('vrf_airloophvac.rb')
+  end
+
   def test_water_economizer_osm
     result = sim_test('water_economizer.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

New test for the ability to connect a `ZoneHVAC:TerminalUnit:VariableRefrigerantFlow` to an `AirLoopHVAC`

Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/pull/4253

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4253/OpenStudio-3.1.1-alpha%2B1a5c1d5d84-Ubuntu-18.04.deb


Related issue in eplusout.err:  https://github.com/NREL/EnergyPlus/issues/8640

This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

This PR adds a new test for a new capabillity of [ZoneHVACTerminalUnitVariableRefrigerantFlow](https://github.com/NREL/OpenStudio/blob/develop/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp)

cf PR https://github.com/NREL/OpenStudio/pull/4253

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions: N/A: it passes only with a new feature branch

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/4253
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version

 - [x] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage). see https://github.com/NREL/OpenStudio-resources/pull/137/checks?check_run_id=2168085314
        ```bash
        + ls test/vrf_airloophvac.rb_3.1.1-alpha_out_Linux_run1.osw
        test/vrf_airloophvac.rb_3.1.1-alpha_out_Linux_run1.osw
        + python process_results.py test-status --tagged --quiet

        Filtering only tests where there is a missing or failed osm OR ruby test
        OK: No Failing tests were found
        HTML file saved in /home/runner/work/OpenStudio-resources/OpenStudio-resources/Test-Stability/Regression_Test_Status.html

        + python process_results.py heatmap --tagged --quiet
        Mapping OS '3.1.1-alpha' to '9.4.0'
        OK: There are NO differences at all
        ```

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**: N/A



----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
