### PR TITLE
Fix #4792 - autosized methods

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,12 +80,14 @@ jobs:
                 raise ValueError("Something went wrong when querying {}, status={}".format(url, r.status_code))
                 exit(0)
             data = r.json()
-            matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-20.04.deb' in x['name']]
+            matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-20.04-x86_64.deb' in x['name']]
 
             if len(matched_installers) == 0:
-                matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Linux.deb' in x['name']]
-                if len(matched_installers) ==0:
-                    raise ValueError("Cannot locate latest openstudio installer")
+                matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-20.04.deb' in x['name']]
+                if len(matched_installers) == 0:
+                    matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Linux.deb' in x['name']]
+                    if len(matched_installers) ==0:
+                        raise ValueError("Cannot locate latest openstudio installer")
 
             if len(matched_installers) > 1:
                 print(f"Found more than one potential installer... {matched_installers}. Using the first found")

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -864,6 +864,7 @@ zones.each_with_index do |zn, zone_index|
     ptac.addToThermalZone(zn)
   when 7
     vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlow.new(model)
+    vrf.autosizeResistiveDefrostHeaterCapacity
     # E+ now throws when the CoolingEIRLowPLR has a curve minimum value of x which
     # is higher than the Minimum Heat Pump Part-Load Ratio.
     # The curve has a min of 0.5 here, so set the MinimumHeatPumpPartLoadRatio to

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -1006,7 +1006,7 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     type = os_type.gsub('OS:', '').gsub(':', '')
 
     # Skip objects with no autosizable fields
-    next if autosizable_field_names.empty? and !has_extra_methods
+    next if autosizable_field_names.empty? && !has_extra_methods
 
     # Skip certain object types entirely
     methods_to_skip = obj_types_to_skip[os_type]

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -867,7 +867,8 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       'autosizedDesignGeneratorFluidFlowRate' # Generator loop not supported by OS
     ],
     'OS:AirConditioner:VariableRefrigerantFlow' => [
-      'autosizedWaterCondenserVolumeFlowRate' # Water-cooled VRF not supported by OS
+      'autosizedResistiveDefrostHeaterCapacity', # OS is missing newly added E+ units in 3.6.0: TODO remove in 3.6.1 https://github.com/NREL/EnergyPlus/pull/9898
+      'autosizedWaterCondenserVolumeFlowRate' # Water-cooled VRF not supported by OS (It is nowadays, but can't do both evaporatively cooled and water cooled)
     ],
     'OS:CoolingTower:TwoSpeed' => [
       'autosizedLowSpeedNominalCapacity', # Method only works on cooling towers sized a certain way, which test model isn't using
@@ -877,14 +878,13 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       'autosizedHeatingDesignCapacity', # No OS methods for this field
       'autosizedCoolingDesignCapacity' # No OS methods for this field
     ],
-    # TODO: for this, see https://github.com/NREL/EnergyPlus/pull/9898
     'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl' => [
       'autosizedResistiveDefrostHeaterCapacity', # Missing units in 23.1.0-IOFreeze. TODO: hopefully remove in 23.1.0 official
-      'autosizedRatedEvaporativeCapacity' # As of 23.1.0-IOFreeze, this is never autosized nor reported
+      'autosizedRatedEvaporativeCapacity' # As of 23.1.0, this is never autosized nor reported
     ],
     'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl:HR' => [
       'autosizedResistiveDefrostHeaterCapacity', # Missing units in 23.1.0-IOFreeze. TODO: hopefully remove in 23.1.0 official
-      'autosizedRatedEvaporativeCapacity' # As of 23.1.0-IOFreeze, this is never autosized nor reported
+      'autosizedRatedEvaporativeCapacity' # As of 23.1.0, this is never autosized nor reported
     ],
     'OS:HeatPump:AirToWater:FuelFired:Cooling' => [
       'autosizedDesignTemperatureLift' # E+ is missing it
@@ -981,9 +981,9 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       'autosizedMinimumOutdoorAirFlowRate',
       'autosizedCoolingDesignAirFlowRate',
       'autosizedHeatingDesignAirFlowRate',
-      'coolingDesignLoad',
-      'designAirFlowRate',
-      'heatingDesignLoad'
+      'autosizedCoolingDesignLoad',
+      'autosizedDesignAirFlowRate',
+      'autosizedHeatingDesignLoad'
     ]
   }
 

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -876,7 +876,13 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:ZoneHVAC:LowTemperatureRadiant:VariableFlow' => [
       'autosizedHeatingDesignCapacity', # No OS methods for this field
       'autosizedCoolingDesignCapacity' # No OS methods for this field
-    ]
+    ],
+    # TODO: Temporary pending a new E+ release where we can add several VRF Types
+    # cf https://github.com/NREL/EnergyPlus/pull/9804
+    'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl' => 'all',
+    'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl:HR' => 'all',
+    'OS:Coil:Cooling:DX:VariableRefrigerantFlow:FluidTemperatureControl' => 'all',
+    'OS:Coil:Heating:DX:VariableRefrigerantFlow:FluidTemperatureControl' => 'all'
   }
 
   # Aliases for some OS onjects
@@ -893,7 +899,6 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
   # not exist in the E+ output, even under a different name.
   # These are things the E+ team should fix.
   missing_getters = {
-
     'OS:Coil:Heating:Water:Baseboard:Radiant' => [
       'autosizedHeatingDesignCapacity'
     ],
@@ -935,7 +940,6 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:Fan:ComponentModel' => [
       'autosizedMinimumFlowRate' # Not in E+ SQL
     ]
-
   }
 
   # List of objects and methods where the getter name does not


### PR DESCRIPTION
Pull request overview
---------------------

Companion PR: https://github.com/NREL/OpenStudio/pull/4796

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [x] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

----------------------------------------------------------------------------------------------------------

### Case 4: Other

Add autosizing tests for several new extra methods


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
