### PR TITLE
Addresses #4615, wrap OutputControl:Table:Style and Output:SQLite

### DIFF
--- a/model/simulationtests/output_objects_2.rb
+++ b/model/simulationtests/output_objects_2.rb
@@ -49,16 +49,16 @@ z.setUseIdealAirLoads(true)
 ###############################################################################
 
 outputcontrol_table_style = model.getOutputControlTableStyle
-outputcontrol_table_style.setColumnSeparator("HTML")
-outputcontrol_table_style.setUnitConversion("InchPound")
+outputcontrol_table_style.setColumnSeparator('HTML')
+outputcontrol_table_style.setUnitConversion('InchPound')
 
 ###############################################################################
 #                                 OUTPUT:SQLITE                               #
 ###############################################################################
 
 output_sqlite = model.getOutputSQLite
-output_sqlite.setOptionType("SimpleAndTabular")
-output_sqlite.setUnitConversionforTabularData("None")
+output_sqlite.setOptionType('SimpleAndTabular')
+output_sqlite.setUnitConversionforTabularData('None')
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,

--- a/model/simulationtests/output_objects_2.rb
+++ b/model/simulationtests/output_objects_2.rb
@@ -2,8 +2,8 @@
 
 # This test aims to test the new **Unique** ModelObjects related to Output
 # added in 3.5.0:
-# * OutputControlTableStyle,
-# * OutputSQLite,
+# * OutputControlTableStyle
+# * OutputSQLite
 
 require 'openstudio'
 require_relative 'lib/baseline_model'

--- a/model/simulationtests/output_objects_2.rb
+++ b/model/simulationtests/output_objects_2.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# This test aims to test the new **Unique** ModelObjects related to Output
+# added in 3.5.0:
+# * OutputControlTableStyle,
+# * OutputSQLite,
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+###############################################################################
+#                             OUTPUTCONTROL:TABLE:STYLE                       #
+###############################################################################
+
+outputcontrol_table_style = model.getOutputControlTableStyle
+outputcontrol_table_style.setColumnSeparator("HTML")
+outputcontrol_table_style.setUnitConversion("InchPound")
+
+###############################################################################
+#                                 OUTPUT:SQLITE                               #
+###############################################################################
+
+output_sqlite = model.getOutputSQLite
+output_sqlite.setOptionType("SimpleAndTabular")
+output_sqlite.setUnitConversionforTabularData("None")
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -768,6 +768,15 @@ class ModelTests < Minitest::Test
     result = sim_test('output_objects.osm')
   end
 
+  def test_output_objects_2_rb
+    result = sim_test('output_objects_2.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.4.0
+  # def test_output_objects_2_osm
+  # result = sim_test('output_objects_2.osm')
+  # end
+
   def test_performanceprecisiontradeoffs_rb
     result = sim_test('performanceprecisiontradeoffs.rb')
   end
@@ -877,7 +886,7 @@ class ModelTests < Minitest::Test
     result = sim_test('refrigeration_system_2.rb')
   end
 
-  def test_refrigeration_system__2_osm
+  def test_refrigeration_system_2_osm
     result = sim_test('refrigeration_system_2.osm')
   end
 


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstrating https://github.com/NREL/OpenStudio/pull/4625

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4625/OpenStudio-3.4.1-alpha%2B3c33c84f02-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for:

* OutputControl:Table:Style
* Output:SQLite

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - with official OpenStudio release (include version):

     - [x] with current develop (incude SHA): https://github.com/NREL/OpenStudio/pull/4625
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
         - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [x] Code style (indentation, variable names, strip trailing spaces)
 - [x] Functional code review (it has to work!)
 - [x] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [x] Appropriate `out.osw` have been committed
 - [x] Test is stable
 - [x] Object is tested in `autosize_hvac` as appropriate
 - [x] The appropriate labels have been added to this PR:
   - [x] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [x] If `NewTest`: add `PendingOSM` or `AddedOSM`
