### PR TITLE
Add new test for Schedule:File ctor with path

### DIFF
--- a/model/simulationtests/schedule_file_2.rb
+++ b/model/simulationtests/schedule_file_2.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 
+# This test aims to test the new ScheduleFile ctor that takes a direct path and does not make a copy to the companion directory. Cf NREL/OpenStudio#4857
+
 require 'openstudio'
 require_relative 'lib/baseline_model'
 
 model = BaselineModel.new
 
-# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+# make a 1 story, 100m X 50m, 1 zone building
 model.add_geometry({ 'length' => 100,
                      'width' => 50,
-                     'num_floors' => 2,
+                     'num_floors' => 1,
                      'floor_to_floor_height' => 4,
-                     'plenum_height' => 1,
-                     'perimeter_zone_depth' => 3 })
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
 
 # add windows at a 40% window-to-wall ratio
 model.add_windows({ 'wwr' => 0.4,
                     'offset' => 1,
                     'application_type' => 'Above Floor' })
 
-# add ASHRAE System type 03, PSZ-AC
-model.add_hvac({ 'ashrae_sys_num' => '03' })
-
 # add thermostats
-model.add_thermostats({ 'heating_setpoint' => 24,
-                        'cooling_setpoint' => 28 })
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
 
 # assign constructions from a local library to the walls/windows/etc. in the model
 model.set_constructions
@@ -33,6 +32,14 @@ model.set_space_type
 
 # add design days to the model (Chicago)
 model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+z.setUseIdealAirLoads(true)
 
 ###############################################################################
 

--- a/model/simulationtests/schedule_file_2.rb
+++ b/model/simulationtests/schedule_file_2.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 2 story, 100m X 50m, 10 zone core/perimeter building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 2,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 1,
+                     'perimeter_zone_depth' => 3 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add ASHRAE System type 03, PSZ-AC
+model.add_hvac({ 'ashrae_sys_num' => '03' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+###############################################################################
+
+# Add output variables?
+add_out_vars = false
+
+###############################################################################
+
+# set year to 2013
+yd = model.getYearDescription
+yd.setCalendarYear(2013)
+
+# add schedule file
+file_name = File.join(File.dirname(__FILE__), 'lib/schedulefile.csv')
+file_name = File.realpath(file_name)
+schedule_file = OpenStudio::Model::ScheduleFile.new(model, file_name, 3, 1)
+
+# apply schedule to all lights
+model.getLightss.each do |lights|
+  lights.setSchedule(schedule_file)
+end
+
+if add_out_vars
+  # request hourly output
+  var = OpenStudio::Model::OutputVariable.new('Schedule Value', model)
+  var.setKeyValue('Test Schedule')
+
+  var = OpenStudio::Model::OutputVariable.new('Site Day Type Index', model)
+end
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1032,6 +1032,15 @@ class ModelTests < Minitest::Test
     result = sim_test('schedule_file.osm')
   end
 
+  def test_schedule_file_2_rb
+    result = sim_test('schedule_file_2.rb')
+  end
+
+  # TODO: To be added in the next official release after: 3.5.1
+  # def test_schedule_file_2_osm
+    # result = sim_test('schedule_file_2.osm')
+  # end
+
   def test_schedule_fixed_interval_rb
     result = sim_test('schedule_fixed_interval.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1038,7 +1038,7 @@ class ModelTests < Minitest::Test
 
   # TODO: To be added in the next official release after: 3.5.1
   # def test_schedule_file_2_osm
-    # result = sim_test('schedule_file_2.osm')
+  # result = sim_test('schedule_file_2.osm')
   # end
 
   def test_schedule_fixed_interval_rb


### PR DESCRIPTION
Pull request overview
---------------------

Add `schedule_file_2.rb`.

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Ubuntu 20.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-4857/OpenStudio-3.6.0-alpha%2Bc768d9fddd-Ubuntu-20.04-x86_64.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,

----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [ ] Tests pass either:
     - [ ] with official OpenStudio release (include version):
         - [ ] A matching OSM test has been added from the successful run of the Ruby one with the official OpenStudio release
         - [ ] The label `AddedOSM` has been added to this PR
         - [ ] All new `out.osw` have been committed

     - [ ] with current develop (incude SHA):
         - [ ] The label `PendingOSM` has been added to this PR
         - [ ] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO.
            ```ruby
            def test_airterminal_cooledbeam_rb
              result = sim_test('airterminal_cooledbeam.rb')
            end

            # TODO: To be added in the next official release after: 2.5.0
            # def test_airterminal_fourpipebeam_osm
            #   result = sim_test('airterminal_fourpipebeam.osm')
            # end
            ```
        - [ ] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [ ] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [ ] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------
### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
