### PR TITLE
Fixup autosizing test for VRF

### DIFF
--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -1049,6 +1049,8 @@ zones.each_with_index do |zn, zone_index|
 
   when 41
     vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlowFluidTemperatureControl.new(model)
+    vrf.autosizeRatedEvaporativeCapacity
+    vrf.autosizeResistiveDefrostHeaterCapacity
     coolingCoil = OpenStudio::Model::CoilCoolingDXVariableRefrigerantFlowFluidTemperatureControl.new(model)
     heatingCoil = OpenStudio::Model::CoilHeatingDXVariableRefrigerantFlowFluidTemperatureControl.new(model)
     fan = OpenStudio::Model::FanVariableVolume.new(model)
@@ -1058,6 +1060,8 @@ zones.each_with_index do |zn, zone_index|
 
   when 42
     vrf = OpenStudio::Model::AirConditionerVariableRefrigerantFlowFluidTemperatureControlHR.new(model)
+    vrf.autosizeRatedEvaporativeCapacity
+    vrf.autosizeResistiveDefrostHeaterCapacity
     coolingCoil = OpenStudio::Model::CoilCoolingDXVariableRefrigerantFlowFluidTemperatureControl.new(model)
     heatingCoil = OpenStudio::Model::CoilHeatingDXVariableRefrigerantFlowFluidTemperatureControl.new(model)
     fan = OpenStudio::Model::FanVariableVolume.new(model)

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -876,6 +876,15 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
     'OS:ZoneHVAC:LowTemperatureRadiant:VariableFlow' => [
       'autosizedHeatingDesignCapacity', # No OS methods for this field
       'autosizedCoolingDesignCapacity' # No OS methods for this field
+    ],
+    # TODO: for this, see https://github.com/NREL/EnergyPlus/pull/9898
+    'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl' => [
+      'autosizedResistiveDefrostHeaterCapacity', # Missing units in 23.1.0-IOFreeze. TODO: hopefully remove in 23.1.0 official
+      'autosizedRatedEvaporativeCapacity' # As of 23.1.0-IOFreeze, this is never autosized nor reported
+    ],
+    'OS:AirConditioner:VariableRefrigerantFlow:FluidTemperatureControl:HR' => [
+      'autosizedResistiveDefrostHeaterCapacity', # Missing units in 23.1.0-IOFreeze. TODO: hopefully remove in 23.1.0 official
+      'autosizedRatedEvaporativeCapacity' # As of 23.1.0-IOFreeze, this is never autosized nor reported
     ]
   }
 


### PR DESCRIPTION
Pull request overview
---------------------

Fix autosizing tests

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Ubuntu 20.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/develop/OpenStudio-3.6.0-alpha%2B64d5ff2e1d-Ubuntu-20.04-x86_64.deb


 - [x] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.


----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
