### PR TITLE
Fix #5355 - E+ 25.1.0: Wrap OutputControl:ResilienceSummaries

### DIFF
--- a/model/simulationtests/output_objects.py
+++ b/model/simulationtests/output_objects.py
@@ -88,5 +88,13 @@ output_table.addSummaryReports(["OutdoorAirSummary", "ObjectCountSummary"])
 # output_table.getSummaryReport(1).get == "AdaptiveComfortSummary"
 # output_table.summaryReportIndex("AdaptiveComfortSummary").get == 1
 
+###############################################################################
+#                       OUTPUTCONTROL:RESILIENCESUMMARIES                     #
+###############################################################################
+if openstudio.VersionString(openstudio.openStudioVersion()) > openstudio.VersionString("3.9.0"):
+    output_table.addSummaryReport("ThermalResilienceSummary")
+    output_rs = model.getOutputControlResilienceSummaries()
+    output_rs.setHeatIndexAlgorithm("Extended")  # Default is 'Simplified'
+
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm(osm_save_directory=None, osm_name="in.osm")

--- a/model/simulationtests/output_objects.rb
+++ b/model/simulationtests/output_objects.rb
@@ -104,7 +104,7 @@ output_table.addSummaryReports(['OutdoorAirSummary', 'ObjectCountSummary'])
 if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('3.9.0')
   output_table.addSummaryReport('ThermalResilienceSummary')
   output_rs = model.getOutputControlResilienceSummaries
-  output_rs.setHeatIndexAlgorithm('Extended')  # Default is 'Simplified'
+  output_rs.setHeatIndexAlgorithm('Extended') # Default is 'Simplified'
 end
 
 # save the OpenStudio model (.osm)

--- a/model/simulationtests/output_objects.rb
+++ b/model/simulationtests/output_objects.rb
@@ -98,6 +98,15 @@ output_table.addSummaryReports(['OutdoorAirSummary', 'ObjectCountSummary'])
 # output_table.getSummaryReport(1).get == "AdaptiveComfortSummary"
 # output_table.summaryReportIndex("AdaptiveComfortSummary").get == 1
 
+###############################################################################
+#                       OUTPUTCONTROL:RESILIENCESUMMARIES                     #
+###############################################################################
+if Gem::Version.new(OpenStudio.openStudioVersion) > Gem::Version.new('3.9.0')
+  output_table.addSummaryReport('ThermalResilienceSummary')
+  output_rs = model.getOutputControlResilienceSummaries
+  output_rs.setHeatIndexAlgorithm('Extended')  # Default is 'Simplified'
+end
+
 # save the OpenStudio model (.osm)
 model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
                             'osm_name' => 'in.osm' })

--- a/print_tests.rb
+++ b/print_tests.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+n = 0
 Dir.glob('model/simulationtests/*.*').each do |f|
-  if /\.osm$/.match(f) || /\.rb$/.match(f)
+  if /\.osm$/.match(f) || /\.rb$/.match(f) || /\.py$/.match(f)
     filename = File.basename(f)
     puts "  def test_#{filename.gsub('.', '_')}"
     puts "    result = sim_test('#{filename}')"
     puts '  end'
     puts
+    n += 1
   end
 end
+
+puts "Found #{n} tests"


### PR DESCRIPTION
Pull request overview
---------------------

* Companion PR: https://github.com/NREL/OpenStudio/pull/5365

Link to the **Ubuntu 22.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-5365/OpenStudio-3.10.0-alpha%2B51228c2c9b-Ubuntu-22.04-x86_64.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,


----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

* Companion PR: https://github.com/NREL/OpenStudio/pull/5365
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following class: `OutputControlResilienceSummaries`

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - output_objects tests continue to pass in 3.9.0: cf https://github.com/NREL/OpenStudio-resources/actions/runs/13807928876/job/38622623179#step:8:27
 - output_objects tests pass in 3.10.0 and have the Resilience Summaries object. The EUI is unaffected.

```
$ rg Resilience -A1testruns/output_objects.py/run/in.idf 
1217:OutputControl:ResilienceSummaries,
1218-  Extended;                               !- Heat Index Algorithm
--
1239:  ThermalResilienceSummary;               !- Report Name 5
1240-
```

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
