### PR TITLE
Remove deprecated methods for AirWallMaterial, Node, SizingSystem, ZoneAirMassFlowConservation

### DIFF
--- a/model/refbuildingtests/measures/AddHVACSystem.rb
+++ b/model/refbuildingtests/measures/AddHVACSystem.rb
@@ -137,7 +137,7 @@ class AddHVACSystem < OpenStudio::Ruleset::ModelUserScript
         hvac = hvac.to_AirLoopHVAC.get
         hvac.addBranchForZone(zone)
         outlet_node = hvac.supplyOutletNode
-        setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+        setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
         setpoint_manager.setControlZone(zone)
       end
 
@@ -200,7 +200,7 @@ class AddHVACSystem < OpenStudio::Ruleset::ModelUserScript
         hvac = hvac.to_AirLoopHVAC.get
         hvac.addBranchForZone(zone)
         outlet_node = hvac.supplyOutletNode
-        setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+        setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
         setpoint_manager.setControlZone(zone)
       end
 
@@ -212,7 +212,7 @@ class AddHVACSystem < OpenStudio::Ruleset::ModelUserScript
         hvac = hvac.to_AirLoopHVAC.get
         hvac.addBranchForZone(zone)
         outlet_node = hvac.supplyOutletNode
-        setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+        setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
         setpoint_manager.setControlZone(zone)
       end
     #if system number is not recognized

--- a/model/simulationtests/afn_single_zone_ac.rb
+++ b/model/simulationtests/afn_single_zone_ac.rb
@@ -196,7 +196,11 @@ def addSimpleSystemAFN(model)
   # set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn('Sensible')
   sizingSystem.autosizeDesignOutdoorAirFlowRate
-  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0)
+  if Gem::Version.new(OpenStudio.openStudioVersion) >= Gem::Version.new('3.3.0')
+    sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0)
+  else
+    sizingSystem.setMinimumSystemAirFlowRatio(1.0)
+  end
   sizingSystem.setPreheatDesignTemperature(7.0)
   sizingSystem.setPreheatDesignHumidityRatio(0.008)
   sizingSystem.setPrecoolDesignTemperature(12.8)

--- a/model/simulationtests/afn_single_zone_ac.rb
+++ b/model/simulationtests/afn_single_zone_ac.rb
@@ -53,7 +53,7 @@ def addSystemType3(model)
   # set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn('Sensible')
   sizingSystem.autosizeDesignOutdoorAirFlowRate
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0)
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0)
   sizingSystem.setPreheatDesignTemperature(7.0)
   sizingSystem.setPreheatDesignHumidityRatio(0.008)
   sizingSystem.setPrecoolDesignTemperature(12.8)
@@ -125,7 +125,7 @@ def addSimpleSystem(model)
   # set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn('Sensible')
   sizingSystem.autosizeDesignOutdoorAirFlowRate
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0)
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0)
   sizingSystem.setPreheatDesignTemperature(7.0)
   sizingSystem.setPreheatDesignHumidityRatio(0.008)
   sizingSystem.setPrecoolDesignTemperature(12.8)
@@ -196,7 +196,7 @@ def addSimpleSystemAFN(model)
   # set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn('Sensible')
   sizingSystem.autosizeDesignOutdoorAirFlowRate
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0)
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0)
   sizingSystem.setPreheatDesignTemperature(7.0)
   sizingSystem.setPreheatDesignHumidityRatio(0.008)
   sizingSystem.setPrecoolDesignTemperature(12.8)
@@ -371,7 +371,7 @@ hvac = addSimpleSystemAFN(model)
 hvac = hvac.to_AirLoopHVAC.get
 hvac.addBranchForZone(zone)
 outlet_node = hvac.supplyOutletNode
-setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
 setpoint_manager.setControlZone(zone)
 
 # add ASHRAE System type 08, VAV w/ PFP Boxes

--- a/model/simulationtests/availability_managers.rb
+++ b/model/simulationtests/availability_managers.rb
@@ -40,15 +40,27 @@ systems.each_with_index do |system, i|
     ventilationTemperatureSchedule = OpenStudio::Model::ScheduleRuleset.new(model)
     ventilationTemperatureSchedule.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 18.0)
     avm.setVentilationTemperatureSchedule(ventilationTemperatureSchedule)
-    system.setAvailabilityManager(avm)
+    if Gem::Version.new(OpenStudio.openStudioVersion) >= Gem::Version.new('2.3.1')
+      system.setAvailabilityManagers([avm])
+    else
+      system.setAvailabilityManager(avm)
+    end
 
   when 1
     avm = OpenStudio::Model::AvailabilityManagerOptimumStart.new(model)
-    system.setAvailabilityManager(avm)
+    if Gem::Version.new(OpenStudio.openStudioVersion) >= Gem::Version.new('2.3.1')
+      system.setAvailabilityManagers([avm])
+    else
+      system.setAvailabilityManager(avm)
+    end
 
   when 2
     avm = OpenStudio::Model::AvailabilityManagerHybridVentilation.new(model)
-    system.setAvailabilityManager(avm)
+    if Gem::Version.new(OpenStudio.openStudioVersion) >= Gem::Version.new('2.3.1')
+      system.setAvailabilityManagers([avm])
+    else
+      system.setAvailabilityManager(avm)
+    end
 
   when 3
     system.setNightCycleControlType('CycleOnAny')

--- a/model/simulationtests/lib/baseline_model.rb
+++ b/model/simulationtests/lib/baseline_model.rb
@@ -361,7 +361,7 @@ class BaselineModel < OpenStudio::Model::Model
           hvac = hvac.to_AirLoopHVAC.get
           hvac.addBranchForZone(zone)
           outlet_node = hvac.supplyOutletNode
-          setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+          setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
           # Set appropriate min/max temperatures (matches Zone Heat/Cool
           # sizing parameters)
           setpoint_manager.setMinimumSupplyAirTemperature(14)
@@ -375,7 +375,7 @@ class BaselineModel < OpenStudio::Model::Model
           hvac = hvac.to_AirLoopHVAC.get
           hvac.addBranchForZone(zone)
           outlet_node = hvac.supplyOutletNode
-          setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+          setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
           setpoint_manager.setControlZone(zone)
         end
       # 5: Packaged VAV w/ Reheat
@@ -413,7 +413,7 @@ class BaselineModel < OpenStudio::Model::Model
           hvac = hvac.to_AirLoopHVAC.get
           hvac.addBranchForZone(zone)
           outlet_node = hvac.supplyOutletNode
-          setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+          setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
           setpoint_manager.setControlZone(zone)
         end
       # 10: Warm air furnace, electric
@@ -423,7 +423,7 @@ class BaselineModel < OpenStudio::Model::Model
           hvac = hvac.to_AirLoopHVAC.get
           hvac.addBranchForZone(zone)
           outlet_node = hvac.supplyOutletNode
-          setpoint_manager = outlet_node.getSetpointManagerSingleZoneReheat.get
+          setpoint_manager = outlet_node.setpointManagers.select { |spm| spm.to_SetpointManagerSingleZoneReheat.is_initialized }.first.to_SetpointManagerSingleZoneReheat.get
           setpoint_manager.setControlZone(zone)
         end
       # if system number is not recognized

--- a/model/simulationtests/lib/baseline_model.rb
+++ b/model/simulationtests/lib/baseline_model.rb
@@ -453,10 +453,14 @@ class BaselineModel < OpenStudio::Model::Model
     building.setDefaultConstructionSet(default_construction_set)
 
     # get the air wall
-    construction_library.getConstructions.each do |c|
-      if c.name.to_s.strip == 'Air_Wall'
-        c.clone(self)
-        break
+    if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('3.4.0')
+      construction_library.getConstructionAirBoundarys.first.clone(self)
+    else
+      construction_library.getConstructions.each do |c|
+        if c.name.to_s.strip == 'Air_Wall'
+          c.clone(self)
+          break
+        end
       end
     end
   end

--- a/model/simulationtests/lifecyclecostparameters.rb
+++ b/model/simulationtests/lifecyclecostparameters.rb
@@ -9,9 +9,13 @@ lifeCycleCostParameters.setAnalysisType('FEMP')
 lifeCycleCostParameters.setLengthOfStudyPeriodInYears(25)
 
 model.getConstructions.each do |construction|
-  layers = construction.layers
-  if layers.size == 1 && !layers[0].to_AirWallMaterial.empty?
-    next
+  if Gem::Version.new(OpenStudio.openStudioVersion) < Gem::Version.new('2.9.0')
+    # At 2.9.0 and above, the ConstructionAirBoundary is used, and it's not
+    # part of the m.getConstructions
+    layers = construction.layers
+    if layers.size == 1 && !layers[0].to_AirWallMaterial.empty?
+      next
+    end
   end
 
   material_cost = OpenStudio::Model::LifeCycleCost.createLifeCycleCost('Material Cost', construction, 10.0, 'CostPerArea', 'Construction', 10, 0)

--- a/model/simulationtests/moisture_settings.rb
+++ b/model/simulationtests/moisture_settings.rb
@@ -42,9 +42,10 @@ model.getSurfaces.each do |surface|
   next unless surface.surfaceType.downcase == 'wall'
 
   surface.construction.get.to_Construction.get.layers.each do |layer|
-    next unless layer.to_StandardOpaqueMaterial.is_initialized
+    std_mat_ = layer.to_StandardOpaqueMaterial
+    next unless std_mat_.is_initialized
 
-    layer.createMaterialPropertyMoisturePenetrationDepthSettings(8.9, 0.0069, 0.9066, 0.0404, 22.1121, 0.005, 140) # drywall
+    std_mat_.get.createMaterialPropertyMoisturePenetrationDepthSettings(8.9, 0.0069, 0.9066, 0.0404, 22.1121, 0.005, 140) # drywall
   end
 end
 

--- a/model/simulationtests/zone_fan_exhaust.rb
+++ b/model/simulationtests/zone_fan_exhaust.rb
@@ -84,7 +84,10 @@ m.setSchedule(model.alwaysOnContinuousSchedule)
 # conserve some mass
 zamfc = model.getZoneAirMassFlowConservation
 zamfc.setAdjustZoneMixingForZoneAirMassFlowBalance(true)
-zamfc.setSourceZoneInfiltrationTreatment('AddInfiltrationFlow')
+if Gem::Version.new(OpenStudio.openStudioVersion) <= Gem::Version.new('3.4.0')
+  # Does nothing as of 1.9.3, removed after 3.4.0
+  zamfc.setSourceZoneInfiltrationTreatment('AddInfiltrationFlow')
+end
 
 # add thermostats
 model.add_thermostats({ 'heating_setpoint' => 24,

--- a/model/simulationtests/zone_mixing.rb
+++ b/model/simulationtests/zone_mixing.rb
@@ -33,12 +33,18 @@ model.set_constructions
 
 # make interior walls air walls
 air_wall = nil
-model.getConstructions.each do |c|
-  if c.name.to_s == 'Air_Wall'
-    air_wall = c
-    break
+if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('3.4.0')
+  air_wall = model.getConstructionAirBoundarys.first
+else
+  model.getConstructions.each do |c|
+    if c.name.to_s == 'Air_Wall'
+      air_wall = c
+      break
+    end
   end
 end
+raise "Could not find an AirWall / ConstructionAirBoundary construction" if air_wall.nil?
+
 model.getBuilding.defaultConstructionSet.get.defaultInteriorSurfaceConstructions.get.setWallConstruction(air_wall)
 
 # set whole building space type; simplified 90.1-2004 Large Office Whole Building

--- a/model/simulationtests/zone_mixing.rb
+++ b/model/simulationtests/zone_mixing.rb
@@ -43,7 +43,7 @@ else
     end
   end
 end
-raise "Could not find an AirWall / ConstructionAirBoundary construction" if air_wall.nil?
+raise 'Could not find an AirWall / ConstructionAirBoundary construction' if air_wall.nil?
 
 model.getBuilding.defaultConstructionSet.get.defaultInteriorSurfaceConstructions.get.setWallConstruction(air_wall)
 

--- a/model/simulationtests/zone_mixing.rb
+++ b/model/simulationtests/zone_mixing.rb
@@ -74,7 +74,10 @@ end
 # conserve some mass
 zamfc = model.getZoneAirMassFlowConservation
 zamfc.setAdjustZoneMixingForZoneAirMassFlowBalance(true)
-zamfc.setSourceZoneInfiltrationTreatment('AdjustInfiltrationFlow')
+if Gem::Version.new(OpenStudio.openStudioVersion) <= Gem::Version.new('3.4.0')
+  # Does nothing as of 1.9.3, removed after 3.4.0
+  zamfc.setSourceZoneInfiltrationTreatment('AdjustInfiltrationFlow')
+end
 
 # add design days to the model (Chicago)
 model.add_design_days


### PR DESCRIPTION
Pull request overview
---------------------

* https://github.com/NREL/OpenStudio/pull/4632

This Pull Request is concerning:


 - [x] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description


## TODO

There seem to be some deviations to investigate

![image](https://user-images.githubusercontent.com/5479063/187952088-d3155083-2f3e-496e-9358-bb8275db5e5b.png)

surface_properties_lwr disapeared after I reran. I think they may be unstable... I'll ignore until closer to the RC

----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [x] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [x] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [x] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [x] **If relevant, new fields that can be autosized have been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**






----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
