### PR TITLE
 Support CoilCoolingDX on AirLoopHVAC

### DIFF
--- a/model/simulationtests/coil_cooling_dx_airloop.rb
+++ b/model/simulationtests/coil_cooling_dx_airloop.rb
@@ -161,7 +161,6 @@ fan.setPressureRise(476.748000740096)
 fan.setMotorEfficiency(1.0)
 fan.setMotorInAirstreamFraction(1.0)
 
-
 # AirLoopHVAC
 air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
 fan.addToNode(air_loop.supplyInletNode)

--- a/model/simulationtests/coil_cooling_dx_airloop.rb
+++ b/model/simulationtests/coil_cooling_dx_airloop.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+m = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+m.add_geometry({ 'length' => 100,
+                 'width' => 50,
+                 'num_floors' => 1,
+                 'floor_to_floor_height' => 4,
+                 'plenum_height' => 0,
+                 'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+m.add_windows({ 'wwr' => 0.4,
+                'offset' => 1,
+                'application_type' => 'Above Floor' })
+
+# add thermostats
+m.add_thermostats({ 'heating_setpoint' => 19,
+                    'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+m.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+m.set_space_type
+
+# add design days to the model (Chicago)
+m.add_design_days
+
+def curve_biquadratic(model, c_1constant, c_2x, c_3xPOW2, c_4y, c_5yPOW2, c_6xTIMESY, minx, maxx, miny, maxy)
+  curve = OpenStudio::Model::CurveBiquadratic.new(model)
+  curve.setCoefficient1Constant(c_1constant)
+  curve.setCoefficient2x(c_2x)
+  curve.setCoefficient3xPOW2(c_3xPOW2)
+  curve.setCoefficient4y(c_4y)
+  curve.setCoefficient5yPOW2(c_5yPOW2)
+  curve.setCoefficient6xTIMESY(c_6xTIMESY)
+  curve.setMinimumValueofx(minx)
+  curve.setMaximumValueofx(maxx)
+  curve.setMinimumValueofy(miny)
+  curve.setMaximumValueofy(maxy)
+  return curve
+end
+
+def curve_quadratic(model, c_1constant, c_2x, c_3xPOW2, minx, maxx, miny, maxy)
+  curve = OpenStudio::Model::CurveQuadratic.new(model)
+  curve.setCoefficient1Constant(c_1constant)
+  curve.setCoefficient2x(c_2x)
+  curve.setCoefficient3xPOW2(c_3xPOW2)
+  curve.setMinimumValueofx(minx)
+  curve.setMaximumValueofx(maxx)
+  curve.setMinimumCurveOutput(miny)
+  curve.setMaximumCurveOutput(maxy)
+  return curve
+end
+
+constant_biquadratic = curve_biquadratic(m, 1, 0, 0, 0, 0, 0, -100, 100, -100, 100)
+
+# CoilCoolingDXCurveFitSpeed
+# speeds correspond to a variable speed central air conditioner
+speed_1 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_1.setGrossTotalCoolingCapacityFraction(1.0)
+speed_1.setGrossSensibleHeatRatio(0.842150793933333)
+speed_1.setGrossCoolingCOP(5.48021287249984)
+
+cool_cap_ft = curve_biquadratic(m, 1.790226088881, -0.0772146982404, 0.00299548780452, 0.0026270330994, -6.81238188e-005, -0.00062105857056, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, -0.1450569952, 0.062239559472, -0.00190953288, -0.012608055432, 0.0010591834752, -0.0003311985672, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_1.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_1.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_1.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_1.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_1.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_1.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_2 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_2.setGrossTotalCoolingCapacityFraction(7137.87761659463 / 4015.05615933448)
+speed_2.setGrossSensibleHeatRatio(0.80758872085)
+speed_2.setGrossCoolingCOP(5.1989191865934)
+
+cool_cap_ft = curve_biquadratic(m, 1.189356223401, -0.0251898606522, 0.0018013099626, 0.004151872233, -4.332993588e-005, -0.0006851085138, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, 1.21042990764, -0.076844452176, 0.00151658244, -0.002526115752, 0.0007214803488, -0.0001603816524, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_2.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_2.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_2.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_2.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_2.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_2.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_3 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_3.setGrossTotalCoolingCapacityFraction(11152.9337759291 / 4015.05615933448)
+speed_3.setGrossSensibleHeatRatio(0.7039025016)
+speed_3.setGrossCoolingCOP(4.64414572911775)
+
+cool_cap_ft = curve_biquadratic(m, -0.300216325722, 0.1194562230534, -0.001862843184, 0.000730227277800001, -3.753475524e-005, -0.00043911348696, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, 0.70183064548, -0.049235917464, 0.00126482472, 0.031408426368, 0.0003622673484, -0.0011050729236, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_3.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_3.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_3.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_3.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_3.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_3.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+speed_4 = OpenStudio::Model::CoilCoolingDXCurveFitSpeed.new(m)
+speed_4.setGrossTotalCoolingCapacityFraction(12937.4031800778 / 4015.05615933448)
+speed_4.setGrossSensibleHeatRatio(0.712483430089655)
+speed_4.setGrossCoolingCOP(4.0695894950265)
+
+cool_cap_ft = curve_biquadratic(m, 0.962249880784, -0.0039087090378, 0.00132934689648, 0.0016072565382, -8.342352e-008, -0.00065486142576, 13.88, 23.88, 18.33, 51.66)
+cool_cap_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_eir_ft = curve_biquadratic(m, -0.74798782608, 0.099914996016, -0.00272789532, 0.026966547, 0.0002513297808, -0.0006019728516, 13.88, 23.88, 18.33, 51.66)
+cool_eir_fff = curve_quadratic(m, 1, 0, 0, 0, 2, 0, 2)
+cool_plf_fplr = curve_quadratic(m, 0.75, 0.25, 0, 0, 1, 0.7, 1)
+
+speed_4.setTotalCoolingCapacityModifierFunctionofTemperatureCurve(cool_cap_ft)
+speed_4.setTotalCoolingCapacityModifierFunctionofAirFlowFractionCurve(cool_cap_fff)
+speed_4.setEnergyInputRatioModifierFunctionofTemperatureCurve(cool_eir_ft)
+speed_4.setEnergyInputRatioModifierFunctionofAirFlowFractionCurve(cool_eir_fff)
+speed_4.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
+speed_4.setWasteHeatModifierFunctionofTemperatureCurve(constant_biquadratic)
+
+# CoilCoolingDXCurveFitOperatingMode
+operating_mode = OpenStudio::Model::CoilCoolingDXCurveFitOperatingMode.new(m)
+operating_mode.setRatedGrossTotalCoolingCapacity(4015.05615933448)
+operating_mode.setMaximumCyclingRate(3)
+operating_mode.setRatioofInitialMoistureEvaporationRateandSteadyStateLatentCapacity(1.5)
+operating_mode.setLatentCapacityTimeConstant(45)
+operating_mode.setNominalTimeforCondensateRemovaltoBegin(1000)
+
+operating_mode.addSpeed(speed_1)
+operating_mode.addSpeed(speed_2)
+operating_mode.addSpeed(speed_3)
+operating_mode.addSpeed(speed_4)
+operating_mode.setNominalSpeedNumber(1)
+
+# CoilCoolingDXCurveFitPerformance
+performance = OpenStudio::Model::CoilCoolingDXCurveFitPerformance.new(m, operating_mode)
+
+# CoilCoolingDX
+coil = OpenStudio::Model::CoilCoolingDX.new(m, performance)
+
+# FanOnOff
+fan = OpenStudio::Model::FanOnOff.new(m)
+fan.setFanEfficiency(0.75)
+fan.setPressureRise(476.748000740096)
+fan.setMotorEfficiency(1.0)
+fan.setMotorInAirstreamFraction(1.0)
+
+
+# AirLoopHVAC
+air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
+fan.addToNode(air_loop.supplyInletNode)
+coil.addToNode(air_loop.supplyInletNode)
+
+# Add to zone
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = m.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+atu = OpenStudio::Model::AirTerminalSingleDuctConstantVolumeNoReheat.new(m, m.alwaysOnDiscreteSchedule)
+air_loop.addBranchForZone(z, atu)
+
+# save the OpenStudio model (.osm)
+m.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                        'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -209,6 +209,15 @@ class ModelTests < Minitest::Test
     result = sim_test('coil_cooling_dx.osm')
   end
 
+  def test_coil_cooling_dx_airloop_rb
+    result = sim_test('coil_cooling_dx_airloop.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.4.0
+  # def test_coil_cooling_dx_airloop_osm
+  #  result = sim_test('coil_cooling_dx_airloop.osm')
+  # end
+
   def test_centralheatpumpsystem_osm
     result = sim_test('centralheatpumpsystem.osm')
   end


### PR DESCRIPTION
Pull request overview
---------------------

Link to relevant GitHub Issue(s) if appropriate: https://github.com/NREL/OpenStudio/pull/4662

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [x] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 2: Fix for an existing test

Please include a link to the specific test you are modifying, and a description of the changes you have made and why they are required.

### Work Checklist

**The change:**
 - [ ] affects site kBTU results
 - [ ] does not affect total site kBTU results

**If it affects total site kBTU:**
 - [ ] Test has been run backwards (see [Instructions for Running Docker](https://github.com/NREL/OpenStudio-resources/blob/develop/doc/Instructions_Docker.md)) for all OpenStudio versions to update numbers
 - [ ] Changes did not make the test fail in older OpenStudio versions where it used to pass
 - [ ] Matching OSM has been replaced with the output of the ruby test for the oldest OpenStudio release where it passes.
 - [ ] All new/changed `out.osw` have been committed for official OpenStudio versions only

**Either way:**

 - [ ] **Ruby test is still stable**: when run multiple times on the same machine, it produces the same total site kBTU.
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign Terminals to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **If relevant, new fields that can be autosized have been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
