### PR TITLE
Python plugin

### DIFF
--- a/model/simulationtests/.gitignore
+++ b/model/simulationtests/.gitignore
@@ -1,1 +1,0 @@
-python_plugin_program.py

--- a/model/simulationtests/.gitignore
+++ b/model/simulationtests/.gitignore
@@ -1,0 +1,1 @@
+python_plugin_program.py

--- a/model/simulationtests/python_plugin.rb
+++ b/model/simulationtests/python_plugin.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 2,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 01, PTAC, Residential
+model.add_hvac({ 'ashrae_sys_num' => '01' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# create the external file object
+file_name = File.join(File.dirname(__FILE__), 'lib/PythonPluginThermochromicWindow.py')
+file_name = File.realpath(file_name)
+external_file = OpenStudio::Model::ExternalFile.getExternalFile(model, file_name)
+external_file = external_file.get
+
+# create the python plugin instance object
+python_plugin_instance = OpenStudio::Model::PythonPluginInstance.new(external_file, "ZN_1_wall_south_Window_1_Control")
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/python_plugin.rb
+++ b/model/simulationtests/python_plugin.rb
@@ -22,16 +22,14 @@ model.set_space_type
 # add design days to the model (Chicago)
 model.add_design_days
 
-zone_names = model.getThermalZones.map{|z| z.nameString}.sort
+zone_names = model.getThermalZones.map(&:nameString).sort
 
 zone_names_str_list = '["' + zone_names.join('", "') + '"]'
-
 
 # Add a PythonPlugin:Variable (all OS SDK PythonPluginVariable objects are
 # translated to a single E+ PythonPlugin:Variables (extensible object))
 py_var = OpenStudio::Model::PythonPluginVariable.new(model)
 py_var.setName('AverageBuildingTemp')
-
 
 # Add a PythonPlugin:OutputVariable for that variable
 py_out_var = OpenStudio::Model::PythonPluginOutputVariable.new(py_var)
@@ -43,8 +41,7 @@ py_out_var.setUnits('C')
 outputVariable = OpenStudio::Model::OutputVariable.new('Zone Mean Air Temperature', model)
 outputVariable.setReportingFrequency('Timestep')
 
-
-python_plugin_file_content = """from pyenergyplus.plugin import EnergyPlusPlugin
+python_plugin_file_content = ''"from pyenergyplus.plugin import EnergyPlusPlugin
 
 class AverageZoneTemps(EnergyPlusPlugin):
 
@@ -77,7 +74,7 @@ class AverageZoneTemps(EnergyPlusPlugin):
         average_temp = numerator / denominator
         self.api.exchange.set_global_value(state, self.data['avg_temp_variable'], average_temp)
         return 0
-"""
+"''
 
 pluginPath = File.join(File.dirname(__FILE__), 'python_plugin_program.py')
 File.write(pluginPath, python_plugin_file_content)

--- a/model/simulationtests/python_plugin.rb
+++ b/model/simulationtests/python_plugin.rb
@@ -41,7 +41,7 @@ external_file = OpenStudio::Model::ExternalFile.getExternalFile(model, file_name
 external_file = external_file.get
 
 # create the python plugin instance object
-python_plugin_instance = OpenStudio::Model::PythonPluginInstance.new(external_file, "ZN_1_wall_south_Window_1_Control")
+python_plugin_instance = OpenStudio::Model::PythonPluginInstance.new(external_file, 'ZN_1_wall_south_Window_1_Control')
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/python_plugin.rb
+++ b/model/simulationtests/python_plugin.rb
@@ -5,25 +5,13 @@ require_relative 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 5 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
-                     'num_floors' => 2,
+                     'num_floors' => 1,
                      'floor_to_floor_height' => 4,
-                     'plenum_height' => 1,
+                     'plenum_height' => 0,
                      'perimeter_zone_depth' => 3 })
-
-# add windows at a 40% window-to-wall ratio
-model.add_windows({ 'wwr' => 0.4,
-                    'offset' => 1,
-                    'application_type' => 'Above Floor' })
-
-# add ASHRAE System type 01, PTAC, Residential
-model.add_hvac({ 'ashrae_sys_num' => '01' })
-
-# add thermostats
-model.add_thermostats({ 'heating_setpoint' => 24,
-                        'cooling_setpoint' => 28 })
 
 # assign constructions from a local library to the walls/windows/etc. in the model
 model.set_constructions
@@ -34,14 +22,73 @@ model.set_space_type
 # add design days to the model (Chicago)
 model.add_design_days
 
+zone_names = model.getThermalZones.map{|z| z.nameString}.sort
+
+zone_names_str_list = '["' + zone_names.join('", "') + '"]'
+
+
+# Add a PythonPlugin:Variable (all OS SDK PythonPluginVariable objects are
+# translated to a single E+ PythonPlugin:Variables (extensible object))
+py_var = OpenStudio::Model::PythonPluginVariable.new(model)
+py_var.setName('AverageBuildingTemp')
+
+
+# Add a PythonPlugin:OutputVariable for that variable
+py_out_var = OpenStudio::Model::PythonPluginOutputVariable.new(py_var)
+py_out_var.setTypeofDatainVariable('Averaged')
+py_out_var.setUpdateFrequency('ZoneTimestep')
+py_out_var.setUnits('C')
+
+# Add output variables for Zone Mean Air Temperature
+outputVariable = OpenStudio::Model::OutputVariable.new('Zone Mean Air Temperature', model)
+outputVariable.setReportingFrequency('Timestep')
+
+
+python_plugin_file_content = """from pyenergyplus.plugin import EnergyPlusPlugin
+
+class AverageZoneTemps(EnergyPlusPlugin):
+
+    def __init__(self):
+        super().__init__()
+        self.do_setup = True
+
+    def on_end_of_zone_timestep_before_zone_reporting(self, state) -> int:
+        if self.do_setup:
+            self.data['zone_volumes'] = []
+            self.data['zone_temps'] = []
+            zone_names = #{zone_names_str_list}
+            for zone_name in zone_names:
+                handle = self.api.exchange.get_internal_variable_handle(state, 'Zone Air Volume', zone_name)
+                zone_volume = self.api.exchange.get_internal_variable_value(state, handle)
+                self.data['zone_volumes'].append(zone_volume)
+                self.data['zone_temps'].append(
+                    self.api.exchange.get_variable_handle(state, 'Zone Mean Air Temperature', zone_name)
+                )
+            self.data['avg_temp_variable'] = self.api.exchange.get_global_handle(state, '#{py_var.nameString}')
+            self.do_setup = False
+        zone_temps = list()
+        for t_handle in self.data['zone_temps']:
+            zone_temps.append(self.api.exchange.get_variable_value(state, t_handle))
+        numerator = 0.0
+        denominator = 0.0
+        for i in range(len(self.data['zone_volumes'])):
+            numerator += self.data['zone_volumes'][i] * zone_temps[i]
+            denominator += self.data['zone_volumes'][i]
+        average_temp = numerator / denominator
+        self.api.exchange.set_global_value(state, self.data['avg_temp_variable'], average_temp)
+        return 0
+"""
+
+pluginPath = File.join(File.dirname(__FILE__), 'python_plugin_program.py')
+File.write(pluginPath, python_plugin_file_content)
+
 # create the external file object
-file_name = File.join(File.dirname(__FILE__), 'lib/PythonPluginThermochromicWindow.py')
-file_name = File.realpath(file_name)
-external_file = OpenStudio::Model::ExternalFile.getExternalFile(model, file_name)
+external_file = OpenStudio::Model::ExternalFile.getExternalFile(model, pluginPath)
 external_file = external_file.get
 
 # create the python plugin instance object
-python_plugin_instance = OpenStudio::Model::PythonPluginInstance.new(external_file, 'ZN_1_wall_south_Window_1_Control')
+python_plugin_instance = OpenStudio::Model::PythonPluginInstance.new(external_file, 'AverageZoneTemps')
+python_plugin_instance.setRunDuringWarmupDays(false)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -856,6 +856,15 @@ class ModelTests < Minitest::Test
     result = sim_test('pv_and_storage_demandleveling.osm')
   end
 
+  def test_python_plugin_rb
+    result = sim_test('python_plugin.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.4.0
+  # def test_python_plugin_osm
+  # result = sim_test('python_plugin.osm')
+  # end
+
   def test_refrigeration_system_rb
     result = sim_test('refrigeration_system.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstrating https://github.com/NREL/OpenStudio/pull/4600

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4600/OpenStudio-3.4.1-alpha%2Bcb946eee32-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
