### PR TITLE
CI: Replace Ubuntu 22.04 with 24.04

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Pull request overview
 
 Link to relevant GitHub Issue(s) if appropriate:
 
-Link to the **Ubuntu 22.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
+Link to the **Ubuntu 24.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
 [OpenStudio Installer]: http://
 
 

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       os_installer_link:
-        description: 'The Link where to download the Ubuntu 22.04 OpenStudio SDK Installer (.DEB)'
+        description: 'The Link where to download the Ubuntu 24.04 OpenStudio SDK Installer (.DEB)'
         required: true
-        default: 'https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.5.1-alpha%2B59f1eb448b-Ubuntu-22.04.deb'
+        default: 'https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.5.1-alpha%2B59f1eb448b-Ubuntu-24.04.deb'
       branch_name:
         description: 'The branch name to use and where to commit the test results. If ommited, it will default to the installer SHA'
         required: false
@@ -21,7 +21,7 @@ on:
 
 jobs:
   test_installer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test_installer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "!(contains(github.event.head_commit.message, 'skip') && contains(github.event.head_commit.message, 'ci'))"
 
     steps:
@@ -80,10 +80,10 @@ jobs:
                 raise ValueError("Something went wrong when querying {}, status={}".format(url, r.status_code))
                 exit(0)
             data = r.json()
-            matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-22.04-x86_64.deb' in x['name']]
+            matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-24.04-x86_64.deb' in x['name']]
 
             if len(matched_installers) == 0:
-                matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-22.04.deb' in x['name']]
+                matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Ubuntu-24.04.deb' in x['name']]
                 if len(matched_installers) == 0:
                     matched_installers = [x['browser_download_url'] for x in data['assets'] if 'Linux.deb' in x['name']]
                     if len(matched_installers) ==0:


### PR DESCRIPTION
Pull request overview
---------------------

The 22.04 runner was moved to GHA and it's offline, so use 24.04 now... FYI @anchapin @tijcolem 

Link to relevant GitHub Issue(s) if appropriate:

Link to the **Ubuntu 24.04 .deb** installer to use for CI Testing. If not set, it will default to latest official release.
[OpenStudio Installer]: http://


This Pull Request is concerning:

 - [ ] **Case 1 - `NewTest`:** a new test for a new model API class,
 - [ ] **Case 2 - `TestFix`:** a fix for an existing test. The GitHub issue should be referenced in the PR description
 - [ ] **Case 3 - `NewTestForExisting`:** a new test for an already-existing model API class
 - [x] **Case 4 - `Other`:** Something else, like maintenance of the repo, or just committing test results with a new OpenStudio version.

Depending on your answer, please fill out the required section below, and delete the three others.
Leave the review checklist in place.



----------------------------------------------------------------------------------------------------------

### Case 4: Other

Please be as explicit as possible about the changes you have made, and why they are warranted.


----------------------------------------------------------------------------------------------------------

### Review Checklist

 - [ ] Code style (indentation, variable names, strip trailing spaces)
 - [ ] Functional code review (it has to work!)
 - [ ] Matching OSM test has been added or `# TODO` added to `model_tests.rb`
 - [ ] Appropriate `out.osw` have been committed
 - [ ] Test is stable
 - [ ] Object is tested in `autosize_hvac` as appropriate
 - [ ] The appropriate labels have been added to this PR:
   - [ ] One of: `NewTest`, `TestFix`, `NewTestForExisting`, `Other`
   - [ ] If `NewTest`: add `PendingOSM` or `AddedOSM`
