### PR TITLE
Add `CLI_SUBCOMMAND` env var to switch between Ruby/C++ CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ we skip the test.
 
 * `USE_EPLUS_SPACES`: if set to True (case-insensitive) or False, forces the `--[no-]space-translation` argument to the openstudio `run` method
 
+* `CLI_SUBCOMMAND`: one of `["classic", "labs"]`, to switch between the Ruby CLI and the C++ CLI (otherwise uses default)
+    * If < 3.5.0, this is ignored (no C++ CLI)
+    * If >= 3.7.0-rc2, labs (C++) is default so passing `labs` is ignored. Conversely, if older, passing `classic` is ignored
+
 Example usage:
 
-    SAVE_IDF=True N=8 CUSTOM_TAG=Ubuntu_run1 DONOTRERUNIFSUCCESS=TRUE openstudio model_tests.rb
+    CLI_SUBCOMMAND=classic SAVE_IDF=True N=8 CUSTOM_TAG=Ubuntu_run1 DONOTRERUNIFSUCCESS=TRUE openstudio model_tests.rb
 
 
 ### Filtering tests to run

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -125,15 +125,14 @@ elsif ENV['USE_EPLUS_SPACES'].to_s.downcase == 'false'
 end
 
 def get_cli_subcommand_from_env(sdk_version_str, debug: false)
-
   cur_sdk_version = Gem::Version.new(sdk_version_str)
   if debug
     puts "sdk_version_str=#{sdk_version_str}, cur_sdk_version=#{cur_sdk_version}"
   end
-  labs_default = cur_sdk_version >= Gem::Version.new("3.7.0-rc2")
+  labs_default = cur_sdk_version >= Gem::Version.new('3.7.0-rc2')
 
   if ENV['CLI_SUBCOMMAND'].nil?
-    default_cli_impl = labs_default ? "labs (C++)" : "classic (Ruby)"
+    default_cli_impl = labs_default ? 'labs (C++)' : 'classic (Ruby)'
     puts "Using the default CLI Implementation: #{default_cli_impl}"
     return ''
   end
@@ -145,20 +144,19 @@ def get_cli_subcommand_from_env(sdk_version_str, debug: false)
   end
 
   cli_sub = ENV['CLI_SUBCOMMAND'].to_s.downcase
-  if !["classic", "labs"].include?(cli_sub.downcase)
-    raise "ERROR: CLI_SUBCOMMAND must be one of [labs, classic]"
+  if !['classic', 'labs'].include?(cli_sub.downcase)
+    raise 'ERROR: CLI_SUBCOMMAND must be one of [labs, classic]'
   end
 
-  is_labs = (cli_sub == "labs")
-
+  is_labs = (cli_sub == 'labs')
 
   if is_labs && labs_default
-    puts "The C++ CLI is already the default, resetting the subcommand to empty"
+    puts 'The C++ CLI is already the default, resetting the subcommand to empty'
     return ''
   end
 
   if !is_labs && !labs_default
-    puts "The Ruby CLI is already the default, resetting the subcommand to empty"
+    puts 'The Ruby CLI is already the default, resetting the subcommand to empty'
     return ''
   end
 


### PR DESCRIPTION
Pull request overview
---------------------


Add `CLI_SUBCOMMAND` env var to switch between Ruby/C++ CLIs

@wenyikuang @kbenne @joseph-robertson FYI.