### PR TITLE
Add reg test for new fields in AirTerminalSingleDuctInletSideMixer

### DIFF
--- a/model/simulationtests/airterminal_inletsidemixer.rb
+++ b/model/simulationtests/airterminal_inletsidemixer.rb
@@ -72,7 +72,7 @@ atu.setControlForOutdoorAir(true)
 
 atu.setPerPersonVentilationRateMode('CurrentOccupancy')
 
-# Rename some nodes for ease of browsing when looking at the IDF
+# Rename some nodes to facilitate looking at the resulting IDF
 z.zoneAirNode.setName('Zone Air Node')
 z.returnAirModelObjects[0].setName('Zone Return Air Node')
 atu.inletModelObject.get.setName('ATU InletSideMixer Inlet Node')

--- a/model/simulationtests/airterminal_inletsidemixer.rb
+++ b/model/simulationtests/airterminal_inletsidemixer.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require 'lib/baseline_model'
+
+m = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone core building
+m.add_geometry({ 'length' => 100,
+                 'width' => 50,
+                 'num_floors' => 1,
+                 'floor_to_floor_height' => 3,
+                 'plenum_height' => 0,
+                 'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+m.add_windows({ 'wwr' => 0.4,
+                'offset' => 1,
+                'application_type' => 'Above Floor' })
+
+# Add ASHRAE System type 07, VAV w/ Reheat, this creates a ChW, a HW loop and a
+# Condenser Loop
+m.add_hvac({ 'ashrae_sys_num' => '07' })
+
+# add thermostats
+m.add_thermostats({ 'heating_setpoint' => 24,
+                    'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+m.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+m.set_space_type
+
+# add design days to the model (Chicago)
+m.add_design_days
+
+###############################################################################
+#                        R E P L A C E    A T Us
+###############################################################################
+
+b = m.getBoilerHotWaters.first
+p_hw = b.plantLoop.get
+
+ch = m.getChillerElectricEIRs.first
+p_chw = ch.plantLoop.get
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = m.getThermalZones.sort_by { |z| z.name.to_s }
+# (There's only one here...)
+z = zones[0]
+a = z.airLoopHVAC.get
+a.removeBranchForZone(z)
+
+atu = OpenStudio::Model::AirTerminalSingleDuctInletSideMixer.new(m)
+a.addBranchForZone(z, atu)
+
+fan = OpenStudio::Model::FanConstantVolume.new(m)
+heatingCoil = OpenStudio::Model::CoilHeatingWater.new(m)
+p_hw.addDemandBranchForComponent(heatingCoil)
+coolingCoil = OpenStudio::Model::CoilCoolingWater.new(m)
+p_chw.addDemandBranchForComponent(coolingCoil)
+fc = OpenStudio::Model::ZoneHVACFourPipeFanCoil.new(m, m.alwaysOnDiscreteSchedule, fan, coolingCoil, heatingCoil)
+fc.addToNode(atu.outletModelObject.get.to_Node.get)
+
+# This replaces the E+ field 'Design Specification Outdoor Air'
+# This will find the Thermal Zone associated, find the space, which has a space
+# type, and that space type has a Design Specification Outdoor Air and it will
+# write the DSOA into the field in E+.
+atu.setControlForOutdoorAir(true)
+
+atu.setPerPersonVentilationRateMode("CurrentOccupancy")
+
+# Rename some nodes for ease of browsing when looking at the IDF
+z.zoneAirNode().setName("Zone Air Node")
+z.returnAirModelObjects[0].setName("Zone Return Air Node")
+atu.inletModelObject.get.setName("ATU InletSideMixer Inlet Node")
+atu.outletModelObject().get.setName("ATU InletSideMixer Outlet to FC Inlet Node")
+fc.outletNode().get.setName("FC Outlet Node")
+z.exhaustPortList.modelObjects[0].setName("Zone Exhaust Air Node")
+
+# save the OpenStudio model (.osm)
+m.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                        'osm_name' => 'in.osm' })

--- a/model/simulationtests/airterminal_inletsidemixer.rb
+++ b/model/simulationtests/airterminal_inletsidemixer.rb
@@ -70,15 +70,15 @@ fc.addToNode(atu.outletModelObject.get.to_Node.get)
 # write the DSOA into the field in E+.
 atu.setControlForOutdoorAir(true)
 
-atu.setPerPersonVentilationRateMode("CurrentOccupancy")
+atu.setPerPersonVentilationRateMode('CurrentOccupancy')
 
 # Rename some nodes for ease of browsing when looking at the IDF
-z.zoneAirNode().setName("Zone Air Node")
-z.returnAirModelObjects[0].setName("Zone Return Air Node")
-atu.inletModelObject.get.setName("ATU InletSideMixer Inlet Node")
-atu.outletModelObject().get.setName("ATU InletSideMixer Outlet to FC Inlet Node")
-fc.outletNode().get.setName("FC Outlet Node")
-z.exhaustPortList.modelObjects[0].setName("Zone Exhaust Air Node")
+z.zoneAirNode.setName('Zone Air Node')
+z.returnAirModelObjects[0].setName('Zone Return Air Node')
+atu.inletModelObject.get.setName('ATU InletSideMixer Inlet Node')
+atu.outletModelObject.get.setName('ATU InletSideMixer Outlet to FC Inlet Node')
+fc.outletNode.get.setName('FC Outlet Node')
+z.exhaustPortList.modelObjects[0].setName('Zone Exhaust Air Node')
 
 # save the OpenStudio model (.osm)
 m.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -53,6 +53,15 @@ class ModelTests < Minitest::Test
     result = sim_test('airterminal_fourpipebeam.osm')
   end
 
+  def test_airterminal_inletsidemixer_rb
+    result = sim_test('airterminal_inletsidemixer.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.2.1
+  # def test_airterminal_inletsidemixer_osm
+  #   result = sim_test('airterminal_inletsidemixer.osm')
+  # end
+
   def test_air_chillers_osm
     result = sim_test('air_chillers.osm')
   end

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -1017,7 +1017,7 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
 
       # Don't test this getter if it is known to be missing from E+ output
       obj_missing_getters = missing_getters[os_type]
-      next if obj_missing_getters && obj_missing_getters.include?(getter_name)
+      next if obj_missing_getters&.include?(getter_name)
 
       # Check if the autosizedFoo method has been implemented for this object
       unless obj.respond_to? getter_name


### PR DESCRIPTION
Pull request overview
---------------------


Link to relevant GitHub Issue(s) if appropriate:
* Issue: https://github.com/NREL/OpenStudio/issues/3599
* Companion PR: https://github.com/NREL/OpenStudio/pull/4350

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4350/OpenStudio-3.2.2-alpha%2B57aa19a6e1-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

This pull request is in relation with the Pull Request https://github.com/NREL/OpenStudio/pull/4350, and  will specifically test for two new fields "Control for Outdoor Air" and "Per Person Ventilation Flow Rate Mode" for the following classes:
* `AirTerminalSingleDuctInletSideMixer`

There was no test aside from the zone_hvac.rb one, so this is more explicitly anyways. 

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/4350
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).

 - [X] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**: N/A

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] Object is tested in `autosize_hvac` as appropriate
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
