### PR TITLE
Fix #4543 - E+ 22.1.0: Wrap SetpointManager:SystemNodeReset:Temperature and SetpointManager:SystemNodeReset:Humidity

### DIFF
--- a/model/simulationtests/setpoint_manager_systemnodereset.rb
+++ b/model/simulationtests/setpoint_manager_systemnodereset.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# This test aims to test the new 'Adiabatic Surface Construction Name' field
+# added in the OS:DefaultConstructionSet
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# add ASHRAE System type 07, VAV w/ Reheat
+model.add_hvac({ 'ashrae_sys_num' => '07' })
+
+# In order to produce more consistent results between different runs,
+# We ensure we do get the same object each time
+boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
+heating_loop = boilers.first.plantLoop.get
+heating_loop.setName('HW Loop')
+cc = model.getCoilCoolingWaters.sort_by { |c| c.name.to_s }.first
+
+a = cc.airLoopHVAC.get
+a_temp_spm = OpenStudio::Model::SetpointManagerSystemNodeResetTemperature.new(model)
+a_temp_spm.setName("Supply Air Temp Setpoint Manager")
+a_temp_spm.setControlVariable("Temperature")
+a_temp_spm.setSetpointatLowReferenceTemperature(16.7)
+a_temp_spm.setSetpointatHighReferenceTemperature(12.8)
+a_temp_spm.setLowReferenceTemperature(20.0)
+a_temp_spm.setHighReferenceTemperature(23.3)
+a_temp_spm.setReferenceNode(a.supplyInletNode)
+a_temp_spm.addToNode(a.supplyOutletNode)
+
+# This is only allowed on an AirLoopHVAC, not a PlantLoop
+a_hum_spm = OpenStudio::Model::SetpointManagerSystemNodeResetHumidity.new(model)
+a_hum_spm.setName("Dehumidification Setpoint Manager")
+a_hum_spm.setControlVariable("MaximumHumidityRatio")
+a_hum_spm.setSetpointatLowReferenceHumidityRatio(0.00924)
+a_hum_spm.setSetpointatHighReferenceHumidityRatio(0.00600)
+a_hum_spm.setLowReferenceHumidityRatio(0.00850)
+a_hum_spm.setHighReferenceHumidityRatio(0.01000)
+a_hum_spm.setReferenceNode(a.supplyInletNode)
+a_hum_spm.addToNode(cc.airOutletModelObject.get.to_Node.get)
+
+# You're better off using a SetpointManagerOutdoorAirReset for this specific
+# application FYI, but this is a demonstration
+p_temp_spm = OpenStudio::Model::SetpointManagerSystemNodeResetTemperature.new(model)
+p_temp_spm.setName("Hot Water Loop Setpoint Manager")
+p_temp_spm.setControlVariable("Temperature")
+p_temp_spm.setSetpointatLowReferenceTemperature(80.0)
+p_temp_spm.setSetpointatHighReferenceTemperature(65.6)
+p_temp_spm.setLowReferenceTemperature(-6.7)
+p_temp_spm.setHighReferenceTemperature(10.0)
+p_temp_spm.setReferenceNode(model.outdoorAirNode)
+p_temp_spm.addToNode(heating_loop.supplyOutletNode)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/setpoint_manager_systemnodereset.rb
+++ b/model/simulationtests/setpoint_manager_systemnodereset.rb
@@ -65,6 +65,8 @@ a_hum_spm.setLowReferenceHumidityRatio(0.00850)
 a_hum_spm.setHighReferenceHumidityRatio(0.01000)
 a_hum_spm.setReferenceNode(a.supplyInletNode)
 a_hum_spm.addToNode(cc.airOutletModelObject.get.to_Node.get)
+# Also need to switch the controller water coil to enable dehumidification
+cc.controllerWaterCoil.get.setControlVariable("TemperatureAndHumidityRatio")
 
 # You're better off using a SetpointManagerOutdoorAirReset for this specific
 # application FYI, but this is a demonstration

--- a/model/simulationtests/setpoint_manager_systemnodereset.rb
+++ b/model/simulationtests/setpoint_manager_systemnodereset.rb
@@ -42,12 +42,12 @@ model.add_hvac({ 'ashrae_sys_num' => '07' })
 boilers = model.getBoilerHotWaters.sort_by { |c| c.name.to_s }
 heating_loop = boilers.first.plantLoop.get
 heating_loop.setName('HW Loop')
-cc = model.getCoilCoolingWaters.sort_by { |c| c.name.to_s }.first
+cc = model.getCoilCoolingWaters.min_by { |c| c.name.to_s }
 
 a = cc.airLoopHVAC.get
 a_temp_spm = OpenStudio::Model::SetpointManagerSystemNodeResetTemperature.new(model)
-a_temp_spm.setName("Supply Air Temp Setpoint Manager")
-a_temp_spm.setControlVariable("Temperature")
+a_temp_spm.setName('Supply Air Temp Setpoint Manager')
+a_temp_spm.setControlVariable('Temperature')
 a_temp_spm.setSetpointatLowReferenceTemperature(16.7)
 a_temp_spm.setSetpointatHighReferenceTemperature(12.8)
 a_temp_spm.setLowReferenceTemperature(20.0)
@@ -57,8 +57,8 @@ a_temp_spm.addToNode(a.supplyOutletNode)
 
 # This is only allowed on an AirLoopHVAC, not a PlantLoop
 a_hum_spm = OpenStudio::Model::SetpointManagerSystemNodeResetHumidity.new(model)
-a_hum_spm.setName("Dehumidification Setpoint Manager")
-a_hum_spm.setControlVariable("MaximumHumidityRatio")
+a_hum_spm.setName('Dehumidification Setpoint Manager')
+a_hum_spm.setControlVariable('MaximumHumidityRatio')
 a_hum_spm.setSetpointatLowReferenceHumidityRatio(0.00924)
 a_hum_spm.setSetpointatHighReferenceHumidityRatio(0.00600)
 a_hum_spm.setLowReferenceHumidityRatio(0.00850)
@@ -66,13 +66,13 @@ a_hum_spm.setHighReferenceHumidityRatio(0.01000)
 a_hum_spm.setReferenceNode(a.supplyInletNode)
 a_hum_spm.addToNode(cc.airOutletModelObject.get.to_Node.get)
 # Also need to switch the controller water coil to enable dehumidification
-cc.controllerWaterCoil.get.setControlVariable("TemperatureAndHumidityRatio")
+cc.controllerWaterCoil.get.setControlVariable('TemperatureAndHumidityRatio')
 
 # You're better off using a SetpointManagerOutdoorAirReset for this specific
 # application FYI, but this is a demonstration
 p_temp_spm = OpenStudio::Model::SetpointManagerSystemNodeResetTemperature.new(model)
-p_temp_spm.setName("Hot Water Loop Setpoint Manager")
-p_temp_spm.setControlVariable("Temperature")
+p_temp_spm.setName('Hot Water Loop Setpoint Manager')
+p_temp_spm.setControlVariable('Temperature')
 p_temp_spm.setSetpointatLowReferenceTemperature(80.0)
 p_temp_spm.setSetpointatHighReferenceTemperature(65.6)
 p_temp_spm.setLowReferenceTemperature(-6.7)

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -944,6 +944,15 @@ class ModelTests < Minitest::Test
     result = sim_test('setpoint_managers.osm')
   end
 
+  def test_setpoint_manager_systemnodereset_rb
+    result = sim_test('setpoint_manager_systemnodereset.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.4.0
+  # def test_setpoint_manager_systemnodereset_osm
+  #   result = sim_test('setpoint_manager_systemnodereset.osm')
+  # end
+
   def test_shadingcontrol_singlezone_rb
     result = sim_test('shadingcontrol_singlezone.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

- Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/issues/4543
- Companion PR: https://github.com/NREL/OpenStudio/pull/4619

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4619/OpenStudio-3.4.1-alpha%2B0b68267784-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with companion PR (incude SHA): https://github.com/NREL/OpenStudio/pull/4619/commits/99c003dc863764919f4af826c1c3bc1378ead693
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.

        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
         - See: https://github.com/NREL/OpenStudio-resources/runs/7091698715?check_suite_focus=true#step:11:771
 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**
     - **N/A** 

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] Object is tested in `autosize_hvac` as appropriate
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
