### PR TITLE
Add Output:Constructions and Output:Schedules

### DIFF
--- a/model/simulationtests/output_objects_2.rb
+++ b/model/simulationtests/output_objects_2.rb
@@ -4,6 +4,8 @@
 # added in 3.5.0:
 # * OutputControlTableStyle
 # * OutputSQLite
+# * OutputSchedules
+# * OutputConstructions
 
 require 'openstudio'
 require_relative 'lib/baseline_model'
@@ -59,6 +61,21 @@ outputcontrol_table_style.setUnitConversion('InchPound')
 output_sqlite = model.getOutputSQLite
 output_sqlite.setOptionType('SimpleAndTabular')
 output_sqlite.setUnitConversionforTabularData('None')
+
+###############################################################################
+#                              OUTPUT:SCHEDULES                               #
+###############################################################################
+
+output_schedules = model.getOutputSchedules
+output_schedules.setKeyField('Timestep')
+
+###############################################################################
+#                            OUTPUT:CONSTRUCTIONS                             #
+###############################################################################
+
+output_constructions = model.getOutputConstructions
+output_constructions.setReportConstructions(true)
+output_constructions.setReportMaterials(true)
 
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,


### PR DESCRIPTION
Pull request overview
---------------------

Add it to output_objects_2, which is pending OSM already (also for objects added in 3.5.0): 
* https://github.com/NREL/OpenStudio-resources/pull/171

Companion PR: 
* https://github.com/NREL/OpenStudio/pull/4685

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4685/OpenStudio-3.5.0-alpha%2Beab1c244f6-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Output:Constructions and Output:Schedules
cf PR: https://github.com/NREL/OpenStudio/pull/4685

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [x] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------


### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
