### PR TITLE
Add new test for OutputControl:Timestamp

### DIFF
--- a/model/simulationtests/outputcontrol_timestamp.rb
+++ b/model/simulationtests/outputcontrol_timestamp.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+###############################################################################
+#                            OUTPUTCONTROL:TIMESTAMP                          #
+###############################################################################
+
+outputcontrol_timestamp = model.getOutputControlTimestamp
+
+outputcontrol_timestamp.setISO8601Format(true)
+outputcontrol_timestamp.setTimestampatBeginningofInterval(true)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model/simulationtests/outputcontrol_timestamp.rb
+++ b/model/simulationtests/outputcontrol_timestamp.rb
@@ -44,7 +44,7 @@ z.setUseIdealAirLoads(true)
 ###############################################################################
 
 outputcontrol_timestamp = model.getOutputControlTimestamp
- 
+
 outputcontrol_timestamp.setISO8601Format(true)
 outputcontrol_timestamp.setTimestampatBeginningofInterval(true)
 

--- a/model/simulationtests/outputcontrol_timestamp.rb
+++ b/model/simulationtests/outputcontrol_timestamp.rb
@@ -44,7 +44,7 @@ z.setUseIdealAirLoads(true)
 ###############################################################################
 
 outputcontrol_timestamp = model.getOutputControlTimestamp
-
+ 
 outputcontrol_timestamp.setISO8601Format(true)
 outputcontrol_timestamp.setTimestampatBeginningofInterval(true)
 

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -821,6 +821,15 @@ class ModelTests < Minitest::Test
     result = sim_test('outputcontrol_files.osm')
   end
 
+  def test_outputcontrol_timestamp_rb
+    result = sim_test('outputcontrol_timestamp.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.5.1
+  # def test_outputcontrol_timestamp_osm
+    # result = sim_test('outputcontrol_timestamp.osm')
+  # end
+
   def test_output_objects_rb
     result = sim_test('output_objects.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -827,7 +827,7 @@ class ModelTests < Minitest::Test
 
   # TODO: To be added in the next official release after: 3.5.1
   # def test_outputcontrol_timestamp_osm
-    # result = sim_test('outputcontrol_timestamp.osm')
+  # result = sim_test('outputcontrol_timestamp.osm')
   # end
 
   def test_output_objects_rb


### PR DESCRIPTION
Pull request overview
---------------------

Add `outputcontrol_timestamp.rb`.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Linux.deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4808/OpenStudio-3.6.0-alpha%2B40b4031db7-Ubuntu-18.04.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
