### PR TITLE
Addresses #4311, add water heaters to supply side of different loops

### DIFF
--- a/model/simulationtests/heatrecovery_chiller.rb
+++ b/model/simulationtests/heatrecovery_chiller.rb
@@ -27,7 +27,7 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 
 # Water Heater Mixed
 water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
-water_heater_mixed.setName("Water Heater")
+water_heater_mixed.setName('Water Heater')
 
 # Plant Loop 1
 plant_loop_1 = OpenStudio::Model::PlantLoop.new(model)
@@ -49,7 +49,7 @@ pipe_1.setName('First Pipe')
 plant_loop_1.addSupplyBranchForComponent(pipe_1)
 
 sch_1 = OpenStudio::Model::ScheduleRuleset.new(model)
-sch_1.setName("Hot_Water_Temperature")
+sch_1.setName('Hot_Water_Temperature')
 sch_1.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 55.0)
 
 hot_water_spm_1 = OpenStudio::Model::SetpointManagerScheduled.new(model, sch_1)

--- a/model/simulationtests/heatrecovery_chiller.rb
+++ b/model/simulationtests/heatrecovery_chiller.rb
@@ -5,72 +5,18 @@ require_relative 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 1 zone building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,
                      'floor_to_floor_height' => 4,
-                     'plenum_height' => 1,
-                     'perimeter_zone_depth' => 3 })
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
 
 # add windows at a 40% window-to-wall ratio
 model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
-
-# add ASHRAE System type 03, PSZ-AC
-model.add_hvac({ 'ashrae_sys_num' => '03' })
-
-# In order to produce more consistent results between different runs,
-# we sort the zones by names
-zones = model.getThermalZones.sort_by { |z| z.name.to_s }
-
-# Water Heater Mixed
-water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
-water_heater_mixed.setName('Water Heater')
-
-# Plant Loop 1
-plant_loop_1 = OpenStudio::Model::PlantLoop.new(model)
-plant_loop_1.setName('First Plant Loop')
-
-# water_heater_mixed.addToNode(plant_loop_1.supplyInletNode)
-plant_loop_1.addSupplyBranchForComponent(water_heater_mixed)
-
-pump_1 = OpenStudio::Model::PumpConstantSpeed.new(model)
-pump_1.setName('First Pump')
-pump_1.addToNode(plant_loop_1.supplyInletNode)
-
-boiler_1 = OpenStudio::Model::BoilerHotWater.new(model)
-boiler_1.setName('First Boiler')
-plant_loop_1.addSupplyBranchForComponent(boiler_1)
-
-pipe_1 = OpenStudio::Model::PipeAdiabatic.new(model)
-pipe_1.setName('First Pipe')
-plant_loop_1.addSupplyBranchForComponent(pipe_1)
-
-sch_1 = OpenStudio::Model::ScheduleRuleset.new(model)
-sch_1.setName('Hot_Water_Temperature')
-sch_1.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 55.0)
-
-hot_water_spm_1 = OpenStudio::Model::SetpointManagerScheduled.new(model, sch_1)
-hot_water_spm_1.addToNode(plant_loop_1.supplyOutletNode)
-
-# Plant Loop 2
-plant_loop_2 = OpenStudio::Model::PlantLoop.new(model)
-plant_loop_2.setName('Second Plant Loop')
-
-# pipe = OpenStudio::Model::PipeAdiabatic.new(model)
-# plant_loop_2.addSupplyBranchForComponent(pipe)
-# water_heater_mixed.addToSourceSideNode(pipe.inletModelObject.get.to_Node.get)
-# pipe.remove
-water_heater_mixed.addToSourceSideNode(plant_loop_2.supplyInletNode)
-
-pump_2 = OpenStudio::Model::PumpConstantSpeed.new(model)
-pump_2.setName('Second Pump')
-pump_2.addToNode(plant_loop_2.supplyInletNode)
-
-hot_water_spm_2 = OpenStudio::Model::SetpointManagerScheduled.new(model, sch_1)
-hot_water_spm_2.addToNode(plant_loop_2.supplyOutletNode)
 
 # add thermostats
 model.add_thermostats({ 'heating_setpoint' => 24,
@@ -84,6 +30,74 @@ model.set_space_type
 
 # add design days to the model (Chicago)
 model.add_design_days
+
+# add ASHRAE System type 07, VAV w/ Reheat: this sets up the loops we want
+model.add_hvac({ 'ashrae_sys_num' => '07' })
+
+# In order to produce more consistent results between different runs,
+# We ensure we do get the same object each time
+cts = model.getCoolingTowerSingleSpeeds.sort_by { |c| c.name.to_s }
+chillers = model.getChillerElectricEIRs.sort_by { |c| c.name.to_s }
+chiller = chillers.first
+boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
+condenser_loop = cts.first.plantLoop.get
+cooling_loop = chillers.first.plantLoop.get
+heating_loop = boilers.first.plantLoop.get
+condenser_loop.setName('CndW Loop')
+heating_loop.setName('HW Loop')
+cooling_loop.setName('ChW Loop')
+
+# We'll setup a WaterHeater:Mixed that sits on the **supply side**
+# of TWO plant loops:
+# * Use Side: the Heating Loop
+# * Source Side: the Heat Recovery loop, on the demand side you find the
+# chiller
+# (Note that you could also just place the chiller on the demand side of
+# the HW loop directly, but that's not what we're testing here)
+
+heat_recovery_loop = OpenStudio::Model::PlantLoop.new(model)
+heat_recovery_loop.setName('HeatRecovery Loop')
+hr_pump = OpenStudio::Model::PumpVariableSpeed.new(model)
+hr_pump.setName("#{heat_recovery_loop} VSD Pump")
+hr_pump.addToNode(heat_recovery_loop.supplyInletNode)
+
+hr_spm_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+hr_spm_sch.setName('Hot_Water_Temperature')
+hr_spm_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 25.0)
+hr_spm = OpenStudio::Model::SetpointManagerScheduled.new(model, hr_spm_sch)
+hr_spm.addToNode(heat_recovery_loop.supplyOutletNode)
+
+# Water Heater Mixed
+water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
+water_heater_mixed.setName('Heat Recovery Tank')
+# The first addSupplyBranchForComponent / addToNode to a supply side will
+# connect the Use Side, so heating loop here
+heating_loop.addSupplyBranchForComponent(water_heater_mixed)
+raise if water_heater_mixed.plantLoop.empty?
+
+# The Second with a supply side node, if use side already connected, will
+# connect the Source Side. You can also be explicit and call
+# addToSourceSideNode
+
+# pipe = OpenStudio::Model::PipeAdiabatic.new(model)
+# heat_recovery_loop.addSupplyBranchForComponent(pipe)
+# water_heater_mixed.addToSourceSideNode(pipe.inletModelObject.get.to_Node.get)
+# pipe.remove
+heat_recovery_loop.addSupplyBranchForComponent(water_heater_mixed)
+
+raise if water_heater_mixed.plantLoop.empty?
+raise if water_heater_mixed.secondaryPlantLoop.empty?
+# More convenient name aliases
+raise if water_heater_mixed.useSidePlantLoop.empty?
+raise if water_heater_mixed.sourceSidePlantLoop.empty?
+raise if water_heater_mixed.useSidePlantLoop.get != heating_loop
+raise if water_heater_mixed.sourceSidePlantLoop.get != heat_recovery_loop
+
+# Connect the chiller to the HR loop
+# Since the secondary loop is already connected (condenser loop)
+# and this is a node on the **demand** side of a **different** loop than the
+# condenser loop, this will call `chiller.addToTertiaryNode`
+heat_recovery_loop.addDemandBranchForComponent(chiller)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/heatrecovery_chiller.rb
+++ b/model/simulationtests/heatrecovery_chiller.rb
@@ -27,12 +27,14 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 
 # Water Heater Mixed
 water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
+water_heater_mixed.setName("Water Heater")
 
 # Plant Loop 1
 plant_loop_1 = OpenStudio::Model::PlantLoop.new(model)
 plant_loop_1.setName("First Plant Loop")
 
-water_heater_mixed.addToNode(plant_loop_1.supplyInletNode)
+# water_heater_mixed.addToNode(plant_loop_1.supplyInletNode)
+plant_loop_1.addSupplyBranchForComponent(water_heater_mixed)
 
 pump_1 = OpenStudio::Model::PumpConstantSpeed.new(model)
 pump_1.setName("First Pump")
@@ -46,18 +48,29 @@ pipe_1 = OpenStudio::Model::PipeAdiabatic.new(model)
 pipe_1.setName("First Pipe")
 plant_loop_1.addSupplyBranchForComponent(pipe_1)
 
+sch_1 = OpenStudio::Model::ScheduleRuleset.new(model)
+sch_1.setName("Hot_Water_Temperature")
+sch_1.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 55.0)
+
+hot_water_spm_1 = OpenStudio::Model::SetpointManagerScheduled.new(model, sch_1)
+hot_water_spm_1.addToNode(plant_loop_1.supplyOutletNode)
+
 # Plant Loop 2
 plant_loop_2 = OpenStudio::Model::PlantLoop.new(model)
 plant_loop_2.setName("Second Plant Loop")
 
-pipe = OpenStudio::Model::PipeAdiabatic.new(model)
-plant_loop_2.addSupplyBranchForComponent(pipe)
-water_heater_mixed.addToSecondaryNode(pipe.inletModelObject.get.to_Node.get)
-pipe.remove
+# pipe = OpenStudio::Model::PipeAdiabatic.new(model)
+# plant_loop_2.addSupplyBranchForComponent(pipe)
+# water_heater_mixed.addToSourceSideNode(pipe.inletModelObject.get.to_Node.get)
+# pipe.remove
+water_heater_mixed.addToSourceSideNode(plant_loop_2.supplyInletNode)
 
 pump_2 = OpenStudio::Model::PumpConstantSpeed.new(model)
 pump_2.setName("Second Pump")
 pump_2.addToNode(plant_loop_2.supplyInletNode)
+
+hot_water_spm_2 = OpenStudio::Model::SetpointManagerScheduled.new(model, sch_1)
+hot_water_spm_2.addToNode(plant_loop_2.supplyOutletNode)
 
 # add thermostats
 model.add_thermostats({ 'heating_setpoint' => 24,

--- a/model/simulationtests/heatrecovery_chiller.rb
+++ b/model/simulationtests/heatrecovery_chiller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 03, PSZ-AC
+model.add_hvac({ 'ashrae_sys_num' => '03' })
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+# Water Heater Mixed
+water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
+
+# Plant Loop 1
+plant_loop_1 = OpenStudio::Model::PlantLoop.new(model)
+plant_loop_1.setName("First Plant Loop")
+
+water_heater_mixed.addToNode(plant_loop_1.supplyInletNode)
+
+pump_1 = OpenStudio::Model::PumpConstantSpeed.new(model)
+pump_1.setName("First Pump")
+pump_1.addToNode(plant_loop_1.supplyInletNode)
+
+boiler_1 = OpenStudio::Model::BoilerHotWater.new(model)
+boiler_1.setName("First Boiler")
+plant_loop_1.addSupplyBranchForComponent(boiler_1)
+
+pipe_1 = OpenStudio::Model::PipeAdiabatic.new(model)
+pipe_1.setName("First Pipe")
+plant_loop_1.addSupplyBranchForComponent(pipe_1)
+
+# Plant Loop 2
+plant_loop_2 = OpenStudio::Model::PlantLoop.new(model)
+plant_loop_2.setName("Second Plant Loop")
+
+pipe = OpenStudio::Model::PipeAdiabatic.new(model)
+plant_loop_2.addSupplyBranchForComponent(pipe)
+water_heater_mixed.addToSecondaryNode(pipe.inletModelObject.get.to_Node.get)
+pipe.remove
+
+pump_2 = OpenStudio::Model::PumpConstantSpeed.new(model)
+pump_2.setName("Second Pump")
+pump_2.addToNode(plant_loop_2.supplyInletNode)
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/heatrecovery_chiller.rb
+++ b/model/simulationtests/heatrecovery_chiller.rb
@@ -30,25 +30,25 @@ water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
 
 # Plant Loop 1
 plant_loop_1 = OpenStudio::Model::PlantLoop.new(model)
-plant_loop_1.setName("First Plant Loop")
+plant_loop_1.setName('First Plant Loop')
 
 water_heater_mixed.addToNode(plant_loop_1.supplyInletNode)
 
 pump_1 = OpenStudio::Model::PumpConstantSpeed.new(model)
-pump_1.setName("First Pump")
+pump_1.setName('First Pump')
 pump_1.addToNode(plant_loop_1.supplyInletNode)
 
 boiler_1 = OpenStudio::Model::BoilerHotWater.new(model)
-boiler_1.setName("First Boiler")
+boiler_1.setName('First Boiler')
 plant_loop_1.addSupplyBranchForComponent(boiler_1)
 
 pipe_1 = OpenStudio::Model::PipeAdiabatic.new(model)
-pipe_1.setName("First Pipe")
+pipe_1.setName('First Pipe')
 plant_loop_1.addSupplyBranchForComponent(pipe_1)
 
 # Plant Loop 2
 plant_loop_2 = OpenStudio::Model::PlantLoop.new(model)
-plant_loop_2.setName("Second Plant Loop")
+plant_loop_2.setName('Second Plant Loop')
 
 pipe = OpenStudio::Model::PipeAdiabatic.new(model)
 plant_loop_2.addSupplyBranchForComponent(pipe)
@@ -56,7 +56,7 @@ water_heater_mixed.addToSecondaryNode(pipe.inletModelObject.get.to_Node.get)
 pipe.remove
 
 pump_2 = OpenStudio::Model::PumpConstantSpeed.new(model)
-pump_2.setName("Second Pump")
+pump_2.setName('Second Pump')
 pump_2.addToNode(plant_loop_2.supplyInletNode)
 
 # add thermostats

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -571,7 +571,7 @@ class ModelTests < Minitest::Test
 
   # TODO: To be added in the next official release after: 3.3.0
   # def test_heatrecovery_chiller_osm
-    # result = sim_test('heatrecovery_chiller.osm')
+  # result = sim_test('heatrecovery_chiller.osm')
   # end
 
   def test_hightemprad_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -565,6 +565,15 @@ class ModelTests < Minitest::Test
     result = sim_test('heatpump_varspeed.osm')
   end
 
+  def test_heatrecovery_chiller_rb
+    result = sim_test('heatrecovery_chiller.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.3.0
+  # def test_heatrecovery_chiller_osm
+    # result = sim_test('heatrecovery_chiller.osm')
+  # end
+
   def test_hightemprad_rb
     result = sim_test('hightemprad.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstrating https://github.com/NREL/OpenStudio/pull/4534

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/incremental/develop/4534/OpenStudio-3.3.1-alpha%2B2a3f136fde-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
