### PR TITLE
#5368 - Wrap OutputTableAnnual and OutputTableMonthly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,10 +27,10 @@ test/*out_*.sqltest
 test/*out_*.xml
 # TODO: keep updating as new versions are incoming
 # We do not commit the current develop version until it's final
-test/*_3.9.1*_out.osw
-test/*_3.9.1*_out*.status
-test/*_3.9.1*_out.sqltest
-test/*_3.9.1*_out*.xml
+test/*_3.10.0*_out.osw
+test/*_3.10.0*_out*.status
+test/*_3.10.0*_out.sqltest
+test/*_3.10.0*_out*.xml
 # Ignore alphas and rcs. CI will force add anything under test/ so it's unaffected
 test/*_[0-9].[0-9].[0-9]-*_out*
 

--- a/model/simulationtests/output_tables.py
+++ b/model/simulationtests/output_tables.py
@@ -1,0 +1,137 @@
+# This test aims to test the new **Unique** ModelObjects related to Output
+# added in 3.0.0:
+# * OutputDiagnostics,
+# * OutputDebuggingData,
+# * OutputJSON, and
+# * OutputTableSummaryReports
+
+import openstudio
+
+from lib.baseline_model import BaselineModel
+
+model = BaselineModel()
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry(length=100, width=50, num_floors=1, floor_to_floor_height=4, plenum_height=0, perimeter_zone_depth=0)
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows(wwr=0.4, offset=1, application_type="Above Floor")
+
+# add thermostats
+model.add_thermostats(heating_setpoint=19, cooling_setpoint=26)
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions()
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type()
+
+# add design days to the model (Chicago)
+model.add_design_days()
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = sorted(model.getThermalZones(), key=lambda z: z.nameString())
+z = zones[0]
+z.setUseIdealAirLoads(True)
+
+###############################################################################
+#                            OUTPUT:TABLE:MONTHLY                             #
+###############################################################################
+
+# Factory method to creates a OutputTableMonthly from the E+ datasets/StandardReports.idf
+# Please use the OutputTableMonthly.validStandardReportNames() static method
+# to look up the valid names as it will throw if it cannot find it
+standardReportName = next(reversed(sorted(openstudio.model.OutputTableMonthly.validStandardReportNames())))
+output_table_monthly = openstudio.model.OutputTableMonthly.fromStandardReports(model, standardReportName)
+
+# You can of course create one yourself
+output_table_monthly = openstudio.model.OutputTableMonthly(model)
+output_table_monthly.setName("Fan Report")
+output_table_monthly.setDigitsAfterDecimal(4)
+
+# To add a group, you can use the convenience method
+# bool addMonthlyVariableGroup(std.string variableOrMeterName, std.string aggregationType = "SumOrAverage");
+
+groups = [
+    # variableOrMeterName, SumOrAverage
+    ("Fan Electricity Energy", "SumOrAverage"),
+    ("Fan Rise in Air Temperature", "SumOrAverage"),
+    ("Fan Electricity Rate", "Maximum"),
+    ("Fan Rise in Air Temperature", "ValueWhenMaximumOrMinimum"),
+]
+output_table_monthly.addMonthlyVariableGroup(groups[0][0], groups[0][1])
+
+# This will in turn actually use the helper class MonthlyVariableGroup
+output_table_monthly.addMonthlyVariableGroup(openstudio.model.MonthlyVariableGroup(groups[1][0], groups[1][1]))
+
+assert output_table_monthly.numberofMonthlyVariableGroups() == 2
+# This is a vector of MonthlyVariableGroup
+assert len(output_table_monthly.monthlyVariableGroups()) == 2
+first_monthly_group = output_table_monthly.monthlyVariableGroups()[0]
+# This returns an OptionalMonthlyVariableGroup
+first_monthly_group_ = output_table_monthly.getMonthlyVariableGroup(0)
+assert first_monthly_group_.is_initialized()
+# The equality operator is defined to check for both variableOrMeterName and
+# aggregationType
+assert first_monthly_group == first_monthly_group_.get()
+assert first_monthly_group.variableOrMeterName() == "Fan Electricity Energy"
+assert first_monthly_group.aggregationType() == "SumOrAverage"
+
+output_table_monthly.removeMonthlyVariableGroup(1)
+output_table_monthly.removeAllMonthlyVariableGroups()
+
+# There is also a batch add
+monthly_groups = [openstudio.model.MonthlyVariableGroup(g[0], g[1]) for g in groups]
+output_table_monthly.addMonthlyVariableGroups(monthly_groups)
+assert output_table_monthly.numberofMonthlyVariableGroups() == 4
+
+###############################################################################
+#                             OUTPUT:TABLE:ANNUAL                             #
+###############################################################################
+
+output_table_annual = openstudio.model.OutputTableAnnual(model)
+output_table_annual.setName("Electricity Report")
+output_table_annual.setSchedule(model.alwaysOnDiscreteSchedule())
+output_table_annual.setFilter("Zone 1")
+output_table_annual.resetFilter()
+
+groups = [
+    # variableorMeterorEMSVariableorField, aggregationType, digitsAfterDecimal
+    ("Electricity:Facility", "SumOrAverage", 3),
+    ("Electricity:Facility", "Maximum", 1),
+]
+
+output_table_annual.addAnnualVariableGroup(groups[0][0], groups[0][1], groups[0][2])
+
+# This will in turn actually use the helper class AnnualVariableGroup
+output_table_annual.addAnnualVariableGroup(
+    openstudio.model.AnnualVariableGroup(groups[1][0], groups[1][1], groups[1][2])
+)
+
+assert output_table_annual.numberofAnnualVariableGroups() == 2
+# This is a vector of AnnualVariableGroup
+assert len(output_table_annual.annualVariableGroups()) == 2
+first_annual_group = output_table_annual.annualVariableGroups()[0]
+# This returns an OptionalAnnualVariableGroup
+first_annual_group_ = output_table_annual.getAnnualVariableGroup(0)
+assert first_annual_group_.is_initialized()
+# The equality operator is defined to check for both variableorMeterorEMSVariableorField and
+# aggregationType
+assert first_annual_group == first_annual_group_.get()
+assert first_annual_group.variableorMeterorEMSVariableorField() == "Electricity:Facility"
+assert first_annual_group.aggregationType() == "SumOrAverage"
+assert first_annual_group.digitsAfterDecimal() == 3
+
+output_table_annual.removeAnnualVariableGroup(1)
+output_table_annual.removeAllAnnualVariableGroups()
+
+# There is also a batch add
+annual_groups = [openstudio.model.AnnualVariableGroup(g[0], g[1], g[2]) for g in groups]
+output_table_annual.addAnnualVariableGroups(annual_groups)
+assert output_table_annual.numberofAnnualVariableGroups() == 2
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm(osm_save_directory=None, osm_name="in.osm")

--- a/model/simulationtests/output_tables.rb
+++ b/model/simulationtests/output_tables.rb
@@ -69,7 +69,7 @@ groups = [
   ['Fan Electricity Energy', 'SumOrAverage'],
   ['Fan Rise in Air Temperature', 'SumOrAverage'],
   ['Fan Electricity Rate', 'Maximum'],
-  ['Fan Rise in Air Temperature', 'ValueWhenMaximumOrMinimum'],
+  ['Fan Rise in Air Temperature', 'ValueWhenMaximumOrMinimum']
 ]
 output_table_monthly.addMonthlyVariableGroup(groups[0][0], groups[0][1])
 
@@ -79,6 +79,7 @@ output_table_monthly.addMonthlyVariableGroup(OpenStudio::Model::MonthlyVariableG
 raise unless output_table_monthly.numberofMonthlyVariableGroups == 2
 # This is a vector of MonthlyVariableGroup
 raise unless output_table_monthly.monthlyVariableGroups.size == 2
+
 first_monthly_group = output_table_monthly.monthlyVariableGroups.first
 # This returns an OptionalMonthlyVariableGroup
 first_monthly_group_ = output_table_monthly.getMonthlyVariableGroup(0)
@@ -102,15 +103,15 @@ raise unless output_table_monthly.numberofMonthlyVariableGroups == 4
 ###############################################################################
 
 output_table_annual = OpenStudio::Model::OutputTableAnnual.new(model)
-output_table_annual.setName("Electricity Report")
+output_table_annual.setName('Electricity Report')
 output_table_annual.setSchedule(model.alwaysOnDiscreteSchedule)
-output_table_annual.setFilter("Zone 1")
+output_table_annual.setFilter('Zone 1')
 output_table_annual.resetFilter
 
 groups = [
-  #variableorMeterorEMSVariableorField, aggregationType, digitsAfterDecimal
+  # variableorMeterorEMSVariableorField, aggregationType, digitsAfterDecimal
   ['Electricity:Facility', 'SumOrAverage', 3],
-  ['Electricity:Facility', 'Maximum', 1],
+  ['Electricity:Facility', 'Maximum', 1]
 ]
 
 output_table_annual.addAnnualVariableGroup(groups[0][0], groups[0][1], groups[0][2])
@@ -121,6 +122,7 @@ output_table_annual.addAnnualVariableGroup(OpenStudio::Model::AnnualVariableGrou
 raise unless output_table_annual.numberofAnnualVariableGroups == 2
 # This is a vector of AnnualVariableGroup
 raise unless output_table_annual.annualVariableGroups.size == 2
+
 first_annual_group = output_table_annual.annualVariableGroups.first
 # This returns an OptionalAnnualVariableGroup
 first_annual_group_ = output_table_annual.getAnnualVariableGroup(0)

--- a/model/simulationtests/output_tables.rb
+++ b/model/simulationtests/output_tables.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# This test aims to test the new **Unique** ModelObjects related to Output
+# added in 3.0.0:
+# * OutputDiagnostics,
+# * OutputDebuggingData,
+# * OutputJSON, and
+# * OutputTableSummaryReports
+
+require 'openstudio'
+require_relative 'lib/baseline_model'
+
+model = BaselineModel.new
+
+# make a 1 story, 100m X 50m, 1 zone building
+model.add_geometry({ 'length' => 100,
+                     'width' => 50,
+                     'num_floors' => 1,
+                     'floor_to_floor_height' => 4,
+                     'plenum_height' => 0,
+                     'perimeter_zone_depth' => 0 })
+
+# add windows at a 40% window-to-wall ratio
+model.add_windows({ 'wwr' => 0.4,
+                    'offset' => 1,
+                    'application_type' => 'Above Floor' })
+
+# add thermostats
+model.add_thermostats({ 'heating_setpoint' => 19,
+                        'cooling_setpoint' => 26 })
+
+# assign constructions from a local library to the walls/windows/etc. in the model
+model.set_constructions
+
+# set whole building space type; simplified 90.1-2004 Large Office Whole Building
+model.set_space_type
+
+# add design days to the model (Chicago)
+model.add_design_days
+
+# In order to produce more consistent results between different runs,
+# we sort the zones by names
+# (There's only one here, but just in case this would be copy pasted somewhere
+# else...)
+zones = model.getThermalZones.sort_by { |z| z.name.to_s }
+z = zones[0]
+z.setUseIdealAirLoads(true)
+
+###############################################################################
+#                            OUTPUT:TABLE:MONTHLY                             #
+###############################################################################
+
+# Factory method to creates a OutputTableMonthly from the E+ datasets/StandardReports.idf
+# Please use the OutputTableMonthly::validStandardReportNames() static method
+# to look up the valid names as it will throw if it cannot find it
+standardReportName = OpenStudio::Model::OutputTableMonthly.validStandardReportNames.sort.reverse[0]
+output_table_monthly = OpenStudio::Model::OutputTableMonthly.fromStandardReports(model, standardReportName)
+
+# You can of course create one yourself
+output_table_monthly = OpenStudio::Model::OutputTableMonthly.new(model)
+output_table_monthly.setName('Fan Report')
+output_table_monthly.setDigitsAfterDecimal(4)
+
+# To add a group, you can use the convenience method
+# bool addMonthlyVariableGroup(std::string variableOrMeterName, std::string aggregationType = "SumOrAverage");
+
+groups = [
+  # variableOrMeterName, SumOrAverage
+  ['Fan Electricity Energy', 'SumOrAverage'],
+  ['Fan Rise in Air Temperature', 'SumOrAverage'],
+  ['Fan Electricity Rate', 'Maximum'],
+  ['Fan Rise in Air Temperature', 'ValueWhenMaximumOrMinimum'],
+]
+output_table_monthly.addMonthlyVariableGroup(groups[0][0], groups[0][1])
+
+# This will in turn actually use the helper class MonthlyVariableGroup
+output_table_monthly.addMonthlyVariableGroup(OpenStudio::Model::MonthlyVariableGroup.new(groups[1][0], groups[1][1]))
+
+raise unless output_table_monthly.numberofMonthlyVariableGroups == 2
+# This is a vector of MonthlyVariableGroup
+raise unless output_table_monthly.monthlyVariableGroups.size == 2
+first_monthly_group = output_table_monthly.monthlyVariableGroups.first
+# This returns an OptionalMonthlyVariableGroup
+first_monthly_group_ = output_table_monthly.getMonthlyVariableGroup(0)
+raise unless first_monthly_group_.is_initialized
+# The equality operator is defined to check for both variableOrMeterName and
+# aggregationType
+raise unless first_monthly_group == first_monthly_group_.get
+raise unless first_monthly_group.variableOrMeterName == 'Fan Electricity Energy'
+raise unless first_monthly_group.aggregationType == 'SumOrAverage'
+
+output_table_monthly.removeMonthlyVariableGroup(1)
+output_table_monthly.removeAllMonthlyVariableGroups
+
+# There is also a batch add
+monthly_groups = groups.map { |g| OpenStudio::Model::MonthlyVariableGroup.new(g[0], g[1]) }
+output_table_monthly.addMonthlyVariableGroups(monthly_groups)
+raise unless output_table_monthly.numberofMonthlyVariableGroups == 4
+
+###############################################################################
+#                             OUTPUT:TABLE:ANNUAL                             #
+###############################################################################
+
+output_table_annual = OpenStudio::Model::OutputTableAnnual.new(model)
+output_table_annual.setName("Electricity Report")
+output_table_annual.setSchedule(model.alwaysOnDiscreteSchedule)
+output_table_annual.setFilter("Zone 1")
+output_table_annual.resetFilter
+
+groups = [
+  #variableorMeterorEMSVariableorField, aggregationType, digitsAfterDecimal
+  ['Electricity:Facility', 'SumOrAverage', 3],
+  ['Electricity:Facility', 'Maximum', 1],
+]
+
+output_table_annual.addAnnualVariableGroup(groups[0][0], groups[0][1], groups[0][2])
+
+# This will in turn actually use the helper class AnnualVariableGroup
+output_table_annual.addAnnualVariableGroup(OpenStudio::Model::AnnualVariableGroup.new(groups[1][0], groups[1][1], groups[1][2]))
+
+raise unless output_table_annual.numberofAnnualVariableGroups == 2
+# This is a vector of AnnualVariableGroup
+raise unless output_table_annual.annualVariableGroups.size == 2
+first_annual_group = output_table_annual.annualVariableGroups.first
+# This returns an OptionalAnnualVariableGroup
+first_annual_group_ = output_table_annual.getAnnualVariableGroup(0)
+raise unless first_annual_group_.is_initialized
+# The equality operator is defined to check for both variableorMeterorEMSVariableorField and
+# aggregationType
+raise unless first_annual_group == first_annual_group_.get
+raise unless first_annual_group.variableorMeterorEMSVariableorField == 'Electricity:Facility'
+raise unless first_annual_group.aggregationType == 'SumOrAverage'
+raise unless first_annual_group.digitsAfterDecimal == 3
+
+output_table_annual.removeAnnualVariableGroup(1)
+output_table_annual.removeAllAnnualVariableGroups
+
+# There is also a batch add
+annual_groups = groups.map { |g| OpenStudio::Model::AnnualVariableGroup.new(g[0], g[1], g[2]) }
+output_table_annual.addAnnualVariableGroups(annual_groups)
+raise unless output_table_annual.numberofAnnualVariableGroups == 2
+
+# save the OpenStudio model (.osm)
+model.save_openstudio_osm({ 'osm_save_directory' => Dir.pwd,
+                            'osm_name' => 'in.osm' })

--- a/model_tests.rb
+++ b/model_tests.rb
@@ -1351,6 +1351,19 @@ class ModelTests < Minitest::Test
     result = sim_test('output_objects_2.osm')
   end
 
+  def test_output_tables_rb
+    result = sim_test('output_tables.rb')
+  end
+
+  def test_output_tables_py
+    result = sim_test('output_tables.py')
+  end
+
+  # TODO: To be added in the next official release after: 3.9.0
+  # def test_output_tables_osm
+  #   result = sim_test('output_tables.osm')
+  # end
+
   def test_performanceprecisiontradeoffs_rb
     result = sim_test('performanceprecisiontradeoffs.rb')
   end


### PR DESCRIPTION
Pull request overview
---------------------

* https://github.com/NREL/OpenStudio/issues/5368
* Companion PR: https://github.com/NREL/OpenStudio/pull/5369

Link to the **Ubuntu 22.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://openstudio-ci-builds.s3-website-us-west-2.amazonaws.com/PR-5369/OpenStudio-3.10.0-alpha%2Bea0e2a7b64-Ubuntu-22.04-x86_64.deb


This Pull Request is concerning:

 - [x] **Case 1 - `NewTest`:** a new test for a new model API class,



----------------------------------------------------------------------------------------------------------

### Case 1: New test for a new model API class

Please include which class(es) you are adding a test to specifically test for.
Include a link to the OpenStudio Pull Request in which you are adding the new classes, or the class itself if already on develop.
<!---
> eg:
>
> This pull request is in relation with the Pull Request [NREL/OpenStudio#3031](https://github.com/NREL/OpenStudio/pull/3031), and  will specifically test for the following classes:
> * `AirTerminalSingleDuctConstantVolumeFourPipeBeam`
> * `CoilCoolingFourPipeBeam`
> * `CoilHeatingFourPipeBeam`
> * Additionally it explicitly tests for the existing class [TableMultiVariableLookUp](https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/model/TableMultiVariableLookup.hpp)
-->

#### Work Checklist

The following has been checked to ensure compliance with the guidelines:

 - [x] Tests pass either:

     - [x] with current develop (incude SHA):
         - [x] The label `PendingOSM` has been added to this PR
         - [x] A matching OSM test has not yet been added because the official release is pending, but `model_tests.rb` has a TODO 
         - [x] No `out.osw` have been committed as they need to be run with an official OpenStudio version


 - [x] **Ruby test is stable**: when run multiple times on the same machine, it produces the same total site kBTU.
    Please paste the heatmap png generated after running the following commands:
     - [x] I ensured that I assign systems/loads/etc in a repeatable manner (eg: if I assign stuff to thermalZones, I do `model.getThermalZones.sort_by{|z| z.name.to_s}.each do ...` so I am sure I put the same ZoneHVAC systems to the same zones regardless of their order)
     - [x] I tested stability using `process_results.py` (see `python process_results.py --help` for usage).

 - [x] **Object has been added to `autosize_hvac.rb` to ensure the autosizedXXX values methods do work**: N/A

----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
