### PR TITLE
Addresses #3666, new test for Coil:WaterHeating:Desuperheater with Refrigeration:Condenser:AirCooled heating source

### DIFF
--- a/model/simulationtests/coil_waterheating_desuperheater_2.rb
+++ b/model/simulationtests/coil_waterheating_desuperheater_2.rb
@@ -33,6 +33,7 @@ def create_refrigeration_test(model, zone, defrost_sch)
   # create a refrigeration system with a case and compressor
   ref_sys1 = OpenStudio::Model::RefrigerationSystem.new(model)
   ref_sys1.addCase(add_case(model, zone, defrost_sch))
+  ref_sys1.addCase(add_case(model, zone, defrost_sch))
   ref_sys1.addCompressor(OpenStudio::Model::RefrigerationCompressor.new(model))
 
   # create aircooled refrigeration condenser

--- a/model/simulationtests/coil_waterheating_desuperheater_2.rb
+++ b/model/simulationtests/coil_waterheating_desuperheater_2.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+def add_case(model, thermal_zone, defrost_sch)
+  ref_case = OpenStudio::Model::RefrigerationCase.new(model, defrost_sch)
+  ref_case.setThermalZone(thermal_zone)
+  return ref_case
+end
+
+# Tests a desuperheater with:
+# * Heat Rejection Target: WaterHeaterMixed
+# * Heating source: RefrigerationCondenserAirCooled.
+#
+# @param model [BaselineModel] The model in which to create it
+# @param zone [OpenStudio::Model::ThermalZone] the zone in question (has a
+# PSZ-AC that we'll mess with to add an AirLoopHVACUnitary with the
+# CoilCoolingDXMultiSpeed)
+# @return [OpenStudio::Model::CoilWaterHeatingDesuperheater]
+def create_refrigeration_test(model, zone, defrost_sch)
+  # create desuperheater object
+  setpoint_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model, 60)
+  coil_water_heating_desuperheater_multi = OpenStudio::Model::CoilWaterHeatingDesuperheater.new(model, setpoint_temp_sch)
+  coil_water_heating_desuperheater_multi.setRatedHeatReclaimRecoveryEfficiency(0.85)
+
+  # Create a SHW Loop with a Mixed Water Heater
+  mixed_swh_loop = model.add_swh_loop('Mixed')
+  water_heater_mixed = mixed_swh_loop.supplyComponents('OS:WaterHeater:Mixed'.to_IddObjectType)[0].to_WaterHeaterMixed.get
+  # Add it as a heat rejection target
+  coil_water_heating_desuperheater_multi.addToHeatRejectionTarget(water_heater_mixed)
+
+  # create a refrigeration system with a case and compressor
+  ref_sys1 = OpenStudio::Model::RefrigerationSystem.new(model)
+  ref_sys1.addCase(add_case(model, zone, defrost_sch))
+  ref_sys1.addCompressor(OpenStudio::Model::RefrigerationCompressor.new(model))
+
+  # create aircooled refrigeration condenser
+  refrigeration_condenser_aircooled = OpenStudio::Model::RefrigerationCondenserAirCooled.new(model)
+
+  # set it as the condenser of the refrigeration system
+  ref_sys1.setRefrigerationCondenser(refrigeration_condenser_aircooled)
+
+  # And Set it as the heating source of the Desuperheater
+  coil_water_heating_desuperheater_multi.setHeatingSource(refrigeration_condenser_aircooled)
+
+  return coil_water_heating_desuperheater_multi
+end
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 1 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# add ASHRAE System type 03, PSZ-AC
+model.add_hvac({ 'ashrae_sys_num' => '03' })
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+
+###############################################################################
+#                  (2) T E S T    R E F R I G E R A T I O N                   #
+###############################################################################
+
+# Schedule Ruleset
+defrost_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+defrost_sch.setName('Refrigeration Defrost Schedule')
+# All other days
+defrost_sch.defaultDaySchedule.setName('Refrigeration Defrost Schedule Default')
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 4, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 4, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 8, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 8, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 12, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 12, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 16, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 16, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 20, 0, 0), 0)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 20, 45, 0), 1)
+defrost_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0)
+
+# Tests a desuperheater with:
+# * Heat Rejection Target: WaterHeaterMixed
+# * Heating source: RefrigrationCondenserAirCooled.
+create_refrigeration_test(model, zones[0], defrost_sch)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd, 'osm_name' => 'in.osm' })

--- a/model/simulationtests/coil_waterheating_desuperheater_2.rb
+++ b/model/simulationtests/coil_waterheating_desuperheater_2.rb
@@ -50,7 +50,7 @@ end
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 1 zone core/perimeter building
+# make a 1 story, 100m X 50m, 1 zone core/perimeter building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
                      'num_floors' => 1,

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -517,6 +517,15 @@ class ModelTests < Minitest::Test
     result = sim_test('coil_waterheating_desuperheater.rb')
   end
 
+  # TODO: To be added in the next official release after: 3.4.0
+  # def test_coil_waterheating_desuperheater_2_osm
+  # result = sim_test('coil_waterheating_desuperheater_2.osm')
+  # end
+
+  def test_coil_waterheating_desuperheater_2_rb
+    result = sim_test('coil_waterheating_desuperheater_2.rb')
+  end
+
   def test_headered_pumps_osm
     result = sim_test('headered_pumps.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Tests demonstrating that RatedHeatReclaimRecoveryEfficiency > 0.3 (and less than 0.9) is valid when Heating Source is Refrigeration:Condenser:XXX.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4629/OpenStudio-3.4.1-alpha%2Bf067327f4e-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
