### PR TITLE
Addresses #4403, add Sql helper methods to retrieve U-factors, SHGC, or VT for glazing systems

### DIFF
--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -70,26 +70,10 @@ window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
 window_property.setFrameWidth(0.1)
 window_property.setNFRCProductTypeforAssemblyCalculations('CurtainWall')
 
-# convert one of the windows to interior
-space = OpenStudio::Model::Space.new(model)
-space.setName('Adjacent Space')
-thermal_zone = OpenStudio::Model::ThermalZone.new(model)
-thermal_zone.setName('Adjacent Thermal Zone')
-space.setThermalZone(thermal_zone)
-non_adiabatic_surface = surfaces[1]
-adjacent_surface = non_adiabatic_surface.createAdjacentSurface(space).get
-adjacent_sub_surface = adjacent_surface.subSurfaces[0]
-adjacent_sub_surface.setName('Adjacent Sub Surface')
-
-# zone needs at least 2 surfaces
-model.getSurfaces.each do |surface|
-  next if surface.surfaceType != 'Floor'
-
-  surface.setSpace(space)
-end
-
 # set window property on all subsurfaces
 model.getSubSurfaces.each do |sub_surface|
+  next if sub_surface.subSurfaceType != 'FixedWindow'
+
   sub_surface.setWindowPropertyFrameAndDivider(window_property)
 end
 

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -66,7 +66,7 @@ end
 # assert adiabatic_surface.construction.get == adiabatic_c
 
 window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
-window_property.setNFRCProductTypeforAssemblyCalculations("ProjectingSingle")
+window_property.setNFRCProductTypeforAssemblyCalculations('ProjectingSingle')
 
 model.getSubSurfaces.each do |sub_surface|
   next if sub_surface.subSurfaceType != 'FixedWindow'

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# This test aims to test the new 'Adiabatic Surface Construction Name' field
+# added in the OS:DefaultConstructionSet
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+# Get the first Outdoors surface, sorting by name to ensure consistency
+surfaces = model.getSurfaces.select { |s| s.outsideBoundaryCondition == 'Outdoors' }.sort_by { |s| s.name.to_s }
+
+adiabatic_surface = surfaces[0]
+# This will remove the subSurfaces (if any)
+adiabatic_surface.setOutsideBoundaryCondition('Adiabatic')
+# assert adiabatic_surface.construction.empty?
+
+# Only one here, but let's be safe
+construction_set = model.getDefaultConstructionSets.min_by { |d| d.name.to_s }
+# I know it's initialized, so I get it already
+ext_set = construction_set.defaultExteriorSurfaceConstructions.get
+# Same, I know it's initialized
+c = ext_set.wallConstruction.get
+adiabatic_c = c.clone(model).to_ConstructionBase.get
+adiabatic_c.setName('Adiabatic Construction')
+
+if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('2.7.1')
+  construction_set.setAdiabaticSurfaceConstruction(adiabatic_c)
+end
+# assert !adiabatic_surface.construction.empty?
+# assert adiabatic_surface.construction.get == adiabatic_c
+
+window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
+window_property.setNFRCProductTypeforAssemblyCalculations("ProjectingSingle")
+
+model.getSubSurfaces.each do |sub_surface|
+  next if sub_surface.subSurfaceType != 'FixedWindow'
+
+  sub_surface.setWindowPropertyFrameAndDivider(window_property)
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -42,29 +42,6 @@ zones = model.getThermalZones.sort_by { |z| z.name.to_s }
 z = zones[0]
 z.setUseIdealAirLoads(true)
 
-# Get the first Outdoors surface, sorting by name to ensure consistency
-surfaces = model.getSurfaces.select { |s| s.outsideBoundaryCondition == 'Outdoors' }.sort_by { |s| s.name.to_s }
-
-adiabatic_surface = surfaces[0]
-# This will remove the subSurfaces (if any)
-adiabatic_surface.setOutsideBoundaryCondition('Adiabatic')
-# assert adiabatic_surface.construction.empty?
-
-# Only one here, but let's be safe
-construction_set = model.getDefaultConstructionSets.min_by { |d| d.name.to_s }
-# I know it's initialized, so I get it already
-ext_set = construction_set.defaultExteriorSurfaceConstructions.get
-# Same, I know it's initialized
-c = ext_set.wallConstruction.get
-adiabatic_c = c.clone(model).to_ConstructionBase.get
-adiabatic_c.setName('Adiabatic Construction')
-
-if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('2.7.1')
-  construction_set.setAdiabaticSurfaceConstruction(adiabatic_c)
-end
-# assert !adiabatic_surface.construction.empty?
-# assert adiabatic_surface.construction.get == adiabatic_c
-
 # create a window property frame and divider
 window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
 window_property.setFrameWidth(0.1)

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -45,6 +45,38 @@ z.setUseIdealAirLoads(true)
 # create a window property frame and divider
 window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
 window_property.setFrameWidth(0.1)
+# Careful: no default, E+ defaults to 0.0 in source code
+window_property.setFrameConductance(2.33)
+
+# All these are just the IDD defaults
+window_property.setFrameOutsideProjection(0.0)
+window_property.setFrameInsideProjection(0.0)
+window_property.setRatioOfFrameEdgeGlassConductanceToCenterOfGlassConductance(1.0)
+window_property.setFrameSolarAbsorptance(0.7)
+window_property.setFrameVisibleAbsorptance(0.7)
+window_property.setFrameThermalHemisphericalEmissivity(0.9)
+window_property.setDividerType('DividedLite')
+window_property.setDividerWidth(0.0)
+window_property.setNumberOfHorizontalDividers(0.0)
+window_property.setNumberOfVerticalDividers(0.0)
+window_property.setDividerOutsideProjection(0.0)
+window_property.setDividerInsideProjection(0.0)
+window_property.setDividerConductance(0.0)
+window_property.setRatioOfDividerEdgeGlassConductanceToCenterOfGlassConductance(1.0)
+window_property.setDividerSolarAbsorptance(0.0)
+window_property.setDividerVisibleAbsorptance(0.0)
+window_property.setDividerThermalHemisphericalEmissivity(0.9)
+window_property.setOutsideRevealDepth(0.0)
+window_property.setOutsideRevealSolarAbsorptance(0.0)
+window_property.setInsideSillDepth(0.0)
+window_property.setInsideSillSolarAbsorptance(0.0)
+window_property.setInsideRevealDepth(0.0)
+window_property.setInsideRevealSolarAbsorptance(0.0)
+
+# This will be used to report the Assembly U-Factor, SGHC
+# and VisibleTransmittance in the SQL/HTML.
+# After a sucessful run, attach a sql file to your model and you can call
+# SubSurface::assemblyUFactor() for eg
 window_property.setNFRCProductTypeforAssemblyCalculations('CurtainWall')
 
 # set window property on all subsurfaces

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -67,22 +67,31 @@ end
 
 # create a window property frame and divider
 window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
-window_property.setNFRCProductTypeforAssemblyCalculations('ProjectingSingle')
+window_property.setFrameWidth(0.1)
+window_property.setNFRCProductTypeforAssemblyCalculations('CurtainWall')
 
 # convert one of the windows to interior
 space = OpenStudio::Model::Space.new(model)
 space.setName('Adjacent Space')
+thermal_zone = OpenStudio::Model::ThermalZone.new(model)
+thermal_zone.setName('Adjacent Thermal Zone')
+space.setThermalZone(thermal_zone)
 non_adiabatic_surface = surfaces[1]
 adjacent_surface = non_adiabatic_surface.createAdjacentSurface(space).get
 adjacent_sub_surface = adjacent_surface.subSurfaces[0]
 adjacent_sub_surface.setName('Adjacent Sub Surface')
 
+# zone needs at least 2 surfaces
+model.getSurfaces.each do |surface|
+  next if surface.surfaceType != 'Floor'
+
+  surface.setSpace(space)
+end
+
 # set window property on all subsurfaces
 model.getSubSurfaces.each do |sub_surface|
   sub_surface.setWindowPropertyFrameAndDivider(window_property)
 end
-
-# TODO: add an interior window
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/window_property_frame_and_divider.rb
+++ b/model/simulationtests/window_property_frame_and_divider.rb
@@ -65,14 +65,24 @@ end
 # assert !adiabatic_surface.construction.empty?
 # assert adiabatic_surface.construction.get == adiabatic_c
 
+# create a window property frame and divider
 window_property = OpenStudio::Model::WindowPropertyFrameAndDivider.new(model)
 window_property.setNFRCProductTypeforAssemblyCalculations('ProjectingSingle')
 
-model.getSubSurfaces.each do |sub_surface|
-  next if sub_surface.subSurfaceType != 'FixedWindow'
+# convert one of the windows to interior
+space = OpenStudio::Model::Space.new(model)
+space.setName('Adjacent Space')
+non_adiabatic_surface = surfaces[1]
+adjacent_surface = non_adiabatic_surface.createAdjacentSurface(space).get
+adjacent_sub_surface = adjacent_surface.subSurfaces[0]
+adjacent_sub_surface.setName('Adjacent Sub Surface')
 
+# set window property on all subsurfaces
+model.getSubSurfaces.each do |sub_surface|
   sub_surface.setWindowPropertyFrameAndDivider(window_property)
 end
+
+# TODO: add an interior window
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1172,6 +1172,15 @@ class ModelTests < Minitest::Test
     result = sim_test('water_heaters.osm')
   end
 
+  def test_window_property_frame_and_divider_rb
+    result = sim_test('window_property_frame_and_divider.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.3.0
+  # def test_window_property_frame_and_divider_osm
+  # result = sim_test('window_property_frame_and_divider.osm')
+  # end
+
   def test_zone_air_movement_rb
     result = sim_test('zone_air_movement.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstration https://github.com/NREL/OpenStudio/pull/4550

Questions:
- [ ] I'm creating an interior window, but it's not populating "Assembly xxx" fields in eplusout.sql:
![image](https://user-images.githubusercontent.com/8516790/158422882-c8c29b84-dfb3-44ac-a685-933dd8e1ed6a.png)

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4550/OpenStudio-3.4.0-alpha%2B19ddb63e3e-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
