### PR TITLE
Addresses #4495, ElectricLoadCenterDistribution FT has incomplete charge/discharge logic

### DIFF
--- a/model/simulationtests/storage_liion_battery_2.rb
+++ b/model/simulationtests/storage_liion_battery_2.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 2 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 2,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+zones.each_with_index do |zone, i|
+  # create the distribution system
+  elcd = OpenStudio::Model::ElectricLoadCenterDistribution.new(model)
+  elcd.setElectricalBussType('DirectCurrentWithInverterDCStorage')
+  elcd.setStorageOperationScheme('TrackFacilityElectricDemandStoreExcessOnSite')
+  elcd.setDesignStorageControlDischargePower(5000)
+  elcd.setDesignStorageControlChargePower(5000)
+  storage_charge_power_fraction_schedule = OpenStudio::Model::ScheduleConstant.new(model)
+  storage_charge_power_fraction_schedule.setValue(0.0)
+  elcd.setStorageChargePowerFractionSchedule(storage_charge_power_fraction_schedule)
+  storage_discharge_power_fraction_schedule = OpenStudio::Model::ScheduleConstant.new(model)
+  storage_discharge_power_fraction_schedule.setValue(1.0)
+  elcd.setStorageDischargePowerFractionSchedule(storage_discharge_power_fraction_schedule)
+
+  # create a generator
+  generator = OpenStudio::Model::GeneratorPVWatts.new(model, 4000)
+
+  # create the inverter
+  inverter = OpenStudio::Model::ElectricLoadCenterInverterPVWatts.new(model)
+
+  nSeries = 139
+  nParallel = 25
+  mass = 342.0
+  surfaceArea = 4.26
+  if i == 0
+    # create the storage using ctor 1
+    storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model, nSeries, nParallel, mass, surfaceArea)
+  else
+    # create the storage using ctor 2
+    storage = OpenStudio::Model::ElectricLoadCenterStorageLiIonNMCBattery.new(model)
+    storage.setNumberofCellsinSeries(nSeries)
+    storage.setNumberofStringsinParallel(nParallel)
+    storage.setBatteryMass(mass)
+    storage.setBatterySurfaceArea(surfaceArea)
+  end
+  storage.setThermalZone(zone)
+  storage.setRadiativeFraction(0)
+  storage.setLifetimeModel('KandlerSmith')
+  storage.setInitialFractionalStateofCharge(0.7)
+  storage.setDCtoDCChargingEfficiency(0.95)
+  storage.setBatterySpecificHeatCapacity(1500)
+  storage.setHeatTransferCoefficientBetweenBatteryandAmbient(7.5)
+  storage.setFullyChargedCellVoltage(4.2)
+  storage.setCellVoltageatEndofExponentialZone(3.53)
+  storage.setCellVoltageatEndofNominalZone(3.342)
+  storage.setDefaultNominalCellVoltage(3.342)
+  storage.setFullyChargedCellCapacity(3.2)
+  storage.setFractionofCellCapacityRemovedattheEndofExponentialZone(0.8075)
+  storage.setFractionofCellCapacityRemovedattheEndofNominalZone(0.976875)
+  storage.setChargeRateatWhichVoltagevsCapacityCurveWasGenerated(1)
+  storage.setBatteryCellInternalElectricalResistance(0.09)
+
+  # Add them to the ELCD
+  elcd.addGenerator(generator)
+  elcd.setInverter(inverter)
+  elcd.setElectricalStorage(storage)
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1015,7 +1015,7 @@ class ModelTests < Minitest::Test
 
   # TODO: To be added in the next official release after: 3.3.0
   # def test_storage_liion_battery_2_osm
-    # result = sim_test('storage_liion_battery_2.osm')
+  # result = sim_test('storage_liion_battery_2.osm')
   # end
 
   def test_surfacecontrol_moveableinsulation_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1009,6 +1009,15 @@ class ModelTests < Minitest::Test
     result = sim_test('storage_liion_battery.osm')
   end
 
+  def test_storage_liion_battery_2_rb
+    result = sim_test('storage_liion_battery_2.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.3.0
+  # def test_storage_liion_battery_2_osm
+    # result = sim_test('storage_liion_battery_2.osm')
+  # end
+
   def test_surfacecontrol_moveableinsulation_rb
     result = sim_test('surfacecontrol_moveableinsulation.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstrating https://github.com/NREL/OpenStudio/pull/4497

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4497/OpenStudio-3.3.0-alpha%2B91fd6b61fa-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Please include which class(es) you are adding a test to specifically test for as it was currently not being tested for.
Include a link to the OpenStudio model classes themselves.

> eg:
>
> This pull request adds missing tests for the following classes:
> *  [AvailabilibityManagerDifferentialThermostat](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerDifferentialThermostat.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOff](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOff.hpp)
> *  [AvailabilibityManagerHighTemperatureTurnOn](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/AvailabilityManagerHighTemperatureTurnOn.hpp)

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] **Test has been run backwards** (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
