### PR TITLE
HeatPump:PlantLoop:EIR: Heat Recovery

### DIFF
--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.8.x'
+        python-version: '3.12.2'
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.8.x'
+        python-version: '3.12.2'
 
     - name: Setup python deps
       shell: bash

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.12.2'
 
     - name: Run rubocop
       id: rubocop

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -411,13 +411,13 @@ chw_loop.addSupplyBranchForComponent(plhp_clg)
 cw_loop.addDemandBranchForComponent(plhp_clg)
 
 # AirSource w/ Heat Recovery
-plhp_clg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
-plhp_clg_hr.setReferenceCapacity(400000)
-plhp_clg_hr.autosizeSourceSideReferenceFlowRate
-plhp_clg_hr.autosizeLoadSideReferenceFlowRate
-plhp_clg_hr.autosizeHeatRecoveryReferenceFlowRate
-plhp_clg_hr.setSizingFactor(1)
-chw_loop.addSupplyBranchForComponent(plhp_clg_hr)
+plhp_airsource_clg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
+plhp_airsource_clg_hr.setReferenceCapacity(400000)
+plhp_airsource_clg_hr.autosizeSourceSideReferenceFlowRate
+plhp_airsource_clg_hr.autosizeLoadSideReferenceFlowRate
+plhp_airsource_clg_hr.autosizeHeatRecoveryReferenceFlowRate
+plhp_airsource_clg_hr.setSizingFactor(1)
+chw_loop.addSupplyBranchForComponent(plhp_airsource_clg_hr)
 
 ffhp_airsource_clg = OpenStudio::Model::HeatPumpAirToWaterFuelFiredCooling.new(model)
 ffhp_airsource_clg.autosizeNominalCoolingCapacity
@@ -481,23 +481,26 @@ hw_loop.addSupplyBranchForComponent(plhp_htg)
 cw_loop.addDemandBranchForComponent(plhp_htg)
 
 # AirSource w/ Heat Recovery
-plhp_htg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
-plhp_htg_hr.setReferenceCapacity(80000)
-plhp_htg_hr.autosizeSourceSideReferenceFlowRate
-plhp_htg_hr.autosizeLoadSideReferenceFlowRate
-plhp_htg_hr.autosizeHeatRecoveryReferenceFlowRate
-plhp_htg_hr.setSizingFactor(1.0)
-hw_loop.addSupplyBranchForComponent(plhp_htg_hr)
+plhp_airsource_htg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
+plhp_airsource_htg_hr.setReferenceCapacity(80000)
+plhp_airsource_htg_hr.autosizeSourceSideReferenceFlowRate
+plhp_airsource_htg_hr.autosizeLoadSideReferenceFlowRate
+plhp_airsource_htg_hr.autosizeHeatRecoveryReferenceFlowRate
+plhp_airsource_htg_hr.setSizingFactor(1.0)
+hw_loop.addSupplyBranchForComponent(plhp_airsource_htg_hr)
 
 # WaterSource
 plhp_clg.setCompanionHeatingHeatPump(plhp_htg)
 plhp_htg.setCompanionCoolingHeatPump(plhp_clg)
 
 # AirSource w/ Heat Recovery
-plhp_clg_hr.setCompanionHeatingHeatPump(plhp_htg_hr)
-plhp_htg_hr.setCompanionCoolingHeatPump(plhp_clg_hr)
-chw_loop.addDemandBranchForComponent(plhp_htg_hr, true)
-hw_loop.addDemandBranchForComponent(plhp_clg_hr, true)
+plhp_airsource_clg_hr.setCompanionHeatingHeatPump(plhp_airsource_htg_hr)
+plhp_airsource_htg_hr.setCompanionCoolingHeatPump(plhp_airsource_clg_hr)
+# If not passing tertiary=true here, this would connect the Source Water Side
+# and swich the HP to a WaterSource one
+tertiary = true
+chw_loop.addDemandBranchForComponent(plhp_airsource_htg_hr, tertiary)
+hw_loop.addDemandBranchForComponent(plhp_airsource_clg_hr, tertiary)
 
 ffhp_airsource_htg = OpenStudio::Model::HeatPumpAirToWaterFuelFiredHeating.new(model)
 ffhp_airsource_htg.autosizeNominalHeatingCapacity

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -396,6 +396,7 @@ chw_storage.setSetpointTemperatureSchedule(chw_temp_sch)
 chw_loop.addSupplyBranchForComponent(chw_storage)
 storage_loop.addDemandBranchForComponent(chw_storage)
 
+# WaterSource
 # TODO: I CANNOT GET autosizeReferenceCapacity to work in E+: see https://github.com/NREL/EnergyPlus/issues/8948
 # Yet it is still reported... so whatever
 plhp_clg = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
@@ -403,11 +404,20 @@ plhp_clg.setReferenceCapacity(400000)
 # plhp_clg.autosizeReferenceCapacity
 plhp_clg.autosizeSourceSideReferenceFlowRate
 plhp_clg.autosizeLoadSideReferenceFlowRate
-plhp_clg.autosizeHeatRecoveryReferenceFlowRate
+# plhp_clg.autosizeHeatRecoveryReferenceFlowRate
 plhp_clg.setSizingFactor(1)
 chw_loop.addSupplyBranchForComponent(plhp_clg)
 # The Source Side Volume Flow Rate is reported only for WaterSource apparently
 cw_loop.addDemandBranchForComponent(plhp_clg)
+
+# AirSource w/ Heat Recovery
+plhp_clg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
+plhp_clg_hr.setReferenceCapacity(400000)
+plhp_clg_hr.autosizeSourceSideReferenceFlowRate
+plhp_clg_hr.autosizeLoadSideReferenceFlowRate
+plhp_clg_hr.autosizeHeatRecoveryReferenceFlowRate
+plhp_clg_hr.setSizingFactor(1)
+chw_loop.addSupplyBranchForComponent(plhp_clg_hr)
 
 ffhp_airsource_clg = OpenStudio::Model::HeatPumpAirToWaterFuelFiredCooling.new(model)
 ffhp_airsource_clg.autosizeNominalCoolingCapacity
@@ -457,20 +467,37 @@ hx = OpenStudio::Model::HeatExchangerFluidToFluid.new(model)
 hw_loop.addSupplyBranchForComponent(hx)
 cw_loop.addDemandBranchForComponent(hx)
 
+# WaterSource
 # TODO: I CANNOT GET autosizeReferenceCapacity to work in E+: see https://github.com/NREL/EnergyPlus/issues/8948
 plhp_htg = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
 plhp_htg.setReferenceCapacity(80000)
 # plhp_htg.autosizeReferenceCapacity()
 plhp_htg.autosizeSourceSideReferenceFlowRate
 plhp_htg.autosizeLoadSideReferenceFlowRate
-plhp_htg.autosizeHeatRecoveryReferenceFlowRate
+# plhp_htg.autosizeHeatRecoveryReferenceFlowRate
 plhp_htg.setSizingFactor(1.0)
 hw_loop.addSupplyBranchForComponent(plhp_htg)
 # The Source Side Volume Flow Rate is reported only for WaterSource apparently
 cw_loop.addDemandBranchForComponent(plhp_htg)
 
+# AirSource w/ Heat Recovery
+plhp_htg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
+plhp_htg_hr.setReferenceCapacity(80000)
+plhp_htg_hr.autosizeSourceSideReferenceFlowRate
+plhp_htg_hr.autosizeLoadSideReferenceFlowRate
+plhp_htg_hr.autosizeHeatRecoveryReferenceFlowRate
+plhp_htg_hr.setSizingFactor(1.0)
+hw_loop.addSupplyBranchForComponent(plhp_htg_hr)
+
+# WaterSource
 plhp_clg.setCompanionHeatingHeatPump(plhp_htg)
 plhp_htg.setCompanionCoolingHeatPump(plhp_clg)
+
+# AirSource w/ Heat Recovery
+plhp_clg_hr.setCompanionHeatingHeatPump(plhp_htg_hr)
+plhp_htg_hr.setCompanionCoolingHeatPump(plhp_clg_hr)
+chw_loop.addDemandBranchForComponent(plhp_htg_hr, true)
+hw_loop.addDemandBranchForComponent(plhp_clg_hr, true)
 
 ffhp_airsource_htg = OpenStudio::Model::HeatPumpAirToWaterFuelFiredHeating.new(model)
 ffhp_airsource_htg.autosizeNominalHeatingCapacity

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -412,6 +412,7 @@ cw_loop.addDemandBranchForComponent(plhp_clg)
 
 # AirSource w/ Heat Recovery
 plhp_clg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
+plhp_clg_hr.setName('Heat Pump Plant Loop EIR Cooling Heat Recovery')
 plhp_clg_hr.setReferenceCapacity(400000)
 plhp_clg_hr.autosizeSourceSideReferenceFlowRate
 plhp_clg_hr.autosizeLoadSideReferenceFlowRate
@@ -482,6 +483,7 @@ cw_loop.addDemandBranchForComponent(plhp_htg)
 
 # AirSource w/ Heat Recovery
 plhp_htg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
+plhp_htg_hr.setName('Heat Pump Plant Loop EIR Heating Heat Recovery')
 plhp_htg_hr.setReferenceCapacity(80000)
 plhp_htg_hr.autosizeSourceSideReferenceFlowRate
 plhp_htg_hr.autosizeLoadSideReferenceFlowRate

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -412,7 +412,6 @@ cw_loop.addDemandBranchForComponent(plhp_clg)
 
 # AirSource w/ Heat Recovery
 plhp_clg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
-plhp_clg_hr.setName('Heat Pump Plant Loop EIR Cooling Heat Recovery')
 plhp_clg_hr.setReferenceCapacity(400000)
 plhp_clg_hr.autosizeSourceSideReferenceFlowRate
 plhp_clg_hr.autosizeLoadSideReferenceFlowRate
@@ -483,7 +482,6 @@ cw_loop.addDemandBranchForComponent(plhp_htg)
 
 # AirSource w/ Heat Recovery
 plhp_htg_hr = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
-plhp_htg_hr.setName('Heat Pump Plant Loop EIR Heating Heat Recovery')
 plhp_htg_hr.setReferenceCapacity(80000)
 plhp_htg_hr.autosizeSourceSideReferenceFlowRate
 plhp_htg_hr.autosizeLoadSideReferenceFlowRate

--- a/model/simulationtests/autosize_hvac.rb
+++ b/model/simulationtests/autosize_hvac.rb
@@ -403,6 +403,7 @@ plhp_clg.setReferenceCapacity(400000)
 # plhp_clg.autosizeReferenceCapacity
 plhp_clg.autosizeSourceSideReferenceFlowRate
 plhp_clg.autosizeLoadSideReferenceFlowRate
+plhp_clg.autosizeHeatRecoveryReferenceFlowRate
 plhp_clg.setSizingFactor(1)
 chw_loop.addSupplyBranchForComponent(plhp_clg)
 # The Source Side Volume Flow Rate is reported only for WaterSource apparently
@@ -462,6 +463,7 @@ plhp_htg.setReferenceCapacity(80000)
 # plhp_htg.autosizeReferenceCapacity()
 plhp_htg.autosizeSourceSideReferenceFlowRate
 plhp_htg.autosizeLoadSideReferenceFlowRate
+plhp_htg.autosizeHeatRecoveryReferenceFlowRate
 plhp_htg.setSizingFactor(1.0)
 hw_loop.addSupplyBranchForComponent(plhp_htg)
 # The Source Side Volume Flow Rate is reported only for WaterSource apparently

--- a/model/simulationtests/heatpump_plantloop_eir_heatrecovery.py
+++ b/model/simulationtests/heatpump_plantloop_eir_heatrecovery.py
@@ -1,0 +1,168 @@
+import openstudio
+
+from lib.baseline_model import BaselineModel
+
+model = BaselineModel()
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry(length=100, width=50, num_floors=1, floor_to_floor_height=4, plenum_height=0, perimeter_zone_depth=0)
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows(wwr=0.4, offset=1, application_type="Above Floor")
+
+# add thermostats
+model.add_thermostats(heating_setpoint=24, cooling_setpoint=28)
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+# add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names (only one here anyways...)
+zones = sorted(model.getThermalZones(), key=lambda z: z.nameString())
+zone = zones[0]
+
+###############################################################################
+#                       M A K E    S O M E    L O O P S                       #
+###############################################################################
+
+############### HEATING / COOLING (LOAD) LOOPS  ###############
+
+hw_loop = openstudio.model.PlantLoop(model)
+hw_loop.setName("Hot Water Loop Air Source")
+hw_loop.setMinimumLoopTemperature(10)
+hw_temp_f = 140
+hw_delta_t_r = 20  # 20F delta-T
+hw_temp_c = openstudio.convert(hw_temp_f, "F", "C").get()
+hw_delta_t_k = openstudio.convert(hw_delta_t_r, "R", "K").get()
+hw_temp_sch = openstudio.model.ScheduleRuleset(model)
+hw_temp_sch.defaultDaySchedule().addValue(openstudio.Time(0, 24, 0, 0), hw_temp_c)
+hw_stpt_manager = openstudio.model.SetpointManagerScheduled(model, hw_temp_sch)
+hw_stpt_manager.addToNode(hw_loop.supplyOutletNode())
+sizing_plant = hw_loop.sizingPlant()
+sizing_plant.setLoopType("Heating")
+sizing_plant.setDesignLoopExitTemperature(hw_temp_c)
+sizing_plant.setLoopDesignTemperatureDifference(hw_delta_t_k)
+# Pump
+hw_pump = openstudio.model.PumpVariableSpeed(model)
+hw_pump_head_ft_h2o = 60.0
+hw_pump_head_press_pa = openstudio.convert(hw_pump_head_ft_h2o, "ftH_{2}O", "Pa").get()
+hw_pump.setRatedPumpHead(hw_pump_head_press_pa)
+hw_pump.setPumpControlType("Intermittent")
+hw_pump.addToNode(hw_loop.supplyInletNode())
+
+chw_loop = openstudio.model.PlantLoop(model)
+chw_loop.setName("Chilled Water Loop Air Source")
+chw_loop.setMaximumLoopTemperature(98)
+chw_loop.setMinimumLoopTemperature(1)
+chw_temp_f = 44
+chw_delta_t_r = 10.1  # 10.1F delta-T
+chw_temp_c = openstudio.convert(chw_temp_f, "F", "C").get()
+chw_delta_t_k = openstudio.convert(chw_delta_t_r, "R", "K").get()
+chw_temp_sch = openstudio.model.ScheduleRuleset(model)
+chw_temp_sch.defaultDaySchedule().addValue(openstudio.Time(0, 24, 0, 0), chw_temp_c)
+chw_stpt_manager = openstudio.model.SetpointManagerScheduled(model, chw_temp_sch)
+chw_stpt_manager.addToNode(chw_loop.supplyOutletNode())
+sizing_plant = chw_loop.sizingPlant()
+sizing_plant.setLoopType("Cooling")
+sizing_plant.setDesignLoopExitTemperature(chw_temp_c)
+sizing_plant.setLoopDesignTemperatureDifference(chw_delta_t_k)
+# Pump
+pri_chw_pump = openstudio.model.HeaderedPumpsConstantSpeed(model)
+pri_chw_pump.setName("Chilled Water Loop Primary Pump Air Source")
+pri_chw_pump_head_ft_h2o = 15
+pri_chw_pump_head_press_pa = openstudio.convert(pri_chw_pump_head_ft_h2o, "ftH_{2}O", "Pa").get()
+pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
+pri_chw_pump.setMotorEfficiency(0.9)
+pri_chw_pump.setPumpControlType("Intermittent")
+pri_chw_pump.addToNode(chw_loop.supplyInletNode())
+
+###############################################################################
+#                         A I R    S O U R C E    H P                         #
+###############################################################################
+
+# PlantLoopHeatPump_EIR_AirSource_Hospital_wSixPipeHeatRecovery.idf
+
+plhp_airsource_htg = openstudio.model.HeatPumpPlantLoopEIRHeating(model)
+plhp_airsource_clg = openstudio.model.HeatPumpPlantLoopEIRCooling(model)
+
+plhp_airsource_htg.setName("Heat Pump Plant Loop EIR Heating - AirSource")
+plhp_airsource_htg.setCompanionCoolingHeatPump(plhp_airsource_clg)
+# This is already the default, since it's not connected to any secondary plant loop
+# plhp_airsource_htg.setCondenserType('AirSource')
+
+plhp_airsource_htg.setLoadSideReferenceFlowRate(0.005)
+plhp_airsource_htg.setSourceSideReferenceFlowRate(2.0)
+plhp_airsource_htg.setReferenceCapacity(80000)
+# plhp_airsource_htg.autosizeReferenceCapacity()
+# plhp_airsource_htg.autosizeSourceSideReferenceFlowRate()
+# plhp_airsource_htg.autosizeLoadSideReferenceFlowRate()
+
+plhp_airsource_htg.setReferenceCoefficientofPerformance(3.5)
+plhp_airsource_htg.setSizingFactor(1)
+plhp_airsource_htg.capacityModifierFunctionofTemperatureCurve().setName("CapCurveFuncTemp Air Source")
+plhp_airsource_htg.electricInputtoOutputRatioModifierFunctionofTemperatureCurve().setName("EIRCurveFuncTemp Air Source")
+plhp_airsource_htg.electricInputtoOutputRatioModifierFunctionofPartLoadRatioCurve().setName(
+    "EIRCurveFuncPLR Air Source"
+)
+
+plhp_airsource_clg.setName("Heat Pump Plant Loop EIR Cooling - AirSource")
+plhp_airsource_clg.setCompanionHeatingHeatPump(plhp_airsource_htg)
+# plhp_airsource_clg.setCondenserType('AirSource')
+
+plhp_airsource_clg.setLoadSideReferenceFlowRate(0.005)
+plhp_airsource_clg.setSourceSideReferenceFlowRate(20.0)
+plhp_airsource_clg.setReferenceCapacity(400000)
+# plhp_airsource_clg.autosizeReferenceCapacity()
+# plhp_airsource_clg.autosizeSourceSideReferenceFlowRate()
+# plhp_airsource_clg.autosizeLoadSideReferenceFlowRate()
+
+plhp_airsource_clg.setReferenceCoefficientofPerformance(3.5)
+plhp_airsource_clg.setSizingFactor(1)
+plhp_airsource_clg.capacityModifierFunctionofTemperatureCurve().setName("CapCurveFuncTemp2 Air Source")
+plhp_airsource_clg.electricInputtoOutputRatioModifierFunctionofTemperatureCurve().setName(
+    "EIRCurveFuncTemp2 Air Source"
+)
+plhp_airsource_clg.electricInputtoOutputRatioModifierFunctionofPartLoadRatioCurve().setName(
+    "EIRCurveFuncPLR2 Air Source"
+)
+
+# Note: Heat Recovery is ONLY available for 'AirSource' HeatPumpPlantLoopEIRs
+tertiary = True
+hw_loop.addSupplyBranchForComponent(plhp_airsource_htg)
+# If not passing tertiary=true here, this would connect the Source Water Side
+# and swich the HP to a WaterSource one
+chw_loop.addDemandBranchForComponent(plhp_airsource_htg, tertiary)
+
+chw_loop.addSupplyBranchForComponent(plhp_airsource_clg)
+hw_loop.addDemandBranchForComponent(plhp_airsource_clg, tertiary)
+
+for plhp in [plhp_airsource_htg, plhp_airsource_clg]:
+    assert plhp.condenserType() == "AirSource", f"{plhp.nameString()} is {plhp.condenserType()}, not 'AirSource'"
+    assert not plhp.sourceSideWaterLoop().is_initialized()
+    assert plhp.loadSideWaterLoop().is_initialized()
+    assert plhp.heatRecoveryLoop().is_initialized()
+
+###############################################################
+
+###############################################################################
+#                            Z O N E    L E V E L                             #
+###############################################################################
+
+fourPipeFan = openstudio.model.FanOnOff(model, model.alwaysOnDiscreteSchedule())
+fourPipeHeat = openstudio.model.CoilHeatingWater(model, model.alwaysOnDiscreteSchedule())
+hw_loop.addDemandBranchForComponent(fourPipeHeat)
+fourPipeCool = openstudio.model.CoilCoolingWater(model, model.alwaysOnDiscreteSchedule())
+chw_loop.addDemandBranchForComponent(fourPipeCool)
+fourPipeFanCoil = openstudio.model.ZoneHVACFourPipeFanCoil(
+    model, model.alwaysOnDiscreteSchedule(), fourPipeFan, fourPipeCool, fourPipeHeat
+)
+fourPipeFanCoil.addToThermalZone(zone)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm(osm_save_directory=None, osm_name="in.osm")

--- a/model/simulationtests/heatpump_plantloop_eir_heatrecovery.rb
+++ b/model/simulationtests/heatpump_plantloop_eir_heatrecovery.rb
@@ -91,7 +91,6 @@ pri_chw_pump.setMotorEfficiency(0.9)
 pri_chw_pump.setPumpControlType('Intermittent')
 pri_chw_pump.addToNode(chw_loop.supplyInletNode)
 
-
 ###############################################################################
 #                         A I R    S O U R C E    H P                         #
 ###############################################################################
@@ -143,12 +142,11 @@ hw_loop.addSupplyBranchForComponent(plhp_airsource_htg)
 # and swich the HP to a WaterSource one
 chw_loop.addDemandBranchForComponent(plhp_airsource_htg, tertiary)
 
-
 chw_loop.addSupplyBranchForComponent(plhp_airsource_clg)
 hw_loop.addDemandBranchForComponent(plhp_airsource_clg, tertiary)
 
 [plhp_airsource_htg, plhp_airsource_clg].each do |plhp|
-  raise unless plhp.condenserType == "AirSource"
+  raise unless plhp.condenserType == 'AirSource'
   raise unless plhp.sourceSideWaterLoop.empty?
   raise if plhp.loadSideWaterLoop.empty?
   raise if plhp.heatRecoveryLoop.empty?

--- a/model/simulationtests/heatrecovery_heatpump.rb
+++ b/model/simulationtests/heatrecovery_heatpump.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 24,
+                        'cooling_setpoint' => 28 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names (only one here anyways...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+zone = zones[0]
+
+###############################################################################
+#                       M A K E    S O M E    L O O P S                       #
+###############################################################################
+
+############### HEATING / COOLING (LOAD) LOOPS  ###############
+
+hw_loop = OpenStudio::Model::PlantLoop.new(model)
+hw_loop.setName('Hot Water Loop Air Source')
+hw_loop.setMinimumLoopTemperature(10)
+hw_temp_f = 140
+hw_delta_t_r = 20 # 20F delta-T
+hw_temp_c = OpenStudio.convert(hw_temp_f, 'F', 'C').get
+hw_delta_t_k = OpenStudio.convert(hw_delta_t_r, 'R', 'K').get
+hw_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+hw_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), hw_temp_c)
+hw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(model, hw_temp_sch)
+hw_stpt_manager.addToNode(hw_loop.supplyOutletNode)
+sizing_plant = hw_loop.sizingPlant
+sizing_plant.setLoopType('Heating')
+sizing_plant.setDesignLoopExitTemperature(hw_temp_c)
+sizing_plant.setLoopDesignTemperatureDifference(hw_delta_t_k)
+# Pump
+hw_pump = OpenStudio::Model::PumpVariableSpeed.new(model)
+hw_pump_head_ft_h2o = 60.0
+hw_pump_head_press_pa = OpenStudio.convert(hw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
+hw_pump.setRatedPumpHead(hw_pump_head_press_pa)
+hw_pump.setPumpControlType('Intermittent')
+hw_pump.addToNode(hw_loop.supplyInletNode)
+
+chw_loop = OpenStudio::Model::PlantLoop.new(model)
+chw_loop.setName('Chilled Water Loop Air Source')
+chw_loop.setMaximumLoopTemperature(98)
+chw_loop.setMinimumLoopTemperature(1)
+chw_temp_f = 44
+chw_delta_t_r = 10.1 # 10.1F delta-T
+chw_temp_c = OpenStudio.convert(chw_temp_f, 'F', 'C').get
+chw_delta_t_k = OpenStudio.convert(chw_delta_t_r, 'R', 'K').get
+chw_temp_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+chw_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), chw_temp_c)
+chw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(model, chw_temp_sch)
+chw_stpt_manager.addToNode(chw_loop.supplyOutletNode)
+sizing_plant = chw_loop.sizingPlant
+sizing_plant.setLoopType('Cooling')
+sizing_plant.setDesignLoopExitTemperature(chw_temp_c)
+sizing_plant.setLoopDesignTemperatureDifference(chw_delta_t_k)
+# Pump
+pri_chw_pump = OpenStudio::Model::HeaderedPumpsConstantSpeed.new(model)
+pri_chw_pump.setName('Chilled Water Loop Primary Pump Air Source')
+pri_chw_pump_head_ft_h2o = 15
+pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
+pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
+pri_chw_pump.setMotorEfficiency(0.9)
+pri_chw_pump.setPumpControlType('Intermittent')
+pri_chw_pump.addToNode(chw_loop.supplyInletNode)
+
+############   C O N D E N S E R    S I D E  ##################
+
+cw_loop = OpenStudio::Model::PlantLoop.new(model)
+cw_loop.setName('Condenser Water Loop Water Source')
+cw_loop.setMaximumLoopTemperature(100)
+cw_loop.setMinimumLoopTemperature(3)
+cw_loop.setPlantLoopVolume(1.0)
+cw_temp_sizing_f = 102 # CW sized to deliver 102F
+cw_delta_t_r = 10 # 10F delta-T
+cw_temp_sizing_c = OpenStudio.convert(cw_temp_sizing_f, 'F', 'C').get
+cw_delta_t_k = OpenStudio.convert(cw_delta_t_r, 'R', 'K').get
+
+sizing_plant = cw_loop.sizingPlant
+sizing_plant.setLoopType('Condenser')
+sizing_plant.setDesignLoopExitTemperature(cw_temp_sizing_c)
+sizing_plant.setLoopDesignTemperatureDifference(cw_delta_t_k)
+
+cw_pump = OpenStudio::Model::PumpVariableSpeed.new(model)
+cw_pump.setName('Condenser Water Loop Pump Water Source')
+cw_pump_head_ft_h2o = 60.0
+cw_pump_head_press_pa = OpenStudio.convert(cw_pump_head_ft_h2o, 'ftH_{2}O', 'Pa').get
+cw_pump.setRatedPumpHead(cw_pump_head_press_pa)
+cw_pump.addToNode(cw_loop.supplyInletNode)
+
+groundHX = OpenStudio::Model::GroundHeatExchangerVertical.new(model)
+# THe default isn't the same as the E+ example file (and apparently wrong)
+groundHX.setUTubeDistance(5.1225E-02)
+
+cw_loop.addSupplyBranchForComponent(groundHX)
+
+ground_temp = OpenStudio::Model::SiteGroundTemperatureDeep.new(model)
+ground_temp.setAllMonthlyTemperatures(
+  [13.03, 13.03, 13.13, 13.30, 13.43, 13.52, 13.62, 13.77, 13.78, 13.55, 13.44, 13.20]
+)
+spm_ground = OpenStudio::Model::SetpointManagerFollowGroundTemperature.new(model)
+spm_ground.setControlVariable('Temperature')
+spm_ground.setOffsetTemperatureDifference(0.0)
+spm_ground.setMaximumSetpointTemperature(80.0)
+spm_ground.setMinimumSetpointTemperature(10.0)
+spm_ground.setReferenceGroundTemperatureObjectType('Site:GroundTemperature:Deep')
+spm_ground.addToNode(cw_loop.supplyOutletNode)
+
+############### HEAT RECOVERY  ###############
+
+heat_recovery_loop = OpenStudio::Model::PlantLoop.new(model)
+heat_recovery_loop.setName('HeatRecovery Loop')
+hr_pump = OpenStudio::Model::PumpVariableSpeed.new(model)
+hr_pump.setName("#{heat_recovery_loop.nameString} VSD Pump")
+hr_pump.addToNode(heat_recovery_loop.supplyInletNode)
+
+hr_spm_sch = OpenStudio::Model::ScheduleRuleset.new(model)
+hr_spm_sch.setName('Hot_Water_Temperature')
+hr_spm_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 25.0)
+hr_spm = OpenStudio::Model::SetpointManagerScheduled.new(model, hr_spm_sch)
+hr_spm.addToNode(heat_recovery_loop.supplyOutletNode)
+
+# Water Heater Mixed
+water_heater_mixed = OpenStudio::Model::WaterHeaterMixed.new(model)
+water_heater_mixed.setName('Heat Recovery Tank')
+# The first addSupplyBranchForComponent / addToNode to a supply side will
+# connect the Use Side, so heating loop here
+hw_loop.addSupplyBranchForComponent(water_heater_mixed)
+raise if water_heater_mixed.plantLoop.empty?
+
+# The Second with a supply side node, if use side already connected, will
+# connect the Source Side. You can also be explicit and call
+# addToSourceSideNode
+
+# pipe = OpenStudio::Model::PipeAdiabatic.new(model)
+# heat_recovery_loop.addSupplyBranchForComponent(pipe)
+# water_heater_mixed.addToSourceSideNode(pipe.inletModelObject.get.to_Node.get)
+# pipe.remove
+heat_recovery_loop.addSupplyBranchForComponent(water_heater_mixed)
+
+raise if water_heater_mixed.plantLoop.empty?
+raise if water_heater_mixed.secondaryPlantLoop.empty?
+# More convenient name aliases
+raise if water_heater_mixed.useSidePlantLoop.empty?
+raise if water_heater_mixed.sourceSidePlantLoop.empty?
+raise if water_heater_mixed.useSidePlantLoop.get != hw_loop
+raise if water_heater_mixed.sourceSidePlantLoop.get != heat_recovery_loop
+
+###############################################################################
+#                         A I R    S O U R C E    H P                         #
+###############################################################################
+
+# PlantLoopHeatPump_EIR_AirSource_Hospital_wSixPipeHeatRecovery.idf
+
+plhp_airsource_htg = OpenStudio::Model::HeatPumpPlantLoopEIRHeating.new(model)
+plhp_airsource_clg = OpenStudio::Model::HeatPumpPlantLoopEIRCooling.new(model)
+
+plhp_airsource_htg.setName('Heat Pump Plant Loop EIR Heating - AirSource')
+plhp_airsource_htg.setCompanionCoolingHeatPump(plhp_airsource_clg)
+# This is already the default, since it's not connected to any secondary plant loop
+# plhp_airsource_htg.setCondenserType('AirSource')
+
+plhp_airsource_htg.setLoadSideReferenceFlowRate(0.005)
+plhp_airsource_htg.setSourceSideReferenceFlowRate(2.0)
+plhp_airsource_htg.setReferenceCapacity(80000)
+# plhp_airsource_htg.autosizeReferenceCapacity()
+# plhp_airsource_htg.autosizeSourceSideReferenceFlowRate()
+# plhp_airsource_htg.autosizeLoadSideReferenceFlowRate()
+
+plhp_airsource_htg.setReferenceCoefficientofPerformance(3.5)
+plhp_airsource_htg.setSizingFactor(1)
+plhp_airsource_htg.capacityModifierFunctionofTemperatureCurve.setName('CapCurveFuncTemp Air Source')
+plhp_airsource_htg.electricInputtoOutputRatioModifierFunctionofTemperatureCurve.setName('EIRCurveFuncTemp Air Source')
+plhp_airsource_htg.electricInputtoOutputRatioModifierFunctionofPartLoadRatioCurve.setName('EIRCurveFuncPLR Air Source')
+
+plhp_airsource_clg.setName('Heat Pump Plant Loop EIR Cooling - AirSource')
+plhp_airsource_clg.setCompanionHeatingHeatPump(plhp_airsource_htg)
+# plhp_airsource_clg.setCondenserType('AirSource')
+
+plhp_airsource_clg.setLoadSideReferenceFlowRate(0.005)
+plhp_airsource_clg.setSourceSideReferenceFlowRate(20.0)
+plhp_airsource_clg.setReferenceCapacity(400000)
+# plhp_airsource_clg.autosizeReferenceCapacity()
+# plhp_airsource_clg.autosizeSourceSideReferenceFlowRate()
+# plhp_airsource_clg.autosizeLoadSideReferenceFlowRate()
+
+plhp_airsource_clg.setReferenceCoefficientofPerformance(3.5)
+plhp_airsource_clg.setSizingFactor(1)
+plhp_airsource_clg.capacityModifierFunctionofTemperatureCurve.setName('CapCurveFuncTemp2 Air Source')
+plhp_airsource_clg.electricInputtoOutputRatioModifierFunctionofTemperatureCurve.setName('EIRCurveFuncTemp2 Air Source')
+plhp_airsource_clg.electricInputtoOutputRatioModifierFunctionofPartLoadRatioCurve.setName('EIRCurveFuncPLR2 Air Source')
+
+hw_loop.addSupplyBranchForComponent(plhp_airsource_htg)
+chw_loop.addSupplyBranchForComponent(plhp_airsource_clg)
+cw_loop.addDemandBranchForComponent(plhp_airsource_clg)
+heat_recovery_loop.addDemandBranchForComponent(plhp_airsource_clg)
+
+###############################################################
+
+###############################################################################
+#                            Z O N E    L E V E L                             #
+###############################################################################
+
+fourPipeFan = OpenStudio::Model::FanOnOff.new(model, model.alwaysOnDiscreteSchedule)
+fourPipeHeat = OpenStudio::Model::CoilHeatingWater.new(model, model.alwaysOnDiscreteSchedule)
+hw_loop.addDemandBranchForComponent(fourPipeHeat)
+fourPipeCool = OpenStudio::Model::CoilCoolingWater.new(model, model.alwaysOnDiscreteSchedule)
+chw_loop.addDemandBranchForComponent(fourPipeCool)
+fourPipeFanCoil = OpenStudio::Model::ZoneHVACFourPipeFanCoil.new(model, model.alwaysOnDiscreteSchedule,
+                                                                 fourPipeFan, fourPipeCool, fourPipeHeat)
+fourPipeFanCoil.addToThermalZone(zone)
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -949,10 +949,11 @@ class ModelTests < Minitest::Test
     result = sim_test('heatpump_plantloop_eir_heatrecovery.rb')
   end
 
-  # def test_heatpump_plantloop_eir_heatrecovery_py
-  #   result = sim_test('heatpump_plantloop_eir_heatrecovery.py')
-  # end
+  def test_heatpump_plantloop_eir_heatrecovery_py
+    result = sim_test('heatpump_plantloop_eir_heatrecovery.py')
+  end
 
+  # TODO: To be added in the next official release after: 3.8.0
   # def test_heatpump_plantloop_eir_heatrecovery_osm
   #   result = sim_test('heatpump_plantloop_eir_heatrecovery.osm')
   # end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -969,6 +969,18 @@ class ModelTests < Minitest::Test
     result = sim_test('heatrecovery_chiller.osm')
   end
 
+  def test_heatrecovery_heatpump_rb
+    result = sim_test('heatrecovery_heatpump.rb')
+  end
+
+  # def test_heatrecovery_heatpump_py
+    # result = sim_test('heatrecovery_heatpump.py')
+  # end
+
+  # def test_heatrecovery_heatpump_osm
+    # result = sim_test('heatrecovery_heatpump.osm')
+  # end
+
   def test_hightemprad_rb
     result = sim_test('hightemprad.rb')
   end

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -974,11 +974,11 @@ class ModelTests < Minitest::Test
   end
 
   # def test_heatrecovery_heatpump_py
-    # result = sim_test('heatrecovery_heatpump.py')
+  # result = sim_test('heatrecovery_heatpump.py')
   # end
 
   # def test_heatrecovery_heatpump_osm
-    # result = sim_test('heatrecovery_heatpump.osm')
+  # result = sim_test('heatrecovery_heatpump.osm')
   # end
 
   def test_hightemprad_rb

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -945,6 +945,18 @@ class ModelTests < Minitest::Test
     result = sim_test('heatpump_plantloop_eir.osm')
   end
 
+  def test_heatpump_plantloop_eir_heatrecovery_rb
+    result = sim_test('heatpump_plantloop_eir_heatrecovery.rb')
+  end
+
+  # def test_heatpump_plantloop_eir_heatrecovery_py
+  #   result = sim_test('heatpump_plantloop_eir_heatrecovery.py')
+  # end
+
+  # def test_heatpump_plantloop_eir_heatrecovery_osm
+  #   result = sim_test('heatpump_plantloop_eir_heatrecovery.osm')
+  # end
+
   def test_heatpump_varspeed_rb
     result = sim_test('heatpump_varspeed.rb')
   end
@@ -968,18 +980,6 @@ class ModelTests < Minitest::Test
   def test_heatrecovery_chiller_osm
     result = sim_test('heatrecovery_chiller.osm')
   end
-
-  def test_heatrecovery_heatpump_rb
-    result = sim_test('heatrecovery_heatpump.rb')
-  end
-
-  # def test_heatrecovery_heatpump_py
-  # result = sim_test('heatrecovery_heatpump.py')
-  # end
-
-  # def test_heatrecovery_heatpump_osm
-  # result = sim_test('heatrecovery_heatpump.osm')
-  # end
 
   def test_hightemprad_rb
     result = sim_test('hightemprad.rb')

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -1136,6 +1136,14 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       objs.sort.each do |o|
         obj = o if o.airLoopHVAC.is_initialized
       end
+    when 'HeatPumpPlantLoopEIRHeating' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
+      objs.sort.each do |o|
+        obj = o if o.name.get == 'Heat Pump Plant Loop EIR Heating Heat Recovery'
+      end
+    when 'HeatPumpPlantLoopEIRCooling' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
+      objs.sort.each do |o|
+        obj = o if o.name.get == 'Heat Pump Plant Loop EIR Cooling Heat Recovery'
+      end
     end
 
     # Test all autosizedFoo methods on this instance

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -1138,11 +1138,11 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       end
     when 'HeatPumpPlantLoopEIRHeating' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
       objs.sort.each do |o|
-        obj = o if o.name.get == 'Heat Pump Plant Loop EIR Heating Heat Recovery'
+        obj = o if o.heatRecoveryLoop.is_initialized
       end
     when 'HeatPumpPlantLoopEIRCooling' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
       objs.sort.each do |o|
-        obj = o if o.name.get == 'Heat Pump Plant Loop EIR Cooling Heat Recovery'
+        obj = o if o.heatRecoveryLoop.is_initialized
       end
     end
 

--- a/test_helpers.rb
+++ b/test_helpers.rb
@@ -1136,20 +1136,20 @@ def autosizing_test(filename, weather_file = nil, model_measures = [], energyplu
       objs.sort.each do |o|
         obj = o if o.airLoopHVAC.is_initialized
       end
-    when 'HeatPumpPlantLoopEIRHeating' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
-      objs.sort.each do |o|
-        obj = o if o.heatRecoveryLoop.is_initialized
-      end
-    when 'HeatPumpPlantLoopEIRCooling' # Need to check a heat pump that has heat recovery or `autosizedHeatRecoveryReferenceFlowRate` won't work
-      objs.sort.each do |o|
-        obj = o if o.heatRecoveryLoop.is_initialized
-      end
     end
 
     # Test all autosizedFoo methods on this instance
     autosizable_field_names.each do |auto_field|
       # Make the getter name from the IDD field
       getter_name = "autosized#{auto_field.gsub(/\W/, '').strip}"
+
+      if ['HeatPumpPlantLoopEIRHeating', 'HeatPumpPlantLoopEIRCooling'].include?(type)
+        if getter_name == 'autosizedHeatRecoveryReferenceFlowRate'
+          obj = objs.sort.select { |o| o.heatRecoveryLoop.is_initialized }.first
+        else
+          obj = objs.sort.reject { |o| o.heatRecoveryLoop.is_initialized }.first
+        end
+      end
 
       # Replace the getter name with known alias, if one exists
       obj_aliases = getter_aliases[os_type]


### PR DESCRIPTION
Pull request overview
---------------------

https://github.com/NREL/OpenStudio/pull/5242#discussion_r1783982722

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Ubuntu 22.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-5242/OpenStudio-3.9.0-alpha%2B9a03587f77-Ubuntu-22.04-x86_64.deb


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [x] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [ ] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.


----------------------------------------------------------------------------------------------------------

### Case 3: New test for an already-existing model API class

Add the Heat Recovery test for the upcoming HeatPumpPlantLoopEIR Heating/Cooling oens from https://github.com/NREL/OpenStudio/pull/5242

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] **Test has been run backwards**:; N/A, this is new in the 3.9.0 release
 - [ ] **A Matching OSM test** has been added with the output of the ruby test for the oldest OpenStudio release where it passes (include OpenStudio Version)

 - [ ] **Ruby test is stable** in the last OpenStudio version: when run multiple times on the same machine, it produces the same total site kBTU.
    - [ ] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [ ] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).
    Please paste the text output or heatmap png generated after running the following commands:
        ```bash
        # Clean up all custom-tagged OSWs
        python process_results.py test-stability clean
        # Run your test 5 times in a row. Replace `testname_rb` (eg `airterminal_fourpipebeam_rb`)
        python process_results.py test-stability run -n testname_rb
        # Check that they all passed
        python process_results.py test-status --tagged
        # Check site kBTU differences
        python process_results.py heatmap --tagged

        ```

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
