### PR TITLE
Update to v22.2.0-IOFreeze

### DIFF
--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -828,7 +828,9 @@ zones.each_with_index do |zn, zone_index|
     fan = OpenStudio::Model::FanConstantVolume.new(model, s1)
     htg_coil = OpenStudio::Model::CoilHeatingGas.new(model, s1)
     clg_coil = new_evap_cooling_coil_dx_singlespeed(model)
-    OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, s1, fan, htg_coil, clg_coil).addToThermalZone(zn)
+    ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, s1, fan, htg_coil, clg_coil)
+    ptac.setSupplyAirFanOperatingModeSchedule(s1)
+    ptac.addToThermalZone(zn)
   when 7
     vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlow.new(model)
     # E+ now throws when the CoolingEIRLowPLR has a curve minimum value of x which


### PR DESCRIPTION
Pull request overview
---------------------

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4658/OpenStudio-3.5.0-alpha%2B38858ac1c8-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [x] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.

-----


### Case 4: Other

Fan Schedule cannot be blank anymore for PTAC


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
