### PR TITLE
#4246 - Add a test for SpaceInfiltrationFlowCoefficient, but also for SpaceInfiltrationEffectiveLeakageArea (and SpaceInfiltrationDesignFlowRate)

### DIFF
--- a/model/simulationtests/infiltration.rb
+++ b/model/simulationtests/infiltration.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# This test aims to test the new 'Adiabatic Surface Construction Name' field
+# added in the OS:DefaultConstructionSet
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 5 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# remove all infiltration
+model.getSpaceInfiltrationDesignFlowRates.each(&:remove)
+
+infilSch = OpenStudio::Model::ScheduleRuleset.new(model, 1)
+infilSch.setName('Infiltration Schedule')
+
+# In order to produce more consistent results between different runs,
+# we sort the spaces by names
+spaces = model.getSpaces.sort_by { |s| s.name.to_s }.reject { |s| s.nameString.downcase.include?('core') }
+spaces.each_with_index do |space, i|
+  if i == 0
+    infil = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+    infil.setSpace(space)
+    infil.setSchedule(infilSch)
+
+    # Use one of these, it will set the "Design Flow Rate Calculation Method"
+    # infil.setDesignFlowRate(0.1)
+    # infil.setFlowperSpaceFloorArea(0.02)
+    # infil.setFlowperExteriorSurfaceArea(0.01)
+    # infil.setFlowperExteriorWallArea(0.01);
+    infil.setAirChangesperHour(0.8)
+
+    infil.setConstantTermCoefficient(1.0)
+    infil.setTemperatureTermCoefficient(0.0)
+    infil.setVelocityTermCoefficient(0.0)
+    infil.setVelocitySquaredTermCoefficient(0.0)
+
+  elsif i == 1
+    infil = OpenStudio::Model::SpaceInfiltrationEffectiveLeakageArea.new(model)
+    infil.setSpace(space)
+    infil.setSchedule(infilSch)
+    infil.setEffectiveAirLeakageArea(0.1)
+    infil.setStackCoefficient(0.1)
+    infil.setWindCoefficient(0.1)
+
+  elsif i == 2
+    infil = OpenStudio::Model::SpaceInfiltrationFlowCoefficient.new(model)
+    infil.setSpace(space)
+    infil.setSchedule(infilSch)
+    infil.setFlowCoefficient(0.02)
+    infil.setStackCoefficient(0.05)
+    infil.setPressureExponent(0.67)
+    infil.setWindCoefficient(0.12)
+    infil.setShelterFactor(0.5)
+  end
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -3,7 +3,7 @@
 require 'openstudio' unless defined?(OpenStudio)
 
 # The config and helpers are inside this file
-require_relative 'test_helpers.rb'
+require_relative 'test_helpers'
 
 # TODO: Include the other ones?
 # require_relative 'highlevel_tests.rb'
@@ -524,6 +524,15 @@ class ModelTests < Minitest::Test
   def test_ideal_plant_osm
     result = sim_test('ideal_plant.osm')
   end
+
+  def test_infiltration_rb
+    result = sim_test('infiltration.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.1.0
+  # def test_infiltration_osm
+  #   result = sim_test('infiltration.osm')
+  # end
 
   def test_interior_partitions_rb
     result = sim_test('interior_partitions.rb')


### PR DESCRIPTION
Pull request overview
---------------------

#4246 - Add a test for SpaceInfiltrationFlowCoefficient, but also for SpaceInfiltrationEffectiveLeakageArea (and SpaceInfiltrationDesignFlowRate)

Link to relevant GitHub Issue(s) if appropriate:Companion PR: https://github.com/NREL/OpenStudio/pull/4258

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

This pull request is in relation with the Pull Request https://github.com/NREL/OpenStudio/pull/4258, and  will specifically test for the following classes:
* `SpaceInfiltrationFlowCoefficient` (**ADDED**)
* Additionally it explicitly tests for the existing class [SpaceInfiltrationEffectiveLeakageArea](https://github.com/NREL/OpenStudio/blob/develop/src/model/SpaceInfiltrationEffectiveLeakageArea.hpp) and [SpaceInfiltrationDesignFlowRate](https://github.com/NREL/OpenStudio/blob/develop/src/model/SpaceInfiltrationDesignFlowRate.hpp)


#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/4258
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**: **N/A**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
