### PR TITLE
Fix Error running some tests in parallel

### DIFF
--- a/model/simulationtests/adiabatic_construction_set.rb
+++ b/model/simulationtests/adiabatic_construction_set.rb
@@ -67,4 +67,4 @@ end
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/elcd_no_generators.rb
+++ b/model/simulationtests/elcd_no_generators.rb
@@ -126,4 +126,4 @@ end
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/environmental_factors.rb
+++ b/model/simulationtests/environmental_factors.rb
@@ -111,4 +111,4 @@ fuelFactors.setNuclearLowLevelEmissionFactorSchedule(alwaysOn)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/fuelcell.rb
+++ b/model/simulationtests/fuelcell.rb
@@ -99,4 +99,4 @@ model.add_design_days
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/lib/baseline_model.rb
+++ b/model/simulationtests/lib/baseline_model.rb
@@ -655,6 +655,7 @@ class BaselineModel < OpenStudio::Model::Model
     force_year_description
 
     save_path = OpenStudio::Path.new("#{osm_save_directory}/#{osm_name}")
+    # puts "Saving to #{save_path}"
     save(save_path, true)
   end
 

--- a/model/simulationtests/output_objects.rb
+++ b/model/simulationtests/output_objects.rb
@@ -100,4 +100,4 @@ output_table.addSummaryReports(['OutdoorAirSummary', 'ObjectCountSummary'])
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/outputcontrol_files.rb
+++ b/model/simulationtests/outputcontrol_files.rb
@@ -85,4 +85,4 @@ outputcontrol_files.setOutputTarcog(false)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/photovoltaics.rb
+++ b/model/simulationtests/photovoltaics.rb
@@ -124,4 +124,4 @@ end
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/photovoltaics_sandia.rb
+++ b/model/simulationtests/photovoltaics_sandia.rb
@@ -138,4 +138,4 @@ elcd.setDemandLimitSchemePurchasedElectricDemandLimit(0.0)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/pv_and_storage_demandleveling.rb
+++ b/model/simulationtests/pv_and_storage_demandleveling.rb
@@ -256,4 +256,4 @@ if add_storage
 end
 
 # save the OpenStudio model (.osm)
-model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'out.osm' })
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/pv_and_storage_facilityexcess.rb
+++ b/model/simulationtests/pv_and_storage_facilityexcess.rb
@@ -254,4 +254,4 @@ if add_storage
 end
 
 # save the OpenStudio model (.osm)
-model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'out.osm' })
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/storage_liion_battery.rb
+++ b/model/simulationtests/storage_liion_battery.rb
@@ -85,4 +85,4 @@ end
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/swimmingpool_indoor.rb
+++ b/model/simulationtests/swimmingpool_indoor.rb
@@ -136,4 +136,4 @@ end
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
-                            'osm_name' => 'out.osm' })
+                            'osm_name' => 'in.osm' })

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -117,10 +117,10 @@ end
 
 $UseEplusSpaces = nil
 if ENV['USE_EPLUS_SPACES'].to_s.downcase == 'true'
-  puts "USE_EPLUS_SPACES=true: Will use the E+ Space Feature"
+  puts 'USE_EPLUS_SPACES=true: Will use the E+ Space Feature'
   $UseEplusSpaces = true
 elsif ENV['USE_EPLUS_SPACES'].to_s.downcase == 'false'
-  puts "USE_EPLUS_SPACES=false: Will force not using the E+ Space Feature"
+  puts 'USE_EPLUS_SPACES=false: Will force not using the E+ Space Feature'
   $UseEplusSpaces = false
 end
 
@@ -328,9 +328,8 @@ end
 
 # run a command in directory dir, throws exception on timeout or exit status != 0, always returns to initial directory
 def run_command(command, dir, timeout)
-
   result = nil
-  Open3.popen3(command, :chdir => dir) do |i, o, e, w|
+  Open3.popen3(command, chdir: dir) do |i, o, e, w|
     out = ''
     begin
       Timeout.timeout(timeout) do

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -676,8 +676,7 @@ def sim_test(filename, options = {})
     # tests used to write out.osm
     out_osm = File.join(dir, 'out.osm')
     if File.exist?(out_osm)
-      # puts "moving #{out_osm} to #{in_osm}"
-      FileUtils.mv(out_osm, in_osm)
+      raise "You cannot use out.osm as an osm_name, use in.osm! Occurred in #{filename}"
     end
 
   when '.osw'

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -309,27 +309,21 @@ end
 # returns full directory name gemfile_dir
 # gemfile at gemfile_dir + 'Gemfile', bundle at gemfile_dir + 'gems'
 def bundle_install(gemfile_dirname, force_install)
-  original_dir = Dir.pwd
   gemfile_dir = File.join($RootDir, 'gemfiles', gemfile_dirname)
   raise "Gemfile dir '#{gemfile_dir}' does not exist" if !File.exist?(gemfile_dir)
 
-  Dir.chdir(gemfile_dir)
-
   if force_install
-    FileUtils.rm_rf('Gemfile.lock') if File.exist?('Gemfile.lock')
-    FileUtils.rm_rf('./gems') if File.exist?('./gems')
-    FileUtils.rm_rf('./bundle') if File.exist?('./bundle')
+    ['Gemfile.lock', 'gems', 'bundle'].each do |x|
+      target = File.join(gemfile_dir, x)
+      FileUtils.rm_rf(target) if target
+    end
   end
 
-  assert(system('bundle install --path ./gems'))
+  run_command('bundle install --path ./gems', gemfile_dir, 3600)
 
-  Dir.chdir(gemfile_dir)
-
-  assert(system('bundle lock --add_platform ruby'))
+  run_command('bundle lock --add_platform ruby', gemfile_dir, 3600)
 
   return gemfile_dir
-ensure
-  Dir.chdir(original_dir)
 end
 
 # run a command in directory dir, throws exception on timeout or exit status != 0, always returns to initial directory


### PR DESCRIPTION
Pull request overview
---------------------

I found a few race condition issues due to the use of the Dir.chdir




```
$ while /bin/rm -Rf testruns/ && openstudio model_tests.rb -n '/(test_shadingcontrol_singlezone_rb)|(test_adiabatic_construction_set_rb)/'; do :; done
Setting ENV['N'] = 15

# Running tests with run options :

Running for OpenStudio 3.2.1+bdbdbc9da6
Ignoring ffi-1.15.4 because its extensions are not built. Try: gem pristine ffi --version 1.15.4
Ignoring iruby-0.7.4 because its extensions are not built. Try: gem pristine iruby --version 0.7.4
Running for OpenStudio 3.2.1+bdbdbc9da6 (Previous=3.2.0)

# Running tests with run options -n "/(test_shadingcontrol_singlezone_rb)|(test_adiabatic_construction_set_rb)/" --seed 22684:

Running sim_test(adiabatic_construction_set.rb)
Running sim_test(shadingcontrol_singlezone.rb)


"/usr/local/openstudio-3.2.1/bin/openstudio" "/home/julien/Software/Others/OpenStudio-resources/model/simulationtests/adiabatic_construction_set.rb" in dir=/home/julien/Software/Others/OpenStudio-resources/testruns/adiabatic_construction_set.rb, pwd=/home/julien/Software/Others/OpenStudio-resources/testruns/adiabatic_construction_set.rb


"/usr/local/openstudio-3.2.1/bin/openstudio" "/home/julien/Software/Others/OpenStudio-resources/model/simulationtests/shadingcontrol_singlezone.rb" in dir=/home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb, pwd=/home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb


"/usr/local/openstudio-3.2.1/bin/openstudio" "/home/julien/Software/Others/OpenStudio-resources/model/simulationtests/adiabatic_construction_set.rb" in dir=/home/julien/Software/Others/OpenStudio-resources/testruns/adiabatic_construction_set.rb, pwd=/home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb
[openstudio.model.YearDescription] <1> 'UseWeatherFile' is not yet a supported option for YearDescription
[openstudio.model.YearDescription] <1> 'UseWeatherFile' is not yet a supported option for YearDescription
Saving to /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/out.osm


E

"/usr/local/openstudio-3.2.1/bin/openstudio" "/home/julien/Software/Others/OpenStudio-resources/model/simulationtests/shadingcontrol_singlezone.rb" in dir=/home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb, pwd=/home/julien/Software/Others/OpenStudio-resources
[openstudio.model.YearDescription] <1> 'UseWeatherFile' is not yet a supported option for YearDescription
[openstudio.model.YearDescription] <1> 'UseWeatherFile' is not yet a supported option for YearDescription
Saving to /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/in.osm


moving /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/out.osm to /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/in.osm
.

Finished tests in 3.251990s, 0.6150 tests/s, 0.0000 assertions/s.


Error:
ModelTests#test_adiabatic_construction_set_rb:
RuntimeError: Cannot find file /home/julien/Software/Others/OpenStudio-resources/testruns/adiabatic_construction_set.rb/in.osm
    /home/julien/Software/Others/OpenStudio-resources/test_helpers.rb:697:in `sim_test'
    /home/julien/Software/Others/OpenStudio-resources/model_tests.rb:33:in `test_adiabatic_construction_set_rb'

2 tests, 0 assertions, 0 failures, 1 errors, 0 skips
```

adiabatic_construction_set.rb ends up saving to /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/out.osm  ...which then gets renamed to /home/julien/Software/Others/OpenStudio-resources/testruns/shadingcontrol_singlezone.rb/in.osm thus overwriting the original shadingcontrol_singlezone


Two points in one:
- The adiabatic construction set OSM is missing
- If the simulation of the shadingcontrol_singlezone OSM happens after the OSM has been overwritten, then you get awesome bogus results since you are running the wrong file! 

https://github.com/NREL/OpenStudio-resources/blob/0adcae854ecb4d4a1a2eb8bb317a651bdb9a3f61/model/simulationtests/adiabatic_construction_set.rb#L70

https://github.com/NREL/OpenStudio-resources/blob/0adcae854ecb4d4a1a2eb8bb317a651bdb9a3f61/test_helpers.rb#L666-L681

and more importantly:

https://github.com/NREL/OpenStudio-resources/blob/0adcae854ecb4d4a1a2eb8bb317a651bdb9a3f61/test_helpers.rb#L337-L341